### PR TITLE
Cleanup include directives

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1,7 +1,7 @@
 #include <config.h>
 
-#include <gio/gio.h>
 #include <errno.h>
+#include <gio/gio.h>
 
 #include "bootchooser.h"
 #include "config_file.h"

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include <gio/gio.h>
 #include <errno.h>
 

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1,6 +1,7 @@
+#include <config.h>
+
 #include <gio/gio.h>
 
-#include <config.h>
 #include <context.h>
 #include <signature.h>
 #include <mount.h>

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2,9 +2,9 @@
 
 #include <gio/gio.h>
 
-#include <context.h>
-#include <signature.h>
-#include <mount.h>
+#include "context.h"
+#include "signature.h"
+#include "mount.h"
 #include "bundle.h"
 
 GQuark

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2,10 +2,10 @@
 
 #include <gio/gio.h>
 
-#include "context.h"
-#include "signature.h"
-#include "mount.h"
 #include "bundle.h"
+#include "context.h"
+#include "mount.h"
+#include "signature.h"
 
 GQuark
 r_bundle_error_quark (void)

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include "checksum.h"
 
 #define RAUC_DEFAULT_CHECKSUM G_CHECKSUM_SHA256

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include <glib.h>
 
 #include "config_file.h"

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -3,8 +3,7 @@
 #include <glib.h>
 
 #include "config_file.h"
-
-#include <utils.h>
+#include "utils.h"
 
 G_DEFINE_QUARK(r-config-error-quark, r_config_error)
 

--- a/src/context.c
+++ b/src/context.c
@@ -1,8 +1,8 @@
 #include <config.h>
 
-#include <config_file.h>
-#include <network.h>
-#include <signature.h>
+#include "config_file.h"
+#include "network.h"
+#include "signature.h"
 #include <gio/gio.h>
 
 #include "context.h"

--- a/src/context.c
+++ b/src/context.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include <config_file.h>
 #include <network.h>
 #include <signature.h>

--- a/src/context.c
+++ b/src/context.c
@@ -1,11 +1,11 @@
 #include <config.h>
 
-#include "config_file.h"
-#include "network.h"
-#include "signature.h"
 #include <gio/gio.h>
 
+#include "config_file.h"
 #include "context.h"
+#include "network.h"
+#include "signature.h"
 
 RaucContext *context = NULL;
 

--- a/src/install.c
+++ b/src/install.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include <glib.h>
 #include <gio/gio.h>
 #include <glib/gstdio.h>
@@ -23,7 +25,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <config.h>
 
 /* All exit codes of hook script above this mean 'rejected' */
 #define INSTALL_HOOK_REJECT_CODE 10

--- a/src/install.c
+++ b/src/install.c
@@ -1,30 +1,30 @@
 #include <config.h>
 
-#include <glib.h>
-#include <gio/gio.h>
-#include <glib/gstdio.h>
-
-#include "context.h"
-#include "network.h"
-#include "signature.h"
-#include "install.h"
-#include "manifest.h"
-#include "bundle.h"
-#include "mount.h"
-#include "utils.h"
-#include "bootchooser.h"
-#include "service.h"
-#include "update_handler.h"
-#include <sys/ioctl.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <gio/gfiledescriptorbased.h>
+#include <gio/gio.h>
 #include <gio/gunixmounts.h>
 #include <gio/gunixoutputstream.h>
-#include <errno.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <glib.h>
+#include <glib/gstdio.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "bootchooser.h"
+#include "bundle.h"
+#include "context.h"
+#include "install.h"
+#include "manifest.h"
+#include "mount.h"
+#include "network.h"
+#include "service.h"
+#include "signature.h"
+#include "update_handler.h"
+#include "utils.h"
 
 /* All exit codes of hook script above this mean 'rejected' */
 #define INSTALL_HOOK_REJECT_CODE 10

--- a/src/install.c
+++ b/src/install.c
@@ -4,9 +4,9 @@
 #include <gio/gio.h>
 #include <glib/gstdio.h>
 
-#include <context.h>
-#include <network.h>
-#include <signature.h>
+#include "context.h"
+#include "network.h"
+#include "signature.h"
 #include "install.h"
 #include "manifest.h"
 #include "bundle.h"

--- a/src/main.c
+++ b/src/main.c
@@ -1,21 +1,21 @@
 #include <config.h>
 
-#include <stdio.h>
+#include <gio/gio.h>
 #include <glib.h>
 #include <glib/gstdio.h>
-#include <gio/gio.h>
 #if ENABLE_JSON
 #include <json-glib/json-glib.h>
 #include <json-glib/json-gobject.h>
 #endif
+#include <stdio.h>
 
 #include "bootchooser.h"
 #include "bundle.h"
 #include "config_file.h"
 #include "context.h"
 #include "install.h"
-#include "service.h"
 #include "rauc-installer-generated.h"
+#include "service.h"
 #include "utils.h"
 
 GMainLoop *r_loop = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -9,7 +9,6 @@
 #include <json-glib/json-gobject.h>
 #endif
 
-#include <config.h>
 #include <bootchooser.h>
 #include <bundle.h>
 #include <config_file.h>

--- a/src/main.c
+++ b/src/main.c
@@ -9,12 +9,12 @@
 #include <json-glib/json-gobject.h>
 #endif
 
-#include <bootchooser.h>
-#include <bundle.h>
-#include <config_file.h>
-#include <context.h>
-#include <install.h>
-#include <service.h>
+#include "bootchooser.h"
+#include "bundle.h"
+#include "config_file.h"
+#include "context.h"
+#include "install.h"
+#include "service.h"
 #include "rauc-installer-generated.h"
 #include "utils.h"
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include "manifest.h"
 
 #include <checksum.h>

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1,10 +1,9 @@
 #include <config.h>
 
-#include "manifest.h"
-
 #include "checksum.h"
 #include "config_file.h"
 #include "context.h"
+#include "manifest.h"
 #include "signature.h"
 #include "utils.h"
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -2,11 +2,11 @@
 
 #include "manifest.h"
 
-#include <checksum.h>
-#include <config_file.h>
-#include <context.h>
-#include <signature.h>
-#include <utils.h>
+#include "checksum.h"
+#include "config_file.h"
+#include "context.h"
+#include "signature.h"
+#include "utils.h"
 
 #define RAUC_IMAGE_PREFIX	"image"
 #define RAUC_FILE_PREFIX	"file"

--- a/src/mount.c
+++ b/src/mount.c
@@ -1,9 +1,9 @@
+#include <config.h>
 #include <unistd.h>
 
 #include <gio/gio.h>
 #include <glib/gstdio.h>
 
-#include <config.h>
 #include "mount.h"
 #include "utils.h"
 #include "context.h"

--- a/src/mount.c
+++ b/src/mount.c
@@ -1,12 +1,12 @@
 #include <config.h>
-#include <unistd.h>
 
 #include <gio/gio.h>
 #include <glib/gstdio.h>
+#include <unistd.h>
 
+#include "context.h"
 #include "mount.h"
 #include "utils.h"
-#include "context.h"
 
 gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar* type, gsize size, GError **error) {
 	GSubprocess *sproc = NULL;

--- a/src/network.c
+++ b/src/network.c
@@ -1,9 +1,9 @@
 #include <config.h>
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <curl/curl.h>
 #include <glib/gstdio.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "network.h"
 

--- a/src/network.c
+++ b/src/network.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <curl/curl.h>

--- a/src/service.c
+++ b/src/service.c
@@ -1,16 +1,16 @@
 #include <config.h>
 
-#include <stdio.h>
-#include <glib.h>
-#include <glib-unix.h>
 #include <gio/gio.h>
+#include <glib-unix.h>
+#include <glib.h>
+#include <stdio.h>
 
+#include "bundle.h"
 #include "context.h"
 #include "install.h"
-#include "service.h"
-#include "bundle.h"
-#include "utils.h"
 #include "rauc-installer-generated.h"
+#include "service.h"
+#include "utils.h"
 
 GMainLoop *service_loop = NULL;
 RInstaller *r_installer = NULL;

--- a/src/service.c
+++ b/src/service.c
@@ -5,11 +5,11 @@
 #include <glib-unix.h>
 #include <gio/gio.h>
 
-#include <context.h>
-#include <install.h>
-#include <service.h>
-#include <bundle.h>
-#include <utils.h>
+#include "context.h"
+#include "install.h"
+#include "service.h"
+#include "bundle.h"
+#include "utils.h"
 #include "rauc-installer-generated.h"
 
 GMainLoop *service_loop = NULL;

--- a/src/signature.c
+++ b/src/signature.c
@@ -6,7 +6,7 @@
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 
-#include <context.h>
+#include "context.h"
 #include "signature.h"
 
 #define R_SIGNATURE_ERROR r_signature_error_quark ()

--- a/src/signature.c
+++ b/src/signature.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include <openssl/cms.h>
 #include <openssl/conf.h>
 #include <openssl/err.h>

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include "update_handler.h"
 #include "mount.h"
 #include "context.h"

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1,18 +1,17 @@
 #include <config.h>
 
-#include "update_handler.h"
-#include "mount.h"
-#include "context.h"
-
-#include <gio/gunixoutputstream.h>
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/ioctl.h>
-#include <fcntl.h>
-#include <string.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <gio/gunixoutputstream.h>
 #include <mtd/ubi-user.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "context.h"
+#include "mount.h"
+#include "update_handler.h"
 
 
 #define R_SLOT_HOOK_PRE_INSTALL "slot-pre-install"

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,10 +1,10 @@
 #include <config.h>
 
 #include <ftw.h>
-#include <string.h>
+#include <gio/gio.h>
 #include <glib.h>
 #include <glib/gstdio.h>
-#include <gio/gio.h>
+#include <string.h>
 
 #include "utils.h"
 


### PR DESCRIPTION
Arrangement of include directives in source files was more or a result of constant development than of wisely chosen and grouped order. Also usage of local and global includes was mixed. On the one hand this this was simply untidy, on the other hand this resulted in real issues, such as #137.

This series addresses this issue and cleans up and fixes the includes.