### PR TITLE
install: fix mount-directory removal on pre install handler error

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -1162,7 +1162,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error) {
 		res = launch_and_wait_handler(mountpoint, r_context()->config->preinstall_handler, manifest, target_group, &ierror);
 		if (!res) {
 			g_propagate_prefixed_error(error, ierror, "Handler error: ");
-			goto out;
+			goto umount;
 		}
 	}
 


### PR DESCRIPTION
If the pre-install handler fails we errorneously goto out instead of goto
umount, leaving the mount-directory on the filesystem. Fix it by using the right
goto directive if the pre-install handler fails.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>