### PR TITLE
Support for extracting and dumping certificate and trust chain info

### DIFF
--- a/include/bundle.h
+++ b/include/bundle.h
@@ -10,6 +10,11 @@ typedef enum {
 	R_BUNDLE_ERROR_KEYRING
 } RBundleError;
 
+typedef struct {
+	gchar *path;
+	gsize size;
+} RaucBundle;
+
 /**
  * Create a bundle.
  *
@@ -26,15 +31,17 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
  *
  * This will verify and check the bundle content.
  *
- * @param bundlemane filename of the bundle to check
- * @param size Return location for the bundle size
+ * @param bundlemane filename of the bundle to check 
+ * @param bundle Return location for a RaucBundle struct.
+ *               This will contain all bundle information obtained by
+ *               check_bundle
  * @param verify If set to true the bundle signature will also be verified, if
  *               set to FALSE this step will be skipped
  * @param error Return location for a GError
  *
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean check_bundle(const gchar *bundlename, gsize *size, gboolean verify, GError **error);
+gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, gboolean verify, GError **error);
 
 /**
  * Resign a bundle.
@@ -103,3 +110,10 @@ gboolean mount_bundle(const gchar *bundlename, const gchar *mountpoint, gboolean
  * @return TRUE on success, FALSE if an error occurred
  */
 gboolean umount_bundle(const gchar *bundlename, GError **error);
+
+/**
+ * Frees the memory allocated by a RaucBundle.
+ *
+ * @param bundle bundle to free
+ */
+void free_bundle(RaucBundle *bundle);

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <openssl/cms.h>
 #include <glib.h>
 
 #define R_BUNDLE_ERROR r_bundle_error_quark ()
@@ -13,6 +14,7 @@ typedef enum {
 typedef struct {
 	gchar *path;
 	gsize size;
+	STACK_OF(X509) *verified_chain;
 } RaucBundle;
 
 /**

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -20,7 +20,7 @@ typedef struct {
 /**
  * Create a bundle.
  *
- * @param bundlemane filename of the bundle to create
+ * @param bundlename filename of the bundle to create
  * @param contentdir directory containing this bundle content
  * @param error Return location for a GError
  *
@@ -33,7 +33,7 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
  *
  * This will verify and check the bundle content.
  *
- * @param bundlemane filename of the bundle to check 
+ * @param bundlename filename of the bundle to check
  * @param bundle Return location for a RaucBundle struct.
  *               This will contain all bundle information obtained by
  *               check_bundle
@@ -68,7 +68,7 @@ gboolean resign_bundle(RaucBundle *bundle, const gchar *outpath, GError **error)
  * This will extract the entire bundle content into a given directory.
  *
  * @param bundle RaucBundle struct as returned by check_bundle()
- * @param outputdir directory to instract content into
+ * @param outputdir directory to extract content into
  * @param error Return location for a GError
  *
  * Note that check_bundle() must be called prior to this, to obtain a
@@ -79,7 +79,7 @@ gboolean resign_bundle(RaucBundle *bundle, const gchar *outpath, GError **error)
 gboolean extract_bundle(RaucBundle *bundle, const gchar *outputdir, GError **error);
 
 /**
- * Extract a single file form a bundle.
+ * Extract a single file from a bundle.
  *
  * This will extract a single file into a given directory.
  *
@@ -87,7 +87,7 @@ gboolean extract_bundle(RaucBundle *bundle, const gchar *outputdir, GError **err
  * RaucBundle struct.
  *
  * @param bundle RaucBundle struct as returned by check_bundle()
- * @param outputdir directory to instract the file into
+ * @param outputdir directory to extract the file into
  * @param file filename of file to extract from bundle
  * @param error Return location for a GError
  *

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -49,67 +49,77 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, gboolean ver
  * This will create a copy of a bundle with a new signature but unmodified
  * content.
  *
- * @param inpath filename of the bundle to resign
+ * Note that check_bundle() must be called prior to this, to obtain a
+ * RaucBundle struct.
+ *
+ * @param bundle RaucBundle struct as returned by check_bundle()
  * @param outpath filename of the resigned output bundle
  * @param error Return location for a GError
  *
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean resign_bundle(const gchar *inpath, const gchar *outpath, GError **error);
+gboolean resign_bundle(RaucBundle *bundle, const gchar *outpath, GError **error);
 
 /**
  * Extract a bundle.
  *
  * This will extract the entire bundle content into a given directory.
  *
- * @param bundlemane filename of the bundle to extract
+ * @param bundle RaucBundle struct as returned by check_bundle()
  * @param outputdir directory to instract content into
- * @param verify If set to true the bundle signature will also be verified, if
- *               set to FALSE this step will be skipped
  * @param error Return location for a GError
+ *
+ * Note that check_bundle() must be called prior to this, to obtain a
+ * RaucBundle struct.
  *
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean extract_bundle(const gchar *bundlename, const gchar *outputdir, gboolean verify, GError **error);
+gboolean extract_bundle(RaucBundle *bundle, const gchar *outputdir, GError **error);
 
 /**
  * Extract a single file form a bundle.
  *
  * This will extract a single file into a given directory.
  *
- * @param bundlemane filename of the bundle to extract
+ * Note that check_bundle() must be called prior to this, to obtain a
+ * RaucBundle struct.
+ *
+ * @param bundle RaucBundle struct as returned by check_bundle()
  * @param outputdir directory to instract the file into
  * @param file filename of file to extract from bundle
- * @param verify If set to true the bundle signature will also be verified, if
- *               set to FALSE this step will be skipped
  * @param error Return location for a GError
  *
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean extract_file_from_bundle(const gchar *bundlename, const gchar *outputdir, const gchar *file, gboolean verify, GError **error);
+gboolean extract_file_from_bundle(RaucBundle *bundle, const gchar *outputdir, const gchar *file, GError **error);
 
 /**
  * Mount a bundle.
  *
- * @param bundlemane filename of the bundle to mount
+ * Note that check_bundle() must be called prior to this, to obtain a
+ * RaucBundle struct.
+ *
+ * @param bundle RaucBundle struct as returned by check_bundle()
  * @param mountpoint path to the desired mount point
- * @param verify If set to true the bundle signature will also be verified, if
- *               set to FALSE this step will be skipped
+ * @param size
  * @param error Return location for a GError
  *
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean mount_bundle(const gchar *bundlename, const gchar *mountpoint, gboolean verify, GError **error);
+gboolean mount_bundle(RaucBundle *bundle, const gchar *mountpoint, GError **error);
 
 /**
  * Unmount a bundle.
  *
- * @param bundlemane filename of the bundle to unmount
+ * Note that check_bundle() must be called prior to this, to obtain a
+ * RaucBundle struct.
+ *
+ * @param bundle RaucBundle struct as returned by check_bundle()
  * @param error Return location for a GError
  *
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean umount_bundle(const gchar *bundlename, GError **error);
+gboolean umount_bundle(RaucBundle *bundle, GError **error);
 
 /**
  * Frees the memory allocated by a RaucBundle.

--- a/include/signature.h
+++ b/include/signature.h
@@ -12,6 +12,11 @@ typedef enum {
 	R_SIGNATURE_ERROR_PARSE_ERROR,
 	R_SIGNATURE_ERROR_CREATE_SIG,
 	R_SIGNATURE_ERROR_SERIALIZE_SIG,
+	R_SIGNATURE_ERROR_X509_CTX_NEW,
+	R_SIGNATURE_ERROR_X509_CTX_INIT,
+	R_SIGNATURE_ERROR_VERIFY_CERT,
+	R_SIGNATURE_ERROR_GET_SIGNER,
+	R_SIGNATURE_ERROR_NUM_SIGNER,
 
 	R_SIGNATURE_ERROR_X509_NEW,
 	R_SIGNATURE_ERROR_X509_LOOKUP,
@@ -76,3 +81,37 @@ gboolean cms_verify(GBytes *content, GBytes *sig, CMS_ContentInfo **cms, X509_ST
  * @return TRUE if succeeded, FALSE if failed
  */
 gboolean cms_verify_file(const gchar *filename, GBytes *sig, gsize limit, CMS_ContentInfo **cms, X509_STORE **store, GError **error);
+
+/**
+ * Returns string representation of certificate.
+ *
+ * @param verified_chain Stack of X509 certificates as returned by
+ *                       cms_get_signer_info
+ * @return allocated string containing default OpenSSL text representation of
+ *         signer certificate (first in chain)
+ */
+gchar* print_signer_cert(STACK_OF(X509) *verified_chain);
+
+/**
+ * Return string representation of certificate chain.
+ *
+ * @param verified_chain Stack of X509 certificates as returned by
+ *                       cms_get_signer_info
+ * @return allocated string containing text representation of certificate chain
+ *         (signer and issuer)
+ */
+gchar* print_cert_chain(STACK_OF(X509) *verified_chain);
+
+/**
+ * Get infos about signer and verification chain.
+ *
+ * Must be called *after* cms_verify()
+ *
+ * @param cms CMS_ContentInfo used in cms_verify()
+ * @param store Store used in cms_verify()
+ * @param verified_chain Return location for the verification chain, or NULL
+ * @param error return location for a GError, or NULL
+ *
+ * @return TRUE if succeeded, FALSE if failed
+ */
+gboolean cms_get_cert_chain(CMS_ContentInfo *cms, X509_STORE *store, STACK_OF(X509) **verified_chain, GError **error);;

--- a/include/signature.h
+++ b/include/signature.h
@@ -2,6 +2,23 @@
 
 #include <glib.h>
 
+#define R_SIGNATURE_ERROR r_signature_error_quark ()
+GQuark r_signature_error_quark (void);
+
+typedef enum {
+	R_SIGNATURE_ERROR_UNKNOWN,
+	R_SIGNATURE_ERROR_LOAD_FAILED,
+	R_SIGNATURE_ERROR_PARSE_ERROR,
+	R_SIGNATURE_ERROR_CREATE_SIG,
+	R_SIGNATURE_ERROR_SERIALIZE_SIG,
+
+	R_SIGNATURE_ERROR_X509_NEW,
+	R_SIGNATURE_ERROR_X509_LOOKUP,
+	R_SIGNATURE_ERROR_CA_LOAD,
+	R_SIGNATURE_ERROR_PARSE,
+	R_SIGNATURE_ERROR_INVALID
+} RSignatureError;
+
 /**
  * Initalization routine.
  */

--- a/include/signature.h
+++ b/include/signature.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <openssl/cms.h>
 #include <glib.h>
 
 #define R_SIGNATURE_ERROR r_signature_error_quark ()
@@ -53,19 +54,25 @@ GBytes *cms_sign_file(const gchar *filename, const gchar *certfile, const gchar 
  *
  * @param content content to verify against signature
  * @param sig signature used to verify
+ * @param cms Return location for the CMS_ContentInfo used for verification
+ * @param store Return location for the X509 store used for verification
  * @param error return location for a GError, or NULL
  *
  * @return TRUE if succeeded, FALSE if failed
  */
-gboolean cms_verify(GBytes *content, GBytes *sig, GError **error);
+gboolean cms_verify(GBytes *content, GBytes *sig, CMS_ContentInfo **cms, X509_STORE **store, GError **error);
 
 
 /**
+ * Verify signature for given file.
+ *
  * @param filename name of file with content to verify against signature
  * @param sig signature used to verify
  * @param limit size of content to use, 0 if all should be included
+ * @param cms Return location for the CMS_ContentInfo used for verification
+ * @param store Return location for the X509 store used for verification
  * @param error return location for a GError, or NULL
  *
  * @return TRUE if succeeded, FALSE if failed
  */
-gboolean cms_verify_file(const gchar *filename, GBytes *sig, gsize limit, GError **error);
+gboolean cms_verify_file(const gchar *filename, GBytes *sig, gsize limit, CMS_ContentInfo **cms, X509_STORE **store, GError **error);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -321,18 +321,13 @@ out:
 	return res;
 }
 
-gboolean resign_bundle(const gchar *inpath, const gchar *outpath, GError **error) {
+gboolean resign_bundle(RaucBundle *bundle, const gchar *outpath, GError **error) {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
-	RaucBundle *bundle;
 
-	res = check_bundle(inpath, &bundle, TRUE, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
-	}
+	g_return_val_if_fail(bundle != NULL, FALSE);
 
-	res = truncate_bundle(inpath, outpath, bundle->size, &ierror);
+	res = truncate_bundle(bundle->path, outpath, bundle->size, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;
@@ -473,23 +468,15 @@ out:
 	return res;
 }
 
-gboolean extract_bundle(const gchar *bundlename, const gchar *outputdir, gboolean verify, GError **error) {
+gboolean extract_bundle(RaucBundle *bundle, const gchar *outputdir, GError **error) {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
-	r_context_begin_step("extract_bundle", "Extracting bundle", 2);
+	g_return_val_if_fail(bundle != NULL, FALSE);
 
-	res = check_bundle(bundlename, NULL, verify, &ierror);
-	if (!res) {
-		if (g_error_matches(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE)) {
-			g_propagate_prefixed_error(error, ierror, "Invalid Bundle: ");
-		} else {
-			g_propagate_error(error, ierror);
-		}
-		goto out;
-	}
+	r_context_begin_step("extract_bundle", "Extracting bundle", 1);
 
-	res = unsquashfs(bundlename, outputdir, NULL, &ierror);
+	res = unsquashfs(bundle->path, outputdir, NULL, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;
@@ -501,21 +488,13 @@ out:
 	return res;
 }
 
-gboolean extract_file_from_bundle(const gchar *bundlename, const gchar *outputdir, const gchar *file, gboolean verify, GError **error) {
+gboolean extract_file_from_bundle(RaucBundle *bundle, const gchar *outputdir, const gchar *file, GError **error) {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
-	res = check_bundle(bundlename, NULL, verify, &ierror);
-	if (!res) {
-		if (g_error_matches(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE)) {
-			g_propagate_prefixed_error(error, ierror, "Invalid Bundle: ");
-		} else {
-			g_propagate_error(error, ierror);
-		}
-		goto out;
-	}
+	g_return_val_if_fail(bundle != NULL, FALSE);
 
-	res = unsquashfs(bundlename, outputdir, file, &ierror);
+	res = unsquashfs(bundle->path, outputdir, file, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;
@@ -526,18 +505,13 @@ out:
 	return res;
 }
 
-gboolean mount_bundle(const gchar *bundlename, const gchar *mountpoint, gboolean verify, GError **error) {
+gboolean mount_bundle(RaucBundle *bundle, const gchar *mountpoint, GError **error) {
 	GError *ierror = NULL;
-	RaucBundle *bundle = NULL;
 	gboolean res = FALSE;
 
-	res = check_bundle(bundlename, &bundle, verify, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
-	}
+	g_return_val_if_fail(bundle != NULL, FALSE);
 
-	res = r_mount_loop(bundlename, mountpoint, bundle->size, &ierror);
+	res = r_mount_loop(bundle->path, mountpoint, bundle->size, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;
@@ -548,11 +522,13 @@ out:
 	return res;
 }
 
-gboolean umount_bundle(const gchar *bundlename, GError **error) {
+gboolean umount_bundle(RaucBundle *bundle, GError **error) {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
-	res = r_umount(bundlename, &ierror);
+	g_return_val_if_fail(bundle != NULL, FALSE);
+
+	res = r_umount(bundle->path, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -448,7 +448,7 @@ gboolean check_bundle(const gchar *bundlename, gsize *size, gboolean verify, GEr
 	if (verify) {
 		g_message("Verifying bundle... ");
 		/* the squashfs image size is in offset */
-		res = cms_verify_file(bundlename, sig, offset, &ierror);
+		res = cms_verify_file(bundlename, sig, offset, NULL, NULL, &ierror);
 		if (!res) {
 			g_propagate_error(error, ierror);
 			goto out;

--- a/src/install.c
+++ b/src/install.c
@@ -1119,7 +1119,7 @@ gboolean do_install_network(const gchar *url, GError **error) {
 		goto out;
 	}
 
-	res = cms_verify(manifest_data, signature_data, &ierror);
+	res = cms_verify(manifest_data, signature_data, NULL, NULL, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,

--- a/src/main.c
+++ b/src/main.c
@@ -602,6 +602,7 @@ static gboolean info_start(int argc, char **argv)
 	GError *error = NULL;
 	gboolean res = FALSE;
 	gchar* (*formatter)(RaucManifest *manifest) = NULL;
+	gchar *text;
 
 	if (argc < 3) {
 		g_printerr("A file name must be provided\n");
@@ -658,7 +659,9 @@ static gboolean info_start(int argc, char **argv)
 		goto out;
 	}
 
-	g_print("%s\n", formatter(manifest));
+	text = formatter(manifest);
+	g_print("%s\n", text);
+	g_free(text);
 
 out:
 	r_exit_status = res ? 0 : 1;

--- a/src/main.c
+++ b/src/main.c
@@ -23,7 +23,7 @@ GMainLoop *r_loop = NULL;
 int r_exit_status = 0;
 
 gboolean install_ignore_compatible = FALSE;
-gboolean info_noverify = FALSE;
+gboolean info_noverify, info_dumpcert = FALSE;
 gchar *output_format = NULL;
 
 static gboolean install_notify(gpointer data) {
@@ -668,6 +668,12 @@ static gboolean info_start(int argc, char **argv)
 		text = print_cert_chain(bundle->verified_chain);
 		g_print("%s\n", text);
 		g_free(text);
+
+		if (info_dumpcert) {
+			text = print_signer_cert(bundle->verified_chain);
+			g_print("%s\n", text);
+			g_free(text);
+		}
 	}
 
 out:
@@ -1007,6 +1013,7 @@ GOptionEntry entries_install[] = {
 GOptionEntry entries_info[] = {
 	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &info_noverify, "disable bundle verification", NULL},
 	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format", "FORMAT"},
+	{"dump-cert", '\0', 0, G_OPTION_ARG_NONE, &info_dumpcert, "dump certificate", NULL},
 	{0}
 };
 

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include "install.h"
 #include "rauc-installer-generated.h"
 #include "service.h"
+#include "signature.h"
 #include "utils.h"
 #include "mark.h"
 
@@ -662,6 +663,12 @@ static gboolean info_start(int argc, char **argv)
 	text = formatter(manifest);
 	g_print("%s\n", text);
 	g_free(text);
+
+	if (!output_format || g_strcmp0(output_format, "readable") == 0) {
+		text = print_cert_chain(bundle->verified_chain);
+		g_print("%s\n", text);
+		g_free(text);
+	}
 
 out:
 	r_exit_status = res ? 0 : 1;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -627,7 +627,7 @@ gboolean verify_manifest(const gchar *dir, RaucManifest **output, gboolean signa
 			goto out;
 		}
 
-		res = cms_verify_file(manifestpath, sig, 0, &ierror);
+		res = cms_verify_file(manifestpath, sig, 0, NULL, NULL, &ierror);
 		if (!res) {
 			g_propagate_error(error, ierror);
 			goto out;

--- a/src/service.c
+++ b/src/service.c
@@ -98,6 +98,7 @@ static gboolean r_on_handle_info(RInstaller *interface,
 	gchar* bundledir = NULL;
 	gchar* manifestpath = NULL;
 	RaucManifest *manifest = NULL;
+	RaucBundle *bundle = NULL;
 	GError *error = NULL;
 	gboolean res = TRUE;
 
@@ -118,7 +119,14 @@ static gboolean r_on_handle_info(RInstaller *interface,
 	bundledir = g_build_filename(tmpdir, "bundle-content", NULL);
 	manifestpath = g_build_filename(bundledir, "manifest.raucm", NULL);
 
-	res = extract_file_from_bundle(arg_bundle, bundledir, "manifest.raucm", TRUE, &error);
+	res = check_bundle(arg_bundle, &bundle, TRUE, &error);
+	if (!res) {
+		g_warning("%s", error->message);
+		g_clear_error(&error);
+		goto out;
+	}
+
+	res = extract_file_from_bundle(bundle, bundledir, "manifest.raucm", &error);
 	if (!res) {
 		g_warning("%s", error->message);
 		g_clear_error(&error);
@@ -152,6 +160,8 @@ out:
 						      G_IO_ERROR_FAILED_HANDLED,
 						      "rauc info error");
 	}
+
+	g_clear_pointer(&bundle, free_bundle);
 
 	return TRUE;
 }

--- a/src/signature.c
+++ b/src/signature.c
@@ -236,6 +236,7 @@ out:
 	BIO_free_all(incontent);
 	BIO_free_all(insig);
 	X509_STORE_free(store);
+	CMS_ContentInfo_free(cms);
 	r_context_end_step("cms_verify", res);
 	return res;
 }

--- a/src/signature.c
+++ b/src/signature.c
@@ -9,24 +9,10 @@
 #include "context.h"
 #include "signature.h"
 
-#define R_SIGNATURE_ERROR r_signature_error_quark ()
-
-static GQuark r_signature_error_quark (void)
+GQuark r_signature_error_quark (void)
 {
   return g_quark_from_static_string ("r_signature_error_quark");
 }
-
-#define R_SIGNATURE_ERROR_UNKNOWN	0
-#define R_SIGNATURE_ERROR_LOAD_FAILED	1
-#define R_SIGNATURE_ERROR_PARSE_ERROR	2
-#define R_SIGNATURE_ERROR_CREATE_SIG	3
-#define R_SIGNATURE_ERROR_SERIALIZE_SIG	4
-
-#define R_SIGNATURE_ERROR_X509_NEW	10
-#define R_SIGNATURE_ERROR_X509_LOOKUP	11
-#define R_SIGNATURE_ERROR_CA_LOAD	12
-#define R_SIGNATURE_ERROR_PARSE		13
-#define R_SIGNATURE_ERROR_INVALID	14
 
 void signature_init(void) {
 	OPENSSL_no_config();

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -52,14 +52,16 @@ static void test_check_empty_bundle(BundleFixture *fixture,
 		gconstpointer user_data)
 {
 	gchar *bundlename;
-	gsize size;
+	RaucBundle *bundle = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
 	bundlename = write_random_file(fixture->tmpdir, "bundle.raucb", 0, 1234);
 	g_assert_nonnull(bundlename);
 
-	res = check_bundle(bundlename, &size, TRUE, &ierror);
+	res = check_bundle(bundlename, &bundle, TRUE, &ierror);
+	g_assert_null(bundle);
+
 	g_assert_error(ierror, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT);
 	g_assert_false(res);
 
@@ -70,14 +72,16 @@ static void test_check_invalid_bundle(BundleFixture *fixture,
 		gconstpointer user_data)
 {
 	gchar *bundlename;
-	gsize size;
+	RaucBundle *bundle = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
 	bundlename = write_random_file(fixture->tmpdir, "bundle.raucb", 1024, 1234);
 	g_assert_nonnull(bundlename);
 
-	res = check_bundle(bundlename, &size, FALSE, &ierror);
+	res = check_bundle(bundlename, &bundle, FALSE, &ierror);
+	g_assert_null(bundle);
+
 	g_assert_error(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE);
 	g_assert_false(res);
 
@@ -134,7 +138,7 @@ static void bundle_test_resign(BundleFixture *fixture,
 		gconstpointer user_data)
 {
 	gchar *resignbundle;
-	gsize size;
+	RaucBundle *bundle = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
@@ -148,10 +152,10 @@ static void bundle_test_resign(BundleFixture *fixture,
 
 	/* Verify input bundle with dev keyring */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-ca.pem");
-	g_assert_true(check_bundle(fixture->bundlename, &size, TRUE, NULL));
+	g_assert_true(check_bundle(fixture->bundlename, &bundle, TRUE, NULL));
 	/* Verify input bundle with rel keyring */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	g_assert_false(check_bundle(fixture->bundlename, &size, TRUE, NULL));
+	g_assert_false(check_bundle(fixture->bundlename, &bundle, TRUE, NULL));
 
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-ca.pem");
 	res = resign_bundle(fixture->bundlename, resignbundle, &ierror);
@@ -164,10 +168,10 @@ static void bundle_test_resign(BundleFixture *fixture,
 	 * installing development bundles as well as moving to production
 	 * bundles. */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-ca.pem");
-	g_assert_true(check_bundle(resignbundle, &size, TRUE, NULL));
+	g_assert_true(check_bundle(resignbundle, &bundle, TRUE, NULL));
 	/* Verify resigned bundle with rel keyring */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	g_assert_true(check_bundle(resignbundle, &size, TRUE, NULL));
+	g_assert_true(check_bundle(resignbundle, &bundle, TRUE, NULL));
 }
 
 int main(int argc, char *argv[])

--- a/test/signature.c
+++ b/test/signature.c
@@ -93,7 +93,7 @@ static void signature_verify(void)
 	GBytes *sig = read_file("test/openssl-ca/manifest-r1.sig", NULL);
 	g_assert_nonnull(content);
 	g_assert_nonnull(sig);
-	g_assert_true(cms_verify(content, sig, NULL));
+	g_assert_true(cms_verify(content, sig, NULL, NULL, NULL));
 	g_bytes_unref(content);
 	g_bytes_unref(sig);
 }
@@ -108,17 +108,17 @@ static void signature_verify_file(void)
 	g_assert_nonnull(isig);
 
 	// Test valid manifest
-	g_assert_true(cms_verify_file("test/openssl-ca/manifest", sig, 0, &error));
+	g_assert_true(cms_verify_file("test/openssl-ca/manifest", sig, 0, NULL, NULL, &error));
 	g_assert_null(error);
 
 	// Test non-existing file
-	g_assert_false(cms_verify_file("path/to/nonexisting/file", sig, 0, &error));
+	g_assert_false(cms_verify_file("path/to/nonexisting/file", sig, 0, NULL, NULL, &error));
 	g_assert_nonnull(error);
 
 	g_clear_error(&error);
 
 	// Test valid manifest against invalid signature
-	g_assert_false(cms_verify_file("test/openssl-ca/manifest", isig, 0, &error));
+	g_assert_false(cms_verify_file("test/openssl-ca/manifest", isig, 0, NULL, NULL, &error));
 	g_assert_nonnull(error);
 
 	g_clear_error(&error);
@@ -137,9 +137,9 @@ static void signature_loopback(void)
 		       r_context()->keypath,
 		       NULL);
 	g_assert_nonnull(sig);
-	g_assert_true(cms_verify(content, sig, NULL));
+	g_assert_true(cms_verify(content, sig, NULL, NULL, NULL));
 	((char *)g_bytes_get_data(content, NULL))[0] = 0x00;
-	g_assert_false(cms_verify(content, sig, NULL));
+	g_assert_false(cms_verify(content, sig, NULL, NULL, NULL));
 	g_bytes_unref(content);
 	g_bytes_unref(sig);
 }


### PR DESCRIPTION
This series performs some refactoring of bundle handling functions. It introduces a `RaucBundle` structure to support passing configuration and meta information to bundle handling functions.
These changes form the base for the also included extraction of certificate and trust chain information obtained during bunde verification.
`rauc info` will now print trust chain information if signature verification succeeded.
A new option for `rauc info` ( ``--dump-cert``) lets you dump useful certificate information about a bundle.

Series is based on PR #152 and #153