### PR TITLE
Fix Exec argument to start service

### DIFF
--- a/data/de.pengutronix.rauc.service.in
+++ b/data/de.pengutronix.rauc.service.in
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=de.pengutronix.rauc
-Exec=@bindir@/rauc
+Exec=@bindir@/rauc service
 User=root
 SystemdService=rauc.service


### PR DESCRIPTION
Exec argument must call rauc with the `service` argument in order to let
it spawn the service. Otherwise d-bus activation will fail and the
client reports:

    Error creating proxy: Error calling StartServiceByName for de.pengutronix.rauc: GDBus.Error:org.freedesktop.DBus.Error.Spawn.ChildExited: Launch helper exited with unknown return code 1
    D-Bus error while installing `/home/root/update-2017.02-1.raucb`