### PR TITLE
Allow passing booted slot via cmdline and context

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -27,6 +27,7 @@ typedef struct {
 	gchar *keypath;
 	/* optional global mount prefix overwrite */
 	gchar *mountprefix;
+	gchar *bootslot;
 
 	gchar *system_serial;
 

--- a/include/install.h
+++ b/include/install.h
@@ -31,9 +31,6 @@ typedef struct {
 	gint status_result;
 } RaucInstallArgs;
 
-void set_bootname_provider(const gchar* (*provider)(void));
-const gchar* get_bootname(void);
-
 gboolean determine_slot_states(GError **error);
 
 GList* get_slot_class_members(const gchar* slotclass);

--- a/src/install.c
+++ b/src/install.c
@@ -159,7 +159,12 @@ gboolean determine_slot_states(GError **error) {
 	}
 	g_list_free_full(mountlist, (GDestroyNotify)g_unix_mount_free);
 
-	bootname = bootname_provider();
+	if (r_context()->bootslot) {
+		bootname = r_context()->bootslot;
+	} else {
+		bootname = bootname_provider();
+	}
+
 	if (bootname == NULL) {
 		g_set_error_literal(
 				error,

--- a/src/main.c
+++ b/src/main.c
@@ -622,7 +622,7 @@ static gchar* r_status_formatter_readable(void)
 	GString *text = g_string_new(NULL);
 
 	g_string_append_printf(text, "Compatible:  %s\n", r_context()->config->system_compatible);
-	g_string_append_printf(text, "booted from: %s\n", get_bootname());
+	g_string_append_printf(text, "booted from: %s\n", r_context()->bootslot);
 
 	g_string_append(text, "slot states:\n");
 	g_hash_table_iter_init(&iter, r_context()->config->slots);
@@ -661,7 +661,7 @@ static gchar* r_status_formatter_shell(void)
 	gchar* slotstring = NULL;
 
 	formatter_shell_append(text, "RAUC_SYSTEM_COMPATIBLE", r_context()->config->system_compatible);
-	formatter_shell_append(text, "RAUC_SYSTEM_BOOTED_BOOTNAME", get_bootname());
+	formatter_shell_append(text, "RAUC_SYSTEM_BOOTED_BOOTNAME", r_context()->bootslot);
 
 	slotnames = g_ptr_array_new();
 	slotnumbers = g_ptr_array_new();
@@ -719,7 +719,7 @@ static gchar* r_status_formatter_json(gboolean pretty)
 	json_builder_add_string_value (builder, r_context()->config->system_compatible);
 
 	json_builder_set_member_name (builder, "booted");
-	json_builder_add_string_value (builder, get_bootname());
+	json_builder_add_string_value (builder, r_context()->bootslot);
 
 	json_builder_set_member_name (builder, "slots");
 	json_builder_begin_array (builder);

--- a/src/main.c
+++ b/src/main.c
@@ -895,7 +895,7 @@ static void cmdline_handler(int argc, char **argv)
 {
 	gboolean help = FALSE, debug = FALSE, version = FALSE;
 	gchar *confpath = NULL, *certpath = NULL, *keypath = NULL, *mount = NULL,
-	      *handlerextra = NULL;
+	      *handlerextra = NULL, *bootslot = NULL;
 	char *cmdarg = NULL;
 	GOptionContext *context = NULL;
 	GOptionEntry entries[] = {
@@ -903,6 +903,7 @@ static void cmdline_handler(int argc, char **argv)
 		{"cert", '\0', 0, G_OPTION_ARG_FILENAME, &certpath, "cert file", "PEMFILE"},
 		{"key", '\0', 0, G_OPTION_ARG_FILENAME, &keypath, "key file", "PEMFILE"},
 		{"mount", '\0', 0, G_OPTION_ARG_FILENAME, &mount, "mount prefix", "PATH"},
+		{"override-boot-slot", '\0', 0, G_OPTION_ARG_STRING, &bootslot, "override auto-detection of booted slot", "SLOTNAME"},
 		{"handler-args", '\0', 0, G_OPTION_ARG_STRING, &handlerextra, "extra handler arguments", "ARGS"},
 		{"debug", 'd', 0, G_OPTION_ARG_NONE, &debug, "enable debug output", NULL},
 		{"version", '\0', 0, G_OPTION_ARG_NONE, &version, "display version", NULL},
@@ -1039,6 +1040,8 @@ static void cmdline_handler(int argc, char **argv)
 			r_context_conf()->keypath = keypath;
 		if (mount)
 			r_context_conf()->mountprefix = mount;
+		if (bootslot)
+			r_context_conf()->bootslot = bootslot;
 		if (handlerextra)
 			r_context_conf()->handlerextra = handlerextra;
 	} else {

--- a/test/common.c
+++ b/test/common.c
@@ -306,10 +306,6 @@ gboolean test_make_slot_user_writable(const gchar* path, const gchar* file) {
 	return res;
 }
 
-const gchar* test_bootname_provider(void) {
-	return "system0";
-}
-
 gboolean test_running_as_root(void) {
 	uid_t uid = getuid();
 	uid_t euid = geteuid();

--- a/test/common.h
+++ b/test/common.h
@@ -20,5 +20,4 @@ gboolean test_umount(const gchar *dirname, const gchar *mountpoint);
 gboolean test_do_chmod(const gchar *path);
 gboolean test_copy_file(const gchar *srcprefix, const gchar *srcfile, const gchar *dstprefix, const gchar *dstfile);
 gboolean test_make_slot_user_writable(const gchar* path, const gchar* file);
-const gchar* test_bootname_provider(void);
 gboolean test_running_as_root(void);

--- a/test/install-fixtures.c
+++ b/test/install-fixtures.c
@@ -71,7 +71,7 @@ void fixture_helper_fixture_set_up_system_user(gchar *tmpdir,
 	g_assert_true(test_make_filesystem(tmpdir, "images/appfs-1"));
 
 	/* Set dummy bootname provider */
-	set_bootname_provider(test_bootname_provider);
+	r_context_conf()->bootslot = g_strdup("system0");
 
 	g_free(configpath);
 	g_free(certpath);

--- a/test/install.c
+++ b/test/install.c
@@ -278,7 +278,7 @@ static void install_fixture_tear_down(InstallFixture *fixture,
 static void install_test_bootname(InstallFixture *fixture,
 		gconstpointer user_data)
 {
-	g_assert_nonnull(get_bootname());
+	g_assert_nonnull(r_context()->bootslot);
 }
 
 static void install_test_target(InstallFixture *fixture,

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -103,6 +103,10 @@ test_expect_success "rauc status" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status
 "
 
+test_expect_success "rauc --override-boot-slot=system0 status" "
+  rauc -c $SHARNESS_TEST_DIRECTORY/test.conf --override-boot-slot=system0 status
+"
+
 test_expect_success "rauc status readable" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status --output-format=readable
 "


### PR DESCRIPTION
* Adds `--override-boot-slot` cmdline argument to allow faking a detected boot slot

* Moves bootslot detection to context