### PR TITLE
src/config_file: not finding a configured parent must be fatal

### DIFF
--- a/include/config_file.h
+++ b/include/config_file.h
@@ -7,7 +7,8 @@
 
 typedef enum {
 	R_CONFIG_ERROR_INVALID_FORMAT,
-	R_CONFIG_ERROR_BOOTLOADER
+	R_CONFIG_ERROR_BOOTLOADER,
+	R_CONFIG_ERROR_PARENT
 } RConfigError;
 
 #define R_CONFIG_ERROR r_config_error_quark()

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -253,8 +253,13 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 
 		s = g_hash_table_lookup(slots, value);
 		if (!s) {
-			g_print("Parent %s not found!\n", value);
-			continue;
+			g_set_error (
+					error,
+					R_CONFIG_ERROR,
+					R_CONFIG_ERROR_PARENT,
+					"Parent slot '%s' not found!", value);
+			res = FALSE;
+			goto free;
 		}
 
 		((RaucSlot*)g_hash_table_lookup(slots, l->data))->parent = s;


### PR DESCRIPTION
If we cannot find a parent that is configured, continuing will lead to
unintended behavior and slot handling. This must be avoided!

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>