### PR TITLE
dbus: use wrapper when starting rauc service

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,8 +87,12 @@ nodist_dbussystem_DATA = data/de.pengutronix.rauc.service
 dbuspolicydir = $(DBUS_POLICYDIR)
 dist_dbuspolicy_DATA = data/de.pengutronix.rauc.conf
 
+dbuswrapperdir = $(libexecdir)
+dist_dbuswrapper_SCRIPTS = data/rauc-service.sh
+
 EXTRA_DIST += data/rauc.service.in \
 	      data/de.pengutronix.rauc.service.in \
+	      data/rauc-service.sh.in \
 	      README.rst \
 	      CHANGES
 
@@ -175,6 +179,7 @@ test_progress_test_LDADD = librauctest.la
 
 SED_REPLACE = $(SED) \
        -e 's|[@]bindir[@]|$(bindir)|g' \
+       -e 's|[@]libexecdir[@]|$(libexecdir)|g' \
        -e 's|[@]datadir[@]|$(pkgdatadir)|g' \
        -e 's|[@]prefix[@]|$(prefix)|g'
 
@@ -203,6 +208,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = "--without-systemdunitdir"
 CLEANFILES = $(gdbus_installer_generated) \
 	     $(nodist_systemdunit_DATA) \
 	     $(nodist_dbussystem_DATA) \
+	     $(dist_dbuswrapper_SCRIPTS) \
 	     data/rauc.service \
 	     test/empty.dat \
 	     test/test-results/rauc.*.counts \

--- a/data/de.pengutronix.rauc.service.in
+++ b/data/de.pengutronix.rauc.service.in
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=de.pengutronix.rauc
-Exec=@bindir@/rauc service
+Exec=@libexecdir@/rauc-service.sh
 User=root
 SystemdService=rauc.service

--- a/data/rauc-service.sh.in
+++ b/data/rauc-service.sh.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+@bindir@/rauc service


### PR DESCRIPTION
On systemd-less systems the rauc service is started by dbus on request.
Since dbus differs from systemd in that it doesn't setup a proper
environment, a wrapper is installed to setup the path before starting
rauc.

The wrapper script sets the path to be
    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
which is similar to what systemd sets up.

Without this, rauc installs fails when calling e.g. `fw_setenv` from
u-boot to set the boot order, and when calling `mkfs.ext4` to install
tarballs on ext4 slots.

Signed-off-by: Martin Hundebøll <mnhu@prevas.dk>