### PR TITLE
Build fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AM_INIT_AUTOMAKE([1.11 subdir-objects foreign no-dist-gzip dist-xz])
 AM_MAINTAINER_MODE([enable])
 AM_SILENT_RULES([yes])
 AC_REQUIRE_AUX_FILE([tap-driver.sh])
+AC_REQUIRE_AUX_FILE([git-version-gen])
 
 AX_IS_RELEASE([git-directory])
 AX_CHECK_ENABLE_DEBUG([yes])

--- a/src/context.c
+++ b/src/context.c
@@ -15,7 +15,7 @@ static gboolean launch_and_wait_variables_handler(gchar *handler_name, GHashTabl
 	GHashTableIter iter;
 	gchar *key = NULL;
 	gchar *value = NULL;
-	GDataInputStream *datainstream;
+	GDataInputStream *datainstream = NULL;
 	GInputStream *instream;
 	gchar* outline;
 


### PR DESCRIPTION
Currently, releases cannot be built with invoking autoreconf as `git-version-gen` is missing in distribution.