### PR TITLE
src/service: flush dbus interface to not drop property updates

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -23,7 +23,6 @@ static gboolean service_install_notify(gpointer data) {
 	while (!g_queue_is_empty(&args->status_messages)) {
 		gchar *msg = g_queue_pop_head(&args->status_messages);
 		g_message("installing %s: %s", args->name, msg);
-		g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_installer));
 	}
 	g_mutex_unlock(&args->status_mutex);
 
@@ -42,6 +41,7 @@ static gboolean service_install_cleanup(gpointer data)
 	}
 	r_installer_emit_completed(r_installer, args->status_result);
 	r_installer_set_operation(r_installer, "idle");
+	g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_installer));
 	g_mutex_unlock(&args->status_mutex);
 
 	install_args_free(args);
@@ -66,6 +66,7 @@ static gboolean r_on_handle_install(RInstaller *interface,
 	args->cleanup = service_install_cleanup;
 
 	r_installer_set_operation(r_installer, "installing");
+	g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_installer));
 	res = install_run(args);
 	if (!res) {
 		goto out;
@@ -203,6 +204,7 @@ static void send_progress_callback(gint percentage,
 
 	progress_update_tuple = g_variant_new_tuple(progress_update, 3);
 	r_installer_set_progress(r_installer, progress_update_tuple);
+	g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_installer));
 }
 
 static void r_on_bus_acquired(GDBusConnection *connection,


### PR DESCRIPTION
This fixes a bug introduced by 7b27396055062ffbdb10a182d08465ed1f825f9d
where the call of `r_installer_set_operation()` was moved without moving
the associated call of `g_dbus_interface_skeleton_flush()`.

If not flushed, notifications for property updates will happen in and
idle loop. Thus multiple property updates might get aggregated.

If the same property is updated multiple times before a notification is
sent out, this will result in status update informations being lost.

A case where this could be observed quite often where the installation
status messages updates that randomly dropped some sub-steps from the
report.

Note that when introducing more fine-grained status updates (e.g.
reporting image write progress, progress updates may be performed
intentionally without calling the flush function in order to not DDoS
the d-bus interface.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>