### PR TITLE
.travis.yml: use --upgrade in pip install cpp-coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     vivid main restricted universe multiverse" -y
   - sudo apt-get update -qq
   - sudo apt-get install -qq user-mode-linux grub-common
-  - sudo pip install cpp-coveralls
+  - sudo pip install --upgrade cpp-coveralls
 addons:
   coverity_scan:
     project:


### PR DESCRIPTION
Latest coveralls is incompatible with default urllib3 version installed.

This currently breaks coveralls checks in Travis as coveralls aborts
with a stack trace noting:

```
...
pkg_resources.UnknownExtra: urllib3 1.7.1 has no such extra feature 'secure'
```

Adding upgrade triggers pip to use the latest version of urllib3.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>