### PR TITLE
Fix and enhance command line handling

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -875,6 +875,7 @@ typedef struct {
 	const RaucCommandType type;
 	const gchar* name;
 	const gchar* usage;
+	const gchar* summary;
 	gboolean (*cmd_handler) (int argc, char **argv);
 	GOptionGroup* options;
 	gboolean while_busy;
@@ -923,14 +924,14 @@ static void cmdline_handler(int argc, char **argv)
 	gchar *text;
 
 	RaucCommand rcommands[] = {
-		{UNKNOWN, "help", "<COMMAND>", unknown_start, NULL, TRUE},
-		{INSTALL, "install", "install <BUNDLE>", install_start, install_group, FALSE},
-		{BUNDLE, "bundle", "bundle <INPUTDIR> <BUNDLENAME>", bundle_start, NULL, FALSE},
-		{CHECKSUM, "checksum", "checksum <DIRECTORY>", checksum_start, NULL, FALSE},
-		{INFO, "info", "info <FILE>", info_start, info_group, FALSE},
-		{STATUS, "status", "status", status_start, status_group, TRUE},
+		{UNKNOWN, "help", "<COMMAND>", "Print help", unknown_start, NULL, TRUE},
+		{INSTALL, "install", "install <BUNDLE>", "Install a bundle", install_start, install_group, FALSE},
+		{BUNDLE, "bundle", "bundle <INPUTDIR> <BUNDLENAME>", "Create a bundle from a content directory", bundle_start, NULL, FALSE},
+		{CHECKSUM, "checksum", "checksum <DIRECTORY>", "Deprecated", checksum_start, NULL, FALSE},
+		{INFO, "info", "info <FILE>", "Print bundle info", info_start, info_group, FALSE},
+		{STATUS, "status", "status", "Show system status", status_start, status_group, TRUE},
 #if ENABLE_SERVICE == 1
-		{SERVICE, "service", "service", service_start, NULL, TRUE},
+		{SERVICE, "service", "service", "Start RAUC service", service_start, NULL, TRUE},
 #endif
 		{0}
 	};
@@ -1017,6 +1018,8 @@ static void cmdline_handler(int argc, char **argv)
 	/* re-setup option context for showing command-specific help */
 	g_clear_pointer(&context, g_option_context_free);
 	context = g_option_context_new(rcommand->usage);
+	if (rcommand->summary)
+		g_option_context_set_summary(context, rcommand->summary);
 	g_option_context_set_help_enabled(context, FALSE);
 	g_option_context_add_main_entries(context, entries, NULL);
 	if (rcommand->options)

--- a/src/main.c
+++ b/src/main.c
@@ -925,7 +925,7 @@ static void cmdline_handler(int argc, char **argv)
 	RaucCommand rcommands[] = {
 		{UNKNOWN, "help", "<COMMAND>", unknown_start, NULL, TRUE},
 		{INSTALL, "install", "install <BUNDLE>", install_start, install_group, FALSE},
-		{BUNDLE, "bundle", "bundle <FILE>", bundle_start, NULL, FALSE},
+		{BUNDLE, "bundle", "bundle <INPUTDIR> <BUNDLENAME>", bundle_start, NULL, FALSE},
 		{CHECKSUM, "checksum", "checksum <DIRECTORY>", checksum_start, NULL, FALSE},
 		{INFO, "info", "info <FILE>", info_start, info_group, FALSE},
 		{STATUS, "status", "status", status_start, status_group, TRUE},

--- a/src/main.c
+++ b/src/main.c
@@ -107,6 +107,11 @@ static gboolean install_start(int argc, char **argv)
 		goto out;
 	}
 
+	if (argc > 3) {
+		g_printerr("Excess argument: %s\n", argv[3]);
+		goto out;
+	}
+
 	bundlescheme = g_uri_parse_scheme(argv[2]);
 	if (bundlescheme == NULL && !g_path_is_absolute(argv[2])) {
 		bundlelocation = g_build_filename(g_get_current_dir(), argv[2], NULL);
@@ -221,9 +226,14 @@ static gboolean bundle_start(int argc, char **argv)
 		goto out;
 	}
 
-	if (argc != 4) {
+	if (argc < 4) {
 		g_printerr("An output bundle name must be provided\n");
 		r_exit_status = 1;
+		goto out;
+	}
+
+	if (argc > 4) {
+		g_printerr("Excess argument: %s\n", argv[4]);
 		goto out;
 	}
 
@@ -540,10 +550,15 @@ static gboolean info_start(int argc, char **argv)
 	gboolean res = FALSE;
 	gchar* (*formatter)(RaucManifest *manifest) = NULL;
 
-	if (argc != 3) {
+	if (argc < 3) {
 		g_printerr("A file name must be provided\n");
 		r_exit_status = 1;
 		return FALSE;
+	}
+
+	if (argc > 3) {
+		g_printerr("Excess argument: %s\n", argv[3]);
+		goto out;
 	}
 
 	if (!output_format || g_strcmp0(output_format, "readable") == 0) {


### PR DESCRIPTION
Some misleading argument number parsings were fixed and commands now can print a summary giving a brief description of what they will do.