### PR TITLE
src/main: add keyring command line argument

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -25,6 +25,7 @@ typedef struct {
 	/* signing data */
 	gchar *certpath;
 	gchar *keypath;
+	gchar *keyringpath;
 	/* optional global mount prefix overwrite */
 	gchar *mountprefix;
 	gchar *bootslot;

--- a/src/context.c
+++ b/src/context.c
@@ -175,6 +175,10 @@ static void r_context_configure(void) {
 		context->config->mount_prefix = g_strdup(context->mountprefix);
 	}
 
+	if (context->keyringpath) {
+		context->config->keyring_path = context->keyringpath;
+	}
+
 	context->pending = FALSE;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -915,7 +915,7 @@ GOptionEntry entries_status[] = {
 static void cmdline_handler(int argc, char **argv)
 {
 	gboolean help = FALSE, debug = FALSE, version = FALSE;
-	gchar *confpath = NULL, *certpath = NULL, *keypath = NULL, *mount = NULL,
+	gchar *confpath = NULL, *certpath = NULL, *keypath = NULL, *keyring = NULL, *mount = NULL,
 	      *handlerextra = NULL, *bootslot = NULL;
 	char *cmdarg = NULL;
 	GOptionContext *context = NULL;
@@ -923,6 +923,7 @@ static void cmdline_handler(int argc, char **argv)
 		{"conf", 'c', 0, G_OPTION_ARG_FILENAME, &confpath, "config file", "FILENAME"},
 		{"cert", '\0', 0, G_OPTION_ARG_FILENAME, &certpath, "cert file", "PEMFILE"},
 		{"key", '\0', 0, G_OPTION_ARG_FILENAME, &keypath, "key file", "PEMFILE"},
+		{"keyring", '\0', 0, G_OPTION_ARG_FILENAME, &keyring, "keyring file", "PEMFILE"},
 		{"mount", '\0', 0, G_OPTION_ARG_FILENAME, &mount, "mount prefix", "PATH"},
 		{"override-boot-slot", '\0', 0, G_OPTION_ARG_STRING, &bootslot, "override auto-detection of booted slot", "SLOTNAME"},
 		{"handler-args", '\0', 0, G_OPTION_ARG_STRING, &handlerextra, "extra handler arguments", "ARGS"},
@@ -1061,6 +1062,8 @@ static void cmdline_handler(int argc, char **argv)
 			r_context_conf()->certpath = certpath;
 		if (keypath)
 			r_context_conf()->keypath = keypath;
+		if (keyring)
+			r_context_conf()->keyringpath = keyring;
 		if (mount)
 			r_context_conf()->mountprefix = mount;
 		if (bootslot)


### PR DESCRIPTION
When using rauc info, for example a keyring file is required in order to
be able to verify the bundle signature.
The keyring could only be configured from the system configuration file
which meant that you had to have a system.conf on your build host if you
wanted to use rauc info properly.

As a system.conf on the build host is not useful and could be
error-prone, thus a keyring argument for the RAUC CLI really simplifies
using rauc info and other possible commands requiring a keyring file.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>