### PR TITLE
Check for slot existence

### DIFF
--- a/include/config_file.h
+++ b/include/config_file.h
@@ -35,6 +35,7 @@ typedef enum {
 	ST_ACTIVE = 1,
 	ST_INACTIVE = 2,
 	ST_BOOTED = 4 | ST_ACTIVE,
+	ST_NOTFOUND = 8,
 } SlotState;
 
 typedef struct _RaucSlot {

--- a/src/install.c
+++ b/src/install.c
@@ -198,6 +198,12 @@ gboolean determine_slot_states(GError **error) {
 	for (GList *l = slotlist; l != NULL; l = l->next) {
 		RaucSlot *s = (RaucSlot*) g_hash_table_lookup(r_context()->config->slots, l->data);
 
+		if (!g_file_test(s->device, G_FILE_TEST_EXISTS)) {
+			g_message("Device for slot %s not found (%s)", s->name, s->device);
+			s->state = ST_NOTFOUND;
+			continue;
+		}
+
 		if (s->parent) {
 			if (s->parent->state & ST_ACTIVE) {
 				s->state |= ST_ACTIVE;

--- a/src/main.c
+++ b/src/main.c
@@ -518,9 +518,12 @@ static gboolean status_start(int argc, char **argv)
 			state = "booted";
 			booted = slot;
 			break;
+		case ST_NOTFOUND:
+			state = "not found";
+			break;
 		case ST_UNKNOWN:
 		default:
-			g_error("invalid slot status");
+			g_warning("invalid slot status (%d)", slot->state);
 			r_exit_status = 1;
 			break;
 		}

--- a/test/install.c
+++ b/test/install.c
@@ -73,6 +73,8 @@ static void install_fixture_set_up_user(InstallFixture *fixture,
 				fixture->tmpdir, "openssl-ca/dev-ca.pem"));
 
 	/* Setup pseudo devices */
+	g_assert(test_prepare_dummy_file(fixture->tmpdir, "images/rescue-0",
+				         SLOT_SIZE, "/dev/zero") == 0);
 	g_assert(test_prepare_dummy_file(fixture->tmpdir, "images/rootfs-0",
 				         SLOT_SIZE, "/dev/zero") == 0);
 	g_assert(test_prepare_dummy_file(fixture->tmpdir, "images/appfs-0",
@@ -81,6 +83,7 @@ static void install_fixture_set_up_user(InstallFixture *fixture,
 				         SLOT_SIZE, "/dev/zero") == 0);
 	g_assert(test_prepare_dummy_file(fixture->tmpdir, "images/appfs-1",
 					 SLOT_SIZE, "/dev/zero") == 0);
+	g_assert_true(test_make_filesystem(fixture->tmpdir, "images/rescue-0"));
 	g_assert_true(test_make_filesystem(fixture->tmpdir, "images/rootfs-0"));
 	g_assert_true(test_make_filesystem(fixture->tmpdir, "images/appfs-0"));
 	g_assert_true(test_make_filesystem(fixture->tmpdir, "images/rootfs-1"));

--- a/test/install.c
+++ b/test/install.c
@@ -273,58 +273,58 @@ compatible=FooCorp Super BarBazzer\n\
 bootloader=barebox\n\
 \n\
 [slot.rescue.0]\n\
-device=/path/to/rescue0\n\
+device=/dev/null\n\
 type=raw\n\
 bootname=factory0\n\
 readonly=true\n\
 \n\
 [slot.rescue.1]\n\
-device=/path/to/rescue1\n\
+device=/dev/null\n\
 type=raw\n\
 bootname=factory1\n\
 readonly=true\n\
 \n\
 [slot.rootfs.0]\n\
-device=/path/to/rootfs0\n\
+device=/dev/null\n\
 bootname=system0\n\
 \n\
 [slot.rootfs.1]\n\
-device=/path/to/rootfs1\n\
+device=/dev/null\n\
 bootname=system1\n\
 \n\
 [slot.rootfs.2]\n\
-device=/path/to/rootfs2\n\
+device=/does/not/exist\n\
 bootname=system2\n\
 \n\
 [slot.appfs.2]\n\
-device=/path/to/appfs1\n\
+device=/does/not/exist\n\
 parent=rootfs.2\n\
 \n\
 [slot.appfs.1]\n\
-device=/path/to/appfs1\n\
+device=/dev/null\n\
 parent=rootfs.1\n\
 \n\
 [slot.appfs.0]\n\
-device=/path/to/appfs0\n\
+device=/dev/null\n\
 parent=rootfs.0\n\
 \n\
 [slot.demofs.0]\n\
-device=/path/to/demofs0\n\
+device=/dev/null\n\
 parent=appfs.0\n\
 \n\
 [slot.demofs.1]\n\
-device=/path/to/demofs1\n\
+device=/dev/null\n\
 parent=appfs.1\n\
 \n\
 [slot.demofs.2]\n\
-device=/path/to/demofs2\n\
+device=/dev/null\n\
 parent=appfs.2\n\
 \n\
 [slot.bootloader.0]\n\
-device=/path/to/bootloader\n\
+device=/dev/null\n\
 \n\
 [slot.prebootloader.0]\n\
-device=/path/to/prebootloader";
+device=/dev/null";
 
 	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
 	g_assert_nonnull(fixture->tmpdir);
@@ -491,6 +491,8 @@ filename=bootloader.img";
 	g_assert_cmpint(((RaucSlot*) g_hash_table_lookup(r_context()->config->slots, "rootfs.1"))->state, ==, ST_INACTIVE);
 	g_assert_cmpint(((RaucSlot*) g_hash_table_lookup(r_context()->config->slots, "appfs.0"))->state, ==, ST_ACTIVE);
 	g_assert_cmpint(((RaucSlot*) g_hash_table_lookup(r_context()->config->slots, "appfs.1"))->state, ==, ST_INACTIVE);
+	g_assert_cmpint(((RaucSlot*) g_hash_table_lookup(r_context()->config->slots, "rootfs.2"))->state, ==, ST_NOTFOUND);
+	g_assert_cmpint(((RaucSlot*) g_hash_table_lookup(r_context()->config->slots, "appfs.2"))->state, ==, ST_NOTFOUND);
 
 	tgrp = determine_target_install_group(rm);
 

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -93,9 +93,19 @@ test_expect_success "rauc bundle" "
 "
 
 
+TMPDIR=$(mktemp -d)
+export TMPDIR
+mkdir $TMPDIR/images
+touch $TMPDIR/images/rescue-0
+touch $TMPDIR/images/rootfs-0
+touch $TMPDIR/images/rootfs-1
+touch $TMPDIR/images/appfs-0
+touch $TMPDIR/images/appfs-1
+
 test_expect_success "rauc status" "
   cp $SHARNESS_TEST_DIRECTORY/test.conf $SHARNESS_TEST_DIRECTORY/test-temp.conf
   sed -i 's!bootname=system0!bootname=$(cat /proc/cmdline | sed 's/.*root=\([^ ]*\).*/\1/')!g' $SHARNESS_TEST_DIRECTORY/test-temp.conf
+  sed -i 's!images!$TMPDIR/images!g' $SHARNESS_TEST_DIRECTORY/test-temp.conf
   rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status &&
   rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status mark-good &&
   rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status mark-bad
@@ -106,5 +116,7 @@ test_expect_success "rauc install invalid local paths" "
   test_must_fail rauc install foo.raucb &&
   test_must_fail rauc install /path/to/foo.raucb
 "
+
+rm -r $TMPDIR
 
 test_done


### PR DESCRIPTION
This adds the SlotState ST_NOTFOUND that will be set when the
destination slot path did not exist when calling determine_slot_states().

When trying to install into a slot with state ST_NOTFUND, the default
handler will report an error.
