### PR TITLE
Support for extracting and handling SPKI hashes

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -6,9 +6,15 @@
 
 
 #include "config_file.h"
+#include "bundle.h"
 
 typedef void (*progress_callback) (gint percentage, const gchar *message,
 				   gint nesting_depth);
+
+typedef struct {
+	/* The bundle currently mounted by RAUC */
+	RaucBundle *mounted_bundle;
+} RContextInstallationInfo;
 
 typedef struct {
 	/* a busy context must not be reconfigured */
@@ -36,6 +42,9 @@ typedef struct {
 	gchar *handlerextra;
 	/* ignore compatible check */
 	gboolean ignore_compatible;
+
+	/* for storing installation runtime informations */
+	RContextInstallationInfo *install_info;
 } RaucContext;
 
 typedef struct {

--- a/include/signature.h
+++ b/include/signature.h
@@ -83,6 +83,27 @@ gboolean cms_verify(GBytes *content, GBytes *sig, CMS_ContentInfo **cms, X509_ST
 gboolean cms_verify_file(const gchar *filename, GBytes *sig, gsize limit, CMS_ContentInfo **cms, X509_STORE **store, GError **error);
 
 /**
+ * Calculates hash for certificate pubkey info.
+ *
+ * This hashes the complete 'Subject Public Key Info' similar to what DANE
+ * does.
+ *
+ * @param cert certificate to calculate hash for
+ *
+ * @return colon-separated hexadecimal representation of subject key hash
+ */
+gchar* get_pubkey_hash(X509 *cert);
+
+/**
+ * Calculates all hashes for certificate stacks pubkeys
+ *
+ * @param certs Stack of certificates
+ *
+ * @return Array of pointers to string representations of hashes
+ */
+gchar** get_pubkey_hashes(STACK_OF(X509) *certs);
+
+/**
  * Returns string representation of certificate.
  *
  * @param verified_chain Stack of X509 certificates as returned by

--- a/src/context.c
+++ b/src/context.c
@@ -390,6 +390,7 @@ RaucContext *r_context_conf(void) {
 		context = g_new0(RaucContext, 1);
 		context->configpath = g_strdup("/etc/rauc/system.conf");
 		context->progress = NULL;
+		context->install_info = g_new0(RContextInstallationInfo, 1);
 	}
 
 	g_assert_false(context->busy);

--- a/src/install.c
+++ b/src/install.c
@@ -994,6 +994,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error) {
 	GHashTable *target_group;
 
 	g_assert_nonnull(bundlefile);
+	g_assert_null(r_context()->install_info->mounted_bundle);
 
 	r_context_begin_step("do_install_bundle", "Installing", 5);
 	res = determine_slot_states(&ierror);

--- a/src/install.c
+++ b/src/install.c
@@ -1031,6 +1031,8 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error) {
 		goto umount;
 	}
 
+	r_context()->install_info->mounted_bundle = bundle;
+
 	res = verify_manifest(mountpoint, &manifest, FALSE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
@@ -1089,6 +1091,7 @@ umount:
 	umount_bundle(bundle, NULL);
 	g_rmdir(mountpoint);
 	g_clear_pointer(&mountpoint, g_free);
+	r_context()->install_info->mounted_bundle = NULL;
 
 out:
 	g_clear_pointer(&bundle, free_bundle);

--- a/src/signature.c
+++ b/src/signature.c
@@ -5,6 +5,7 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
+#include <openssl/crypto.h>
 
 #include "context.h"
 #include "signature.h"
@@ -155,6 +156,68 @@ out:
 	BIO_free_all(incontent);
 	BIO_free_all(outsig);
 	return res;
+}
+
+gchar* get_pubkey_hash(X509 *cert) {
+		gchar *data = NULL;
+		GString *string;
+		unsigned char *der_buf, *tmp_buf = NULL;
+		unsigned int len = 0;
+		unsigned int n = 0;
+		unsigned char md[SHA256_DIGEST_LENGTH];
+
+		/* As we print colon-separated hex, we need 3 chars per byte */
+		string = g_string_sized_new(SHA256_DIGEST_LENGTH * 3);
+
+		len = i2d_X509_PUBKEY(X509_get_X509_PUBKEY(cert), NULL);
+		if (len <= 0) {
+			g_warning("DER Encoding failed\n");
+			goto out;
+		}
+		/* As i2d_X509_PUBKEY() moves pointer after end of data,
+		 * we must use a tmp pointer, here */
+		der_buf = tmp_buf = g_malloc(len);
+		i2d_X509_PUBKEY(X509_get_X509_PUBKEY(cert), &tmp_buf);
+
+		g_assert(tmp_buf- der_buf == len);
+
+		if (!EVP_Digest(der_buf, len, md, &n, EVP_sha256(), NULL)) {
+			g_warning("Error in EVP_Digest\n");
+			goto out;
+		}
+
+		g_assert_cmpint(n, ==, SHA256_DIGEST_LENGTH);
+
+		for (int j = 0; j < (int)n; j++) {
+			g_string_append_printf(string, "%02X:", md[j]);
+		}
+		g_string_truncate(string, SHA256_DIGEST_LENGTH * 3 - 1);
+
+		data = g_string_free(string, FALSE);
+out:
+		g_clear_pointer(&der_buf, g_free);
+		return data;
+}
+
+gchar** get_pubkey_hashes(STACK_OF(X509) *verified_chain) {
+	GPtrArray *hashes = g_ptr_array_new_full(4, g_free);
+	gchar **ret = NULL;
+
+	for (int i = 0; i < sk_X509_num(verified_chain); i++) {
+		gchar *hash;
+
+		hash = get_pubkey_hash(sk_X509_value(verified_chain, i));
+		if (hash == NULL) {
+			g_ptr_array_free(hashes, TRUE);
+			goto out;
+		}
+		g_ptr_array_add(hashes, hash);
+	}
+	g_ptr_array_add(hashes, NULL);
+
+	ret = (gchar**) g_ptr_array_free(hashes, FALSE);
+out:
+	return ret;
 }
 
 gchar* print_signer_cert(STACK_OF(X509) *verified_chain) {

--- a/src/signature.c
+++ b/src/signature.c
@@ -249,6 +249,7 @@ gchar* print_cert_chain(STACK_OF(X509) *verified_chain) {
 		X509_NAME_oneline(X509_get_issuer_name(sk_X509_value(verified_chain, i)),
 				buf, sizeof buf);
 		g_string_append_printf(text, "   Issuer: %s\n", buf);
+		g_string_append_printf(text, "   SPKI sha256: %s\n", get_pubkey_hash(sk_X509_value(verified_chain, i)));
 	}
 
 	return g_string_free(text, FALSE);

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -11,6 +11,7 @@
 
 #include "context.h"
 #include "mount.h"
+#include "signature.h"
 #include "update_handler.h"
 
 
@@ -381,6 +382,18 @@ static gboolean run_slot_hook(const gchar *hook_name, const gchar *hook_cmd, Rau
 		g_subprocess_launcher_setenv(launcher, "RAUC_IMAGE_CLASS", image->slotclass, TRUE);
 	}
 	g_subprocess_launcher_setenv(launcher, "RAUC_MOUNT_PREFIX", r_context()->config->mount_prefix, TRUE);
+
+	if (r_context()->install_info->mounted_bundle) {
+		gchar **hashes = NULL;
+		gchar *string = NULL;
+
+		hashes = get_pubkey_hashes(r_context()->install_info->mounted_bundle->verified_chain);
+		string = g_strjoinv(" ", hashes);
+		g_strfreev(hashes);
+
+		g_subprocess_launcher_setenv(launcher, "RAUC_BUNDLE_SPKI_HASHES", string, FALSE);
+		g_free(string);
+	}
 
 	sproc = g_subprocess_launcher_spawn(
 			launcher, &ierror,


### PR DESCRIPTION
This series adds functions for extracting public key hashes of certificates involved in signing and the trust chain.

This potentially allows to perform decisions about key chains to use on the target depending on which certificate was used to sign the bundle. A common use case for this is to switch from a development-key-signed bundle to one signed with a release key without changing the bundle content.

Based on PR #154