### PR TITLE
Skippable

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -167,6 +167,11 @@ hierarchical separator.
   Marks the slot as existing but not updatable. May be used for sanity checking
   or informative purpose. A ``readonly`` slot cannot be a target slot.
 
+``ignore-checksum``
+  If set to ``true`` this will bypass the default hash comparison for this slot
+  and force RAUC to unconditionally update it. The default value is ``false``,
+  which means that updating this slot will be skipped if new image's hash
+  matches hash of installed one.
 
 Manifest
 --------
@@ -478,7 +483,7 @@ Performing an update using the default RAUC mechanism will work as follows:
    A. Determine update handler (based on image and slot type)
    #. Try to mount slot and read slot status information
 
-      a. Skip update if new image hash matches hash of insalled one
+      a. Skip update if new image hash matches hash of installed one
 
    #. Perform slot update (image copy / mkfs+tar extract / ...)
    #. Try to write slot status information

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -74,6 +74,8 @@ typedef struct _RaucSlot {
 	gchar *bootname;
 	/** flag indicating if the slot is updatable */
 	gboolean readonly;
+	/** flag indicating if the slot update may be forced */
+	gboolean ignore_checksum;
 
 	/** current state of the slot (runtime) */
 	SlotState state;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -300,6 +300,17 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 				goto free;
 			}
 
+			slot->ignore_checksum = g_key_file_get_boolean(key_file, groups[i], "ignore-checksum", &ierror);
+			if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+				slot->ignore_checksum = FALSE;
+				g_clear_error(&ierror);
+			}
+			else if (ierror) {
+				g_propagate_error(error, ierror);
+				res = FALSE;
+				goto free;
+			}
+
 			g_hash_table_insert(slots, (gchar*)slot->name, slot);
 
 		}

--- a/src/install.c
+++ b/src/install.c
@@ -875,7 +875,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 				slot_state->status = g_strdup("update");
 			} else {
 				/* skip if slot is up-to-date */
-				if (g_str_equal(mfimage->checksum.digest, slot_state->checksum.digest)) {
+				if (!dest_slot->ignore_checksum && g_str_equal(mfimage->checksum.digest, slot_state->checksum.digest)) {
 					install_args_update(args, g_strdup_printf("Skipping update for correct image %s", mfimage->filename));
 					g_message("Skipping update for correct image %s", mfimage->filename);
 					r_context_end_step("check_slot", TRUE);


### PR DESCRIPTION
Add flag to system.conf to avoid skipping of slots. This force installation even if hashes are unchanged.