### PR TITLE
src/bootchooser: implement noop bootloader support

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -381,6 +381,9 @@ gboolean r_boot_set_state(RaucSlot *slot, gboolean good) {
 		return grub_set_state(slot, good);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "uboot") == 0) {
 		return uboot_set_state(slot, good);
+	} else if (g_strcmp0(r_context()->config->system_bootloader, "noop") == 0) {
+		g_message("noop bootloader: ignore setting slot %s status to %s", slot->name, good ? "good" : "bad");
+		return TRUE;
 	}
 
 	g_error("bootloader type '%s' not supported yet", r_context()->config->system_bootloader);
@@ -394,6 +397,9 @@ gboolean r_boot_set_primary(RaucSlot *slot) {
 		return grub_set_primary(slot);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "uboot") == 0) {
 		return uboot_set_primary(slot);
+	} else if (g_strcmp0(r_context()->config->system_bootloader, "noop") == 0) {
+		g_message("noop bootloader: ignore setting slot %s as primary", slot->name);
+		return TRUE;
 	}
 
 	g_error("bootloader type '%s' not supported yet", r_context()->config->system_bootloader);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -59,7 +59,7 @@ gboolean is_slot_mountable(RaucSlot *slot) {
 	return FALSE;
 }
 
-static const gchar *supported_bootloaders[] = {"barebox", "grub", "uboot", NULL};
+static const gchar *supported_bootloaders[] = {"barebox", "grub", "uboot", "noop", NULL};
 
 gboolean load_config(const gchar *filename, RaucConfig **config, GError **error) {
 	GError *ierror = NULL;


### PR DESCRIPTION
This is primary for testing purpose and will allow running RAUC without
having a bootloader implementation set-up.
To prevent from unintionally leaving this in a final design, a message
will be printed on each 'noop' call.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>