### PR TITLE
activate-installed & mark-active

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,7 @@ librauc_la_SOURCES = \
 	src/context.c \
 	src/install.c \
 	src/manifest.c \
+	src/mark.c \
 	src/mount.c \
 	src/service.c \
 	src/signature.c \
@@ -53,6 +54,7 @@ librauc_la_SOURCES = \
 	include/context.h \
 	include/install.h \
 	include/manifest.h \
+	include/mark.h \
 	include/mount.h \
 	include/service.h \
 	include/signature.h \

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -64,6 +64,13 @@ Example configuration:
   Only valid when ``bootloader`` is set to ``grub``.
   Specifies the path under which the GRUB environment can be accessed.
 
+``activate-installed``
+  This boolean value controls if a freshly installed slot is automatically
+  marked active with respect to the used bootloader. Its default value is
+  ``true`` which means that this slot is going to be started the next time the
+  system boots. If the value of this parameter is ``false`` the slot has to be
+  activated manually in order to be booted.
+
 **[keyring] section**
 
 The ``keyring`` section refers to the trusted keyring used for signature

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -64,12 +64,14 @@ Example configuration:
   Only valid when ``bootloader`` is set to ``grub``.
   Specifies the path under which the GRUB environment can be accessed.
 
+.. _activate-installed:
+
 ``activate-installed``
   This boolean value controls if a freshly installed slot is automatically
   marked active with respect to the used bootloader. Its default value is
   ``true`` which means that this slot is going to be started the next time the
   system boots. If the value of this parameter is ``false`` the slot has to be
-  activated manually in order to be booted.
+  activated manually in order to be booted, see section :ref:`mark-active`.
 
 **[keyring] section**
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -132,6 +132,8 @@ See details about using handlers in `Custom Handlers (Interface)`_.
   (see :ref:`[handler] section <sec-manifest-handler>`)
   RAUC will not execute any system handler script.
 
+.. _slot.slot-class.idx-section:
+
 **[slot.<slot-class>.<idx>] section**
 
 Each slot is identified by a section starting with ``slot.`` followed by

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -130,14 +130,45 @@ argument to explicitely identify the slot to act on:
 
   rauc status mark-{good,bad} [booted | other | <SLOT_NAME>]
 
-Choosing ``other`` marks the next bootable slot that is not the one that is
-currently booted. In a two-slot-setup this is just... the other one. If one
-wants to explicitely address a known slot, one can do so by using its slot name
-which has the form ``<slot-class>.<idx>`` (e.g. ``rootfs.1``), see :ref:`this
-<slot.slot-class.idx-section>` part of section :ref:`System Configuration File
-<sec_ref_slot_config>`. Last but not least choosing ``booted`` as the argument
-which is, by the way, the default if the optional argument has been omitted acts
-on the currently booted slot.
+This is to maintain consistency with respect to ``rauc status mark-active``
+where that argument is definitively wanted, see :ref:`here
+<optional-slot-identifier-argument>`.
+
+.. _mark-active:
+
+Manually Switch to a Different Slot
+-----------------------------------
+
+One can think of a variety of reasons to switch the preferred slot for the next
+boot by hand, for example:
+
+* Recurrently test the installation of a bundle in development starting from a
+  known state.
+* Activate a slot that has been installed sometime before and whose activation
+  has explicitely been prevented at that time using the system configuration
+  file's parameter :ref:`activate-installed <activate-installed>`.
+* Switch back to the previous slot because one really knows |better (TM)|.
+
+.. |better (TM)| unicode:: better U+2122 .. with trademark sign
+
+To do so, RAUC offers the subcommand
+
+.. _optional-slot-identifier-argument:
+
+.. code-block:: sh
+
+  rauc status mark-active [booted | other | <SLOT_NAME>]
+
+where the optional argument decides which slot to (re-)activate at the expense
+of the remaining slots. Choosing ``other`` switches to the next bootable slot
+that is not the one that is currently booted. In a two-slot-setup this is
+just... the other one. If one wants to explicitely address a known slot, one can
+do so by using its slot name which has the form ``<slot-class>.<idx>`` (e.g.
+``rootfs.1``), see :ref:`this <slot.slot-class.idx-section>` part of section
+:ref:`System Configuration File <sec_ref_slot_config>`. Last but not least,
+after switching to a different slot by mistake, this can be remedied by choosing
+``booted`` as the argument which is, by the way, the default if the optional
+argument has been omitted.
 
 Customizing the Update
 ----------------------

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -123,6 +123,22 @@ If the current boot failed in some kind, this command can be used to communicate
 that to the underlying bootloader implementation. In most cases this will
 disable the currently booted slot or at least switch to a different one.
 
+Although not very useful in the field, both commands recognize an optional
+argument to explicitely identify the slot to act on:
+
+.. code-block:: sh
+
+  rauc status mark-{good,bad} [booted | other | <SLOT_NAME>]
+
+Choosing ``other`` marks the next bootable slot that is not the one that is
+currently booted. In a two-slot-setup this is just... the other one. If one
+wants to explicitely address a known slot, one can do so by using its slot name
+which has the form ``<slot-class>.<idx>`` (e.g. ``rootfs.1``), see :ref:`this
+<slot.slot-class.idx-section>` part of section :ref:`System Configuration File
+<sec_ref_slot_config>`. Last but not least choosing ``booted`` as the argument
+which is, by the way, the default if the optional argument has been omitted acts
+on the currently booted slot.
+
 Customizing the Update
 ----------------------
 

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -20,6 +20,7 @@ typedef struct {
 	/* path prefix where rauc may create mount directories */
 	gchar *mount_prefix;
 	gchar *grubenv_path;
+	gboolean activate_installed;
 	gchar *keyring_path;
 
 	gchar *autoinstall_path;

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -39,6 +39,16 @@ typedef enum {
 	ST_BOOTED = 4 | ST_ACTIVE,
 } SlotState;
 
+typedef enum {
+	R_SLOT_ERROR_NO_CONFIG,
+	R_SLOT_ERROR_NO_BOOTSLOT,
+	R_SLOT_ERROR_NO_SLOT_WITH_STATE_BOOTED,
+	R_SLOT_ERROR_FAILED
+} RSlotError;
+
+#define R_SLOT_ERROR r_slot_error_quark()
+GQuark r_slot_error_quark(void);
+
 typedef struct _RaucSlot {
 	/** name of the slot. A glib intern string. */
 	const gchar *name;

--- a/include/mark.h
+++ b/include/mark.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <glib.h>
+
+gboolean mark_run(const gchar *state,
+		  const gchar *slot_identifier,
+		  gchar **slot_name,
+		  gchar **message);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -128,6 +128,17 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		}
 	}
 
+	c->activate_installed = g_key_file_get_boolean(key_file, "system", "activate-installed", &ierror);
+	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+		c->activate_installed = TRUE;
+		g_clear_error(&ierror);
+	}
+	else if (ierror) {
+		g_propagate_error(error, ierror);
+		res = FALSE;
+		goto free;
+	}
+
 	/* parse [keyring] section */
 	c->keyring_path = resolve_path(filename,
 		g_key_file_get_string(key_file, "keyring", "path", NULL));

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -8,6 +8,7 @@
 #include "utils.h"
 
 G_DEFINE_QUARK(r-config-error-quark, r_config_error)
+G_DEFINE_QUARK(r-slot-error-quark, r_slot_error)
 
 #define RAUC_SLOT_PREFIX	"slot"
 

--- a/src/install.c
+++ b/src/install.c
@@ -760,20 +760,24 @@ image_out:
 		install_args_update(args, g_strdup_printf("Updating slot %s done", dest_slot->name));
 	}
 
-	/* Mark all parent destination slots bootable */
-	g_message("Marking slots as bootable...");
-	g_hash_table_iter_init(&iter, target_group);
-	while (g_hash_table_iter_next(&iter, NULL, (gpointer *)&dest_slot)) {
-		if (dest_slot->parent || !dest_slot->bootname)
-			continue;
+	if (r_context()->config->activate_installed) {
+		/* Mark all parent destination slots bootable */
+		g_message("Marking slots as bootable...");
+		g_hash_table_iter_init(&iter, target_group);
+		while (g_hash_table_iter_next(&iter, NULL, (gpointer *)&dest_slot)) {
+			if (dest_slot->parent || !dest_slot->bootname)
+				continue;
 
-		res = r_boot_set_primary(dest_slot);
+			res = r_boot_set_primary(dest_slot);
 
-		if (!res) {
-			g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_BOOTABLE,
-					"Failed marking slot %s bootable", dest_slot->name);
-			goto out;
+			if (!res) {
+				g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_BOOTABLE,
+						"Failed marking slot %s bootable", dest_slot->name);
+				goto out;
+			}
 		}
+	} else {
+		g_message("Leaving target slot non-bootable as requested by activate_installed == false.");
 	}
 
 	install_args_update(args, "All slots updated");
@@ -950,19 +954,23 @@ slot_out:
 		goto out;
 	}
 
-	/* Mark all parent destination slots bootable */
-	g_message("Marking slots as bootable...");
-	g_hash_table_iter_init(&iter, target_group);
-	while (g_hash_table_iter_next(&iter, NULL, (gpointer *)&slot)) {
-		if (slot->parent || !slot->bootname)
-			continue;
+	if (r_context()->config->activate_installed) {
+		/* Mark all parent destination slots bootable */
+		g_message("Marking slots as bootable...");
+		g_hash_table_iter_init(&iter, target_group);
+		while (g_hash_table_iter_next(&iter, NULL, (gpointer *)&slot)) {
+			if (slot->parent || !slot->bootname)
+				continue;
 
-		res = r_boot_set_primary(slot);
+			res = r_boot_set_primary(slot);
 
-		if (!res) {
-			g_warning("Failed marking slot %s bootable", slot->name);
-			goto out;
+			if (!res) {
+				g_warning("Failed marking slot %s bootable", slot->name);
+				goto out;
+			}
 		}
+	} else {
+		g_message("Leaving target slot non-bootable as requested by activate_installed == false.");
 	}
 
 	res = TRUE;

--- a/src/install.c
+++ b/src/install.c
@@ -29,13 +29,6 @@
 /* All exit codes of hook script above this mean 'rejected' */
 #define INSTALL_HOOK_REJECT_CODE 10
 
-#define R_SLOT_ERROR r_slot_error_quark ()
-
-static GQuark r_slot_error_quark (void)
-{
-	return g_quark_from_static_string ("r_slot_error_quark");
-}
-
 #define R_INSTALL_ERROR r_install_error_quark ()
 
 GQuark r_install_error_quark (void)
@@ -82,7 +75,7 @@ gboolean determine_slot_states(GError **error) {
 		g_set_error_literal(
 				error,
 				R_SLOT_ERROR,
-				1,
+				R_SLOT_ERROR_NO_CONFIG,
 				"No slot configuration found");
 		goto out;
 	}
@@ -107,7 +100,7 @@ gboolean determine_slot_states(GError **error) {
 		g_set_error_literal(
 				error,
 				R_SLOT_ERROR,
-				2,
+				R_SLOT_ERROR_NO_BOOTSLOT,
 				"Bootname not found");
 		goto out;
 	}
@@ -164,7 +157,7 @@ gboolean determine_slot_states(GError **error) {
 		g_set_error_literal(
 				error,
 				R_SLOT_ERROR,
-				3,
+				R_SLOT_ERROR_NO_SLOT_WITH_STATE_BOOTED,
 				"Did not find booted slot");
 		goto out;
 	}

--- a/src/install.c
+++ b/src/install.c
@@ -101,7 +101,7 @@ gboolean determine_slot_states(GError **error) {
 				error,
 				R_SLOT_ERROR,
 				R_SLOT_ERROR_NO_BOOTSLOT,
-				"Bootname not found");
+				"Bootname or device of booted slot not found");
 		goto out;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -927,6 +927,9 @@ static gboolean status_start(int argc, char **argv)
 	} else if (g_strcmp0(argv[2], "mark-bad") == 0) {
 		g_print("marking slot %s as bad\n", slot->name);
 		r_exit_status = r_boot_set_state(slot, FALSE) ? 0 : 1;
+	} else if (g_strcmp0(argv[2], "mark-active") == 0) {
+		g_print("marking slot %s as active\n", slot->name);
+		r_exit_status = r_boot_set_primary(slot) ? 0 : 1;
 	} else {
 		g_message("unknown subcommand %s", argv[2]);
 		r_exit_status = 1;

--- a/src/main.c
+++ b/src/main.c
@@ -857,6 +857,7 @@ static gboolean status_start(int argc, char **argv)
 	}
 
 out:
+	g_free(text);
 	return TRUE;
 }
 

--- a/src/mark.c
+++ b/src/mark.c
@@ -1,0 +1,117 @@
+#include "bootchooser.h"
+#include "context.h"
+#include "mark.h"
+
+static RaucSlot* get_slot_by_identifier(const gchar *identifier, GError **error)
+{
+	GHashTableIter iter;
+	RaucSlot *slot = NULL, *booted = NULL;
+
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	g_hash_table_iter_init(&iter, r_context()->config->slots);
+	while (g_hash_table_iter_next(&iter, NULL, (gpointer *)&booted)) {
+		if (booted->state == ST_BOOTED)
+			break;
+		booted = NULL;
+	}
+
+	if (!g_strcmp0(identifier, "booted")) {
+		if (booted)
+			slot = booted;
+		else
+			g_set_error(
+				error,
+				R_SLOT_ERROR,
+				R_SLOT_ERROR_NO_SLOT_WITH_STATE_BOOTED,
+				"Did not find booted slot");
+	} else if (!g_strcmp0(identifier, "other")) {
+		if (booted) {
+			g_hash_table_iter_init(&iter, r_context()->config->slots);
+			while (g_hash_table_iter_next(&iter, NULL, (gpointer *)&slot)) {
+				if (slot->sclass == booted->sclass && !slot->parent && slot->bootname && slot != booted)
+					break;
+				slot = NULL;
+			}
+			if (!slot)
+				g_set_error(error,
+					    R_SLOT_ERROR,
+					    R_SLOT_ERROR_FAILED,
+					    "No other bootable slot of the same class found");
+		} else {
+			g_set_error(
+				error,
+				R_SLOT_ERROR,
+				R_SLOT_ERROR_NO_SLOT_WITH_STATE_BOOTED,
+				"Did not find booted slot needed to find another bootable slot of the same class");
+		}
+	} else {
+		gchar **groupsplit = g_strsplit(identifier, ".", -1);
+
+		if (g_strv_length(groupsplit) == 2) {
+			g_hash_table_iter_init(&iter, r_context()->config->slots);
+			while (g_hash_table_iter_next(&iter, NULL, (gpointer *)&slot)) {
+				if (!g_strcmp0(slot->sclass, groupsplit[0]) && !slot->parent && !g_strcmp0(slot->name, identifier))
+					break;
+				slot = NULL;
+			}
+			if (!slot)
+				g_set_error(error,
+					    R_SLOT_ERROR,
+					    R_SLOT_ERROR_FAILED,
+					    "No slot with class %s and name %s found",
+					    groupsplit[0],
+					    identifier);
+		} else {
+			g_set_error(error,
+				    R_SLOT_ERROR,
+				    R_SLOT_ERROR_FAILED,
+				    "Invalid slot name format");
+		}
+
+		g_strfreev(groupsplit);
+	}
+
+	return slot;
+}
+
+gboolean mark_run(const gchar *state,
+		  const gchar *slot_identifier,
+		  gchar **slot_name,
+		  gchar **message)
+{
+	RaucSlot *slot = NULL;
+	GError *ierror = NULL;
+	gboolean res;
+
+	g_assert(slot_name == NULL || *slot_name == NULL);
+	g_assert(message != NULL && *message == NULL);
+
+	slot = get_slot_by_identifier(slot_identifier, &ierror);
+	if (ierror) {
+		res = FALSE;
+		*message = g_strdup(ierror->message);
+		g_error_free(ierror);
+		goto out;
+	}
+
+	if (!g_strcmp0(state, "good")) {
+		res = r_boot_set_state(slot, TRUE);
+		*message = g_strdup_printf((res) ? "marked slot %s as good" : "failed to mark slot %s as good", slot->name);
+	} else if (!g_strcmp0(state, "bad")) {
+		res = r_boot_set_state(slot, FALSE);
+		*message = g_strdup_printf((res) ? "marked slot %s as bad" : "failed to mark slot %s as bad", slot->name);
+	} else if (!g_strcmp0(state, "active")) {
+		res = r_boot_set_primary(slot);
+		*message = g_strdup_printf((res) ? "activated slot %s" : "failed to activate slot %s", slot->name);
+	} else {
+		res = FALSE;
+		*message = g_strdup_printf("unknown subcommand %s", state);
+	}
+
+out:
+	if (res && slot_name)
+		*slot_name = g_strdup(slot->name);
+
+	return res;
+}

--- a/src/rauc-installer.xml
+++ b/src/rauc-installer.xml
@@ -22,6 +22,25 @@
       <arg name="version" type="s" direction="out" />
     </method>
 
+    <!--
+         Mark:
+         @state: operation to perform (one out of "good", "bad" or "active")
+         @slot_identifier: can be "booted", "other" or <SLOT_NAME> (e.g.
+             "rootfs.1")
+         @slot_name: name of the slot which has ultimately been marked
+         @message: message describing what has been done successfully (e.g.
+             "activated slot rootfs.0")
+
+         Keeps a slot bootable (state == "good"), makes it unbootable (state ==
+         "bad") or explicitely activates it for the next boot (state == "active").
+    -->
+    <method name="Mark">
+      <arg name="state" type="s" direction="in"/>
+      <arg name="slot_identifier" type="s" direction="in"/>
+      <arg name="slot_name" type="s" direction="out"/>
+      <arg name="message" type="s" direction="out"/>
+    </method>
+
     <!-- Operation: Represents the current (global) operation rauc performs -->
     <property name="Operation" type="s" access="read"/>
     <!-- LastError: Holds a message describing the last error that occurred -->

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -136,6 +136,10 @@ test_expect_success "rauc status mark-bad" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status mark-bad
 "
 
+test_expect_success "rauc status mark-active" "
+  rauc -c $SHARNESS_TEST_DIRECTORY/test-temp.conf status mark-active
+"
+
 test_expect_success "rauc install invalid local paths" "
   test_must_fail rauc install foo &&
   test_must_fail rauc install foo.raucb &&

--- a/uml-test-init
+++ b/uml-test-init
@@ -31,5 +31,14 @@ grub-editenv test/grubenv.test create
 touch /tmp/boot/grub/grubenv
 mount --bind test/grubenv.test /tmp/boot/grub/grubenv
 
+cp -a /etc/dbus-1/system.d /tmp
+cp -a data/de.pengutronix.rauc.conf /tmp/system.d
+chown root:root /tmp/system.d/de.pengutronix.rauc.conf
+chmod 644 /tmp/system.d/de.pengutronix.rauc.conf
+mount --bind /tmp/system.d /etc/dbus-1/system.d
+mkdir /tmp/var_run_dbus
+mount --bind /tmp/var_run_dbus /var/run/dbus
+dbus-daemon --system --fork --nopidfile
+
 make check && touch uml-test-ok || true
 poweroff -f


### PR DESCRIPTION
Today RAUC bundles are copied to the local filesystem, then installed via `rauc install <PATH/TO/BUNDLE.raucb>` and finally the system is rebooted into the new software.

Additionally support for the following use case is needed: after installation the freshly installed slot is not activated automatically, but only after an explict decision made by a user. Before this activation reboots shall only start the old slot. This comes from practical demands of a service technician who wants to push new software to some dozens of systems at the same time, but take them into operation individually and under supervision.