### PR TITLE
signature: add missing CMS_BINARY to CMS_verify flags

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -216,7 +216,7 @@ gboolean cms_verify(GBytes *content, GBytes *sig, GError **error) {
 		goto out;
 	}
 
-	if (!CMS_verify(cms, other, store, incontent, NULL, CMS_DETACHED)) {
+	if (!CMS_verify(cms, other, store, incontent, NULL, CMS_DETACHED | CMS_BINARY)) {
 		unsigned long err;
 		const gchar *data;
 		int flags;


### PR DESCRIPTION
As in CMS_sign() also in CMS_verify() the CMS_BINARY argument must be
set in ordert to make libcrypto handle the data as binary data.

Note that since OpenSSL 1.1.x this really makes a difference in handling
and a missing CMS_BINARY flag will result in a verification error:

    140573172512064:error:2E09D06D:CMS routines:CMS_verify:content verify error:../crypto/cms/cms_smime.c:393:

Fixes: #115