### PR TITLE
src/install: add support for already mounted devices

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -190,6 +190,11 @@ hierarchical separator.
   active slots, so that the inactive one can be selected as the update target.
   The parent slot is referenced using the form ``<slot-class>.<idx>``.
 
+``mounted``
+  Setting this entry to ``true`` tells RAUC to umount the slot before
+  updating it, and to remount it when done. Used for slots that are
+  mounted at boot by the system.
+
 ``readonly``
   Marks the slot as existing but not updatable. May be used for sanity checking
   or informative purpose. A ``readonly`` slot cannot be a target slot.

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -88,6 +88,8 @@ typedef struct _RaucSlot {
 	gchar *type;
 	/** the name this slot is known to the bootloader */
 	gchar *bootname;
+	/** flag to indicate that this slot is always mounted */
+	gboolean system_mounted;
 	/** flag indicating if the slot is updatable */
 	gboolean readonly;
 	/** flag indicating if the slot update may be forced */

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -305,6 +305,17 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 			value = g_key_file_get_string(key_file, groups[i], "bootname", NULL);
 			slot->bootname = value;
 
+			slot->system_mounted = g_key_file_get_boolean(key_file, groups[i], "mounted", &ierror);
+			if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+				slot->system_mounted = FALSE;
+				g_clear_error(&ierror);
+			}
+			else if (ierror) {
+				g_propagate_error(error, ierror);
+				res = FALSE;
+				goto free;
+			}
+
 			slot->readonly = g_key_file_get_boolean(key_file, groups[i], "readonly", &ierror);
 			if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
 				slot->readonly = FALSE;

--- a/test/install-fixtures.c
+++ b/test/install-fixtures.c
@@ -23,6 +23,7 @@ void fixture_helper_fixture_set_up_system_user(gchar *tmpdir,
 	g_assert(test_mkdir_relative(tmpdir, "images", 0777) == 0);
 	g_assert(test_mkdir_relative(tmpdir, "openssl-ca", 0777) == 0);
 	g_assert(test_mkdir_relative(tmpdir, "slot", 0777) == 0);
+	g_assert(test_mkdir_relative(tmpdir, "bootloader", 0777) == 0);
 
 	/* copy system config to temp dir*/
 	if (!configname)
@@ -67,10 +68,13 @@ void fixture_helper_fixture_set_up_system_user(gchar *tmpdir,
 					SLOT_SIZE, "/dev/zero") == 0);
 	g_assert(test_prepare_dummy_file(tmpdir, "images/appfs-1",
 					SLOT_SIZE, "/dev/zero") == 0);
+	g_assert(test_prepare_dummy_file(tmpdir, "images/bootloader-0",
+					SLOT_SIZE, "/dev/zero") == 0);
 	g_assert_true(test_make_filesystem(tmpdir, "images/rootfs-0"));
 	g_assert_true(test_make_filesystem(tmpdir, "images/appfs-0"));
 	g_assert_true(test_make_filesystem(tmpdir, "images/rootfs-1"));
 	g_assert_true(test_make_filesystem(tmpdir, "images/appfs-1"));
+	g_assert_true(test_make_filesystem(tmpdir, "images/bootloader-0"));
 
 	/* Set dummy bootname provider */
 	r_context_conf()->bootslot = g_strdup("system0");
@@ -98,12 +102,19 @@ void fixture_helper_set_up_system(gchar *tmpdir,
 	test_make_slot_user_writable(tmpdir, "images/appfs-0");
 	test_make_slot_user_writable(tmpdir, "images/rootfs-1");
 	test_make_slot_user_writable(tmpdir, "images/appfs-1");
+	test_make_slot_user_writable(tmpdir, "images/bootloader-0");
 
 	/* Provide active mounted slot */
 	slotfile = g_build_filename(tmpdir, "images/rootfs-0", NULL);
 	slotpath = g_build_filename(tmpdir, "slot", NULL);
 	g_assert(test_mount(slotfile, slotpath));
+	g_free(slotfile);
+	g_free(slotpath);
 
+	/* Provide already mounted slot */
+	slotfile = g_build_filename(tmpdir, "images/bootloader-0", NULL);
+	slotpath = g_build_filename(tmpdir, "bootloader", NULL);
+	g_assert(test_mount(slotfile, slotpath));
 	g_free(slotfile);
 	g_free(slotpath);
 }
@@ -134,8 +145,11 @@ void fixture_helper_set_up_bundle(gchar *tmpdir,
 					SLOT_SIZE, "/dev/zero") == 0);
 	g_assert(test_prepare_dummy_file(tmpdir, "content/appfs.ext4",
 					SLOT_SIZE, "/dev/zero") == 0);
+	g_assert(test_prepare_dummy_file(tmpdir, "content/bootloader.ext4",
+					SLOT_SIZE, "/dev/zero") == 0);
 	g_assert_true(test_make_filesystem(tmpdir, "content/rootfs.ext4"));
 	g_assert_true(test_make_filesystem(tmpdir, "content/appfs.ext4"));
+	g_assert_true(test_make_filesystem(tmpdir, "content/bootloader.ext4"));
 	if (manifest_content) {
 		g_assert_true(write_tmp_file(tmpdir, "content/manifest.raucm", manifest_content, NULL));
 	} else {
@@ -145,6 +159,7 @@ void fixture_helper_set_up_bundle(gchar *tmpdir,
 	/* Make images user-writable */
 	test_make_slot_user_writable(tmpdir, "content/rootfs.ext4");
 	test_make_slot_user_writable(tmpdir, "content/appfs.ext4");
+	test_make_slot_user_writable(tmpdir, "content/bootloader.ext4");
 
 	/* Write test file to slot */
 	g_assert(test_mkdir_relative(tmpdir, "mnt", 0777) == 0);

--- a/test/install.c
+++ b/test/install.c
@@ -34,6 +34,23 @@ static void install_fixture_set_up_bundle_central_status(InstallFixture *fixture
 	fixture_helper_set_up_bundle(fixture->tmpdir, NULL, FALSE, FALSE);
 }
 
+static void install_fixture_set_up_bundle_already_mounted(InstallFixture *fixture,
+		gconstpointer user_data)
+{
+	const gchar *manifest_file = "\
+[update]\n\
+compatible=Test Config\n\
+\n\
+[image.bootloader]\n\
+filename=bootloader.ext4\n\
+";
+
+	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+
+	fixture_helper_set_up_system(fixture->tmpdir, NULL);
+	fixture_helper_set_up_bundle(fixture->tmpdir, manifest_file, TRUE, FALSE);
+}
+
 static void install_fixture_set_up_bundle_custom_handler(InstallFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1214,6 +1231,41 @@ static void install_test_bundle_hook_post_install(InstallFixture *fixture,
 	g_free(bundlepath);
 }
 
+/* Test with already mounted slot */
+static void install_test_already_mounted(InstallFixture *fixture,
+		gconstpointer user_data)
+{
+	gchar *bundlepath, *mountprefix;
+	RaucInstallArgs *args;
+	GError *ierror = NULL;
+	gboolean res;
+
+	/* needs to run as root */
+	if (!test_running_as_root())
+		return;
+
+	/* Set mount path to current temp dir */
+	mountprefix = g_build_filename(fixture->tmpdir, "mount", NULL);
+	g_assert_nonnull(mountprefix);
+	r_context_conf()->mountprefix = mountprefix;
+	r_context();
+
+	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
+	g_assert_nonnull(bundlepath);
+
+	args = install_args_new();
+	args->name = g_strdup(bundlepath);
+	args->notify = install_notify;
+	args->cleanup = install_cleanup;
+	res = do_install_bundle(args, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+
+	args->status_result = 0;
+
+	g_free(bundlepath);
+}
+
 static void install_fixture_set_up_system_user(InstallFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1291,6 +1343,10 @@ int main(int argc, char *argv[])
 
 	g_test_add("/install/bundle-hook/slot-post-install", InstallFixture, NULL,
 			install_fixture_set_up_bundle_post_hook, install_test_bundle_hook_post_install,
+			install_fixture_tear_down);
+
+	g_test_add("/install/already-mounted", InstallFixture, NULL,
+			install_fixture_set_up_bundle_already_mounted, install_test_already_mounted,
 			install_fixture_tear_down);
 
 	return g_test_run();

--- a/test/service.c
+++ b/test/service.c
@@ -270,7 +270,7 @@ static void service_test_slot_status(ServiceFixture *fixture, gconstpointer user
 			&error);
 	g_assert_no_error(error);
 	g_assert_nonnull(slot_status_array);
-	g_assert_cmpint(g_variant_n_children(slot_status_array), ==, 5);
+	g_assert_cmpint(g_variant_n_children(slot_status_array), ==, 6);
 
 out:
 	g_clear_pointer(&installer, g_object_unref);

--- a/test/test.conf
+++ b/test/test.conf
@@ -39,3 +39,7 @@ device=images/appfs-1
 type=ext4
 parent=rootfs.1
 
+[slot.bootloader.0]
+device=images/bootloader-0
+type=ext4
+mounted=true

--- a/uml-test-init
+++ b/uml-test-init
@@ -49,6 +49,7 @@ chown root:root /tmp/system.d/de.pengutronix.rauc.conf
 chmod 644 /tmp/system.d/de.pengutronix.rauc.conf
 mount --bind /tmp/system.d /etc/dbus-1/system.d
 mkdir /tmp/var_run_dbus
+mkdir -p /var/run/dbus
 mount --bind /tmp/var_run_dbus /var/run/dbus
 dbus-daemon --system --fork --nopidfile
 

--- a/uml-test-init
+++ b/uml-test-init
@@ -14,11 +14,16 @@ if [ -d /usr/lib/uml/modules ]; then
     mount --bind /usr/lib/uml/modules /lib/modules
 fi
 
-ip addr add 127.0.0.1 dev lo
-ip link set lo up
-ip addr add 10.0.2.15/24 dev eth0
-ip link set eth0 up
-ip route add default via 10.0.2.2
+if [ -d /sys/class/net/lo ]; then
+    ip addr add 127.0.0.1 dev lo
+    ip link set lo up
+fi
+
+if [ -d /sys/class/net/eth0 -a -x /usr/bin/slirp-fullbolt ]; then
+    ip addr add 10.0.2.15/24 dev eth0
+    ip link set eth0 up
+    ip route add default via 10.0.2.2
+fi
 
 modprobe loop max_loop=24
 for i in $(seq 0 23); do

--- a/uml-test-init
+++ b/uml-test-init
@@ -17,7 +17,10 @@ ip addr add 10.0.2.15/24 dev eth0
 ip link set eth0 up
 ip route add default via 10.0.2.2
 
-modprobe loop
+modprobe loop max_loop=24
+for i in $(seq 0 23); do
+    [ -b /dev/loop$i ] || mknod -m 660 /dev/loop$i b 7 $i
+done
 
 if grep -q 127.0.0.1 /etc/resolv.conf; then
     echo "nameserver 10.0.2.2" > /tmp/resolv.conf

--- a/uml-test-init
+++ b/uml-test-init
@@ -9,7 +9,10 @@ mount -t sysfs none /sys
 mount -t tmpfs none /tmp
 mount -t tmpfs none /mnt
 
-mount --bind /usr/lib/uml/modules /lib/modules
+if [ -d /usr/lib/uml/modules ]; then
+    mkdir -p /lib/modules
+    mount --bind /usr/lib/uml/modules /lib/modules
+fi
 
 ip addr add 127.0.0.1 dev lo
 ip link set lo up


### PR DESCRIPTION
In cases where a slot device is mounted at boot by the system being
updated, rauc should umount the device before doing its update, and then
remount when done.

This becomes usefull on boards like RPi and Beaglebone Black, where the
boot partition must be mounted at boot to read/write the u-boot
environment, but also updated by rauc (i.e. to update the bootloader).

Signed-off-by: Martin Hundebøll <mnhu@prevas.dk>