### PR TITLE
config_file: enhance parsing boolean "readonly" key

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -180,7 +180,16 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 			value = g_key_file_get_string(key_file, groups[i], "bootname", NULL);
 			slot->bootname = value;
 
-			slot->readonly = g_key_file_get_boolean(key_file, groups[i], "readonly", NULL);
+			slot->readonly = g_key_file_get_boolean(key_file, groups[i], "readonly", &ierror);
+			if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+				slot->readonly = FALSE;
+				g_clear_error(&ierror);
+			}
+			else if (ierror) {
+				g_propagate_error(error, ierror);
+				res = FALSE;
+				goto free;
+			}
 
 			g_hash_table_insert(slots, (gchar*)slot->name, slot);
 


### PR DESCRIPTION
Return an error instead of interpreting a typo in the readonly key's value as
"false".

Signed-off-by: Ulrich Ölmann <u.oelmann@pengutronix.de>