### PR TITLE
network: allow basic error handling

### DIFF
--- a/include/network.h
+++ b/include/network.h
@@ -11,7 +11,7 @@ void network_init(void);
 static inline void network_init(void) { return; }
 #endif
 
-gboolean download_file(const gchar *target, const gchar *url, gsize limit);
+gboolean download_file(const gchar *target, const gchar *url, gsize limit, GError **error);
 gboolean download_file_checksum(const gchar *target, const gchar *url,
 				const RaucChecksum *checksum);
 gboolean download_mem(GBytes **data, const gchar *url, gsize limit);

--- a/src/network.c
+++ b/src/network.c
@@ -77,6 +77,7 @@ static gboolean transfer(RaucTransfer *xfer) {
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, xfer);
 	curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, xfer_cb);
 	curl_easy_setopt(curl, CURLOPT_XFERINFODATA, xfer);
+	curl_easy_setopt(curl, CURLOPT_FAILONERROR, xfer);
 
 	r = curl_easy_perform(curl);
 	if (r != CURLE_OK) {

--- a/src/network.c
+++ b/src/network.c
@@ -56,7 +56,7 @@ static int xfer_cb(void *clientp, curl_off_t dltotal, curl_off_t dlnow,
 	return 0;
 }
 
-static gboolean transfer(RaucTransfer *xfer) {
+static gboolean transfer(RaucTransfer *xfer, GError **error) {
 	CURL *curl = NULL;
 	CURLcode r;
 	gboolean res = FALSE;
@@ -80,7 +80,12 @@ static gboolean transfer(RaucTransfer *xfer) {
 	curl_easy_setopt(curl, CURLOPT_FAILONERROR, xfer);
 
 	r = curl_easy_perform(curl);
-	if (r != CURLE_OK) {
+	if (r == CURLE_HTTP_RETURNED_ERROR) {
+		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "HTTP returned >=400");
+		res = FALSE;
+		goto out;
+	} else if (r != CURLE_OK) {
+		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Transfer failed");
 		res = FALSE;
 		goto out;
 	}
@@ -97,6 +102,7 @@ out:
 gboolean download_file(const gchar *target, const gchar *url, gsize limit, GError **error) {
 	RaucTransfer xfer = {0};
 	gboolean res = FALSE;
+	GError *ierror = NULL;
 
 	xfer.url = url;
 	xfer.limit = limit;
@@ -109,9 +115,9 @@ gboolean download_file(const gchar *target, const gchar *url, gsize limit, GErro
 		goto out;
 	}
 
-	res = transfer(&xfer);
+	res = transfer(&xfer, &ierror);
 	if (!res) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Transfer failed");
+		g_propagate_error(error, ierror);
 		goto out;
 	}
 
@@ -170,7 +176,7 @@ gboolean download_mem(GBytes **data, const gchar *url, gsize limit) {
 		goto out;
 	}
 
-	res = transfer(&xfer);
+	res = transfer(&xfer, NULL);
 	if (!res)
 		goto out;
 	

--- a/test/network.c
+++ b/test/network.c
@@ -28,10 +28,14 @@ static void test_download_file(NetworkFixture *fixture,
 			       gconstpointer user_data)
 {
 	const gchar *target;
+	GError *ierror = NULL;
+	gboolean res;
 
 	target = g_build_filename(fixture->tmpdir, "target", NULL);
 	
-	g_assert_true(download_file(target, "http://example.com/", 0));
+	res = download_file(target, "http://example.com/", 0, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 }
 
 static void test_download_mem(void)


### PR DESCRIPTION
downloading files from network did not provide any GError functionalities nor did fail on severe issues, such as getting 404 from a webserver.

This adds at least a few basic constructs to allow obtaining error information from `download_file()`.