### PR TITLE
.travis.yml: manually install dbus-x11 to have dbus-launch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq autoconf automake libglib2.0-dev libjson-glib-dev
     libssl-dev libcurl4-openssl-dev squashfs-tools dosfstools lcov slirp python-sphinx
+    dbus-x11
   - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/
     vivid main restricted universe multiverse" -y
   - sudo apt-get update -qq


### PR DESCRIPTION
Prior Travis build slaves seem to have provided this by default.
Now it is missing and causes the rauc.t service tests to fail.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>