### PR TITLE
src/install: fix build without network support

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -192,6 +192,7 @@ static RaucSlot* get_parent_root_slot(RaucSlot *slot) {
 	return base;
 }
 
+#if ENABLE_NETWORK
 /* Returns newly allocated NULL-teminated string array of all classes listed in
  * given manifest.
  * Free with g_strfreev */
@@ -214,6 +215,7 @@ static gchar** get_all_file_slot_classes(const RaucManifest *manifest) {
 
 	return (gchar**) g_ptr_array_free(slotclasses, FALSE);
 }
+#endif
 
 /* Gets all classes that do not have a parent
  * 


### PR DESCRIPTION
function 'get_all_file_slot_classes()' is only used by
'launch_and_wait_network_handler()'.
Thus it leads to a compile error if the static function is defined
unconditionally.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>