### PR TITLE
Fixes and error handling rework for RAUC boot selection layer

### DIFF
--- a/include/bootchooser.h
+++ b/include/bootchooser.h
@@ -16,16 +16,18 @@ GQuark r_bootchooser_error_quark (void);
  *
  * @param slot Slot to mark
  * @param good Whether to mark it as good (instead of bad)
+ * @param error return location for a GError, or NULL
  *
  * @return TRUE if successful, FALSE if failed
  */
-gboolean r_boot_set_state(RaucSlot *slot, gboolean good);
+gboolean r_boot_set_state(RaucSlot *slot, gboolean good, GError **error);
 
 /**
  * Mark slot as primary boot option of its slot class.
  *
  * @param slot Slot to mark
+ * @param error return location for a GError, or NULL
  *
  * @return TRUE if successful, FALSE if failed
  */
-gboolean r_boot_set_primary(RaucSlot *slot);
+gboolean r_boot_set_primary(RaucSlot *slot, GError **error);

--- a/include/bootchooser.h
+++ b/include/bootchooser.h
@@ -4,6 +4,13 @@
 
 #include "config_file.h"
 
+#define R_BOOTCHOOSER_ERROR r_bootchooser_error_quark ()
+GQuark r_bootchooser_error_quark (void);
+
+#define R_BOOTCHOOSER_ERROR_FAILED		0
+#define R_BOOTCHOOSER_ERROR_NOT_SUPPORTED	10
+#define R_BOOTCHOOSER_ERROR_PARSE_FAILED	20
+
 /**
  * Mark slot as good or bad.
  *

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -21,8 +21,8 @@ static gboolean bootchooser_order_primay(RaucSlot *slot, GString **value) {
 	GString *order = g_string_sized_new(10);
 	GList *slots;
 
-	g_assert_nonnull(slot);
-	g_assert_nonnull(value);
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(value, FALSE);
 
 	g_string_append(order, slot->bootname);
 
@@ -55,6 +55,9 @@ static gboolean barebox_state_get_int(const gchar* name, int *value) {
 	guint64 result = 0;
 	GPtrArray *args = g_ptr_array_new_full(10, g_free);
 	
+	g_return_val_if_fail(bootname, FALSE);
+	g_return_val_if_fail(bb_state, FALSE);
+
 	g_ptr_array_add(args, g_strdup(BAREBOX_STATE_NAME));
 	g_ptr_array_add(args, g_strdup("-g"));
 	g_ptr_array_add(args, g_strdup(name));
@@ -107,6 +110,8 @@ static gboolean barebox_state_set(GPtrArray *pairs) {
 	gboolean res = FALSE;
 	GPtrArray *args = g_ptr_array_new_full(2*pairs->len+2, g_free);
 
+	g_return_val_if_fail(pairs, FALSE);
+
 	g_assert_cmpuint(pairs->len, >, 0);
 	
 	g_ptr_array_add(args, g_strdup(BAREBOX_STATE_NAME));
@@ -142,7 +147,7 @@ static gboolean barebox_set_state(RaucSlot *slot, gboolean good) {
 	GPtrArray *pairs = g_ptr_array_new_full(10, g_free);
 	int attempts;
 
-	g_assert_nonnull(slot);
+	g_return_val_if_fail(slot, FALSE);
 
 	if (good) {
 		attempts = BAREBOX_STATE_DEFAULT_ATTEMPS;
@@ -174,7 +179,7 @@ static gboolean barebox_set_primary(RaucSlot *slot) {
 	gboolean res = FALSE;
 	GList *slots;
 
-	g_assert_nonnull(slot);
+	g_return_val_if_fail(slot, FALSE);
 
 	/* Iterate over class members */
 	slots = g_hash_table_get_values(r_context()->config->slots);
@@ -214,6 +219,8 @@ static gboolean grub_env_set(GPtrArray *pairs) {
 	GError *error = NULL;
 	gboolean res = FALSE;
 
+	g_return_val_if_fail(pairs, FALSE);
+
 	g_assert_cmpuint(pairs->len, >, 0);
 	g_assert_nonnull(r_context()->config->grubenv_path);
 
@@ -250,7 +257,7 @@ static gboolean grub_set_state(RaucSlot *slot, gboolean good) {
 	GPtrArray *pairs = g_ptr_array_new_full(10, g_free);
 	gboolean res = FALSE;
 
-	g_assert_nonnull(slot);
+	g_return_val_if_fail(slot, FALSE);
 
 	if (good) {
 		g_ptr_array_add(pairs, g_strdup_printf("%s_OK=1", slot->bootname));
@@ -278,7 +285,7 @@ static gboolean grub_set_primary(RaucSlot *slot) {
 	GString *order = NULL;
 	gboolean res = FALSE;
 
-	g_assert_nonnull(slot);
+	g_return_val_if_fail(slot, FALSE);
 
 	res = bootchooser_order_primay(slot, &order);
 	if (!res) {
@@ -314,8 +321,8 @@ static gboolean uboot_env_get(const gchar *key, GString **value) {
 	gboolean res = FALSE;
 	gint ret;
 
-	g_assert_nonnull(key);
-	g_assert_nonnull(value);
+	g_return_val_if_fail(key, FALSE);
+	g_return_val_if_fail(value && *value == NULL, FALSE);
 
 	sub = g_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE, &error,
 			       UBOOT_FWGETENV_NAME, key, NULL);
@@ -363,8 +370,8 @@ static gboolean uboot_env_set(const gchar *key, const gchar *value) {
 	GError *error = NULL;
 	gboolean res = FALSE;
 
-	g_assert_nonnull(key);
-	g_assert_nonnull(value);
+	g_return_val_if_fail(key, FALSE);
+	g_return_val_if_fail(value, FALSE);
 
 	sub = g_subprocess_new(G_SUBPROCESS_FLAGS_NONE, &error, UBOOT_FWSETENV_NAME,
 			       key, value, NULL);
@@ -390,7 +397,7 @@ static gboolean uboot_set_state(RaucSlot *slot, gboolean good) {
 	gboolean res = FALSE;
 	gchar *key = NULL;
 
-	g_assert_nonnull(slot);
+	g_return_val_if_fail(slot, FALSE);
 
 	key = g_strdup_printf("BOOT_%s_LEFT", slot->bootname);
 
@@ -413,7 +420,7 @@ static gboolean uboot_set_primary(RaucSlot *slot) {
 	gboolean res = FALSE;
 	gchar *key = NULL;
 
-	g_assert_nonnull(slot);
+	g_return_val_if_fail(slot, FALSE);
 
 	/* Add updated slot as first entry in new boot order */
 	g_string_append(order_new, slot->bootname);
@@ -460,6 +467,9 @@ out:
 }
 
 gboolean r_boot_set_state(RaucSlot *slot, gboolean good) {
+
+	g_return_val_if_fail(slot, FALSE);
+
 	if (g_strcmp0(r_context()->config->system_bootloader, "barebox") == 0) {
 		return barebox_set_state(slot, good);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "grub") == 0) {
@@ -476,6 +486,9 @@ gboolean r_boot_set_state(RaucSlot *slot, gboolean good) {
 }
 
 gboolean r_boot_set_primary(RaucSlot *slot) {
+
+	g_return_val_if_fail(slot, FALSE);
+
 	if (g_strcmp0(r_context()->config->system_bootloader, "barebox") == 0) {
 		return barebox_set_primary(slot);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "grub") == 0) {

--- a/src/install.c
+++ b/src/install.c
@@ -732,7 +732,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 			continue;
 		}
 
-		res = r_boot_set_state(dest_slot, FALSE);
+		res = r_boot_set_state(dest_slot, FALSE, NULL);
 
 		if (!res) {
 			g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_NONBOOTABLE,
@@ -887,7 +887,7 @@ image_out:
 			if (dest_slot->parent || !dest_slot->bootname)
 				continue;
 
-			res = r_boot_set_primary(dest_slot);
+			res = r_boot_set_primary(dest_slot, NULL);
 
 			if (!res) {
 				g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_BOOTABLE,
@@ -972,7 +972,7 @@ static gboolean launch_and_wait_network_handler(const gchar* base_url,
 			break;
 		}
 
-		res = r_boot_set_state(slot, FALSE);
+		res = r_boot_set_state(slot, FALSE, NULL);
 
 		if (!res) {
 			g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_NONBOOTABLE,
@@ -1090,7 +1090,7 @@ slot_out:
 			if (slot->parent || !slot->bootname)
 				continue;
 
-			res = r_boot_set_primary(slot);
+			res = r_boot_set_primary(slot, NULL);
 
 			if (!res) {
 				g_warning("Failed marking slot %s bootable", slot->name);

--- a/src/mark.c
+++ b/src/mark.c
@@ -96,13 +96,13 @@ gboolean mark_run(const gchar *state,
 	}
 
 	if (!g_strcmp0(state, "good")) {
-		res = r_boot_set_state(slot, TRUE);
+		res = r_boot_set_state(slot, TRUE, NULL);
 		*message = g_strdup_printf((res) ? "marked slot %s as good" : "failed to mark slot %s as good", slot->name);
 	} else if (!g_strcmp0(state, "bad")) {
-		res = r_boot_set_state(slot, FALSE);
+		res = r_boot_set_state(slot, FALSE, NULL);
 		*message = g_strdup_printf((res) ? "marked slot %s as bad" : "failed to mark slot %s as bad", slot->name);
 	} else if (!g_strcmp0(state, "active")) {
-		res = r_boot_set_primary(slot);
+		res = r_boot_set_primary(slot, NULL);
 		*message = g_strdup_printf((res) ? "activated slot %s" : "failed to activate slot %s", slot->name);
 	} else {
 		res = FALSE;

--- a/test/bin/barebox-state
+++ b/test/bin/barebox-state
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# List of valid variables
-varlist="bootstate.system0.remaining_attempts bootstate.system0.priority bootstate.system0.ok bootstate.system1.remaining_attempts bootstate.system1.priority bootstate.system1.ok bootstate.factory.remaining_attempts bootstate.factory.priority bootstate.factory.ok=0"
+# escape to bash-compatible variable assignment for saving pre-values
+for i in $BAREBOX_STATE_VARS_PRE; do
+	eval $(echo $i | sed 's/\./__/g')
+done
 
 # Command line parsing
 while [[ $# > 1 ]]; do
@@ -25,8 +27,8 @@ done
 
 function check_var {
 	found=0
-	for l in $varlist; do
-		if [ "$1" = "$l" ]; then
+	for l in $BAREBOX_STATE_VARS_PRE; do
+		if [ "$1" = "${l%=*}" ]; then
 			found=1
 		fi
 	done
@@ -34,7 +36,6 @@ function check_var {
 		echo "Invalid variable: $1"
 		exit 1
 	fi
-	printf "$1=$2\n"
 }
 
 for i in $SETVAR; do
@@ -43,6 +44,8 @@ for i in $SETVAR; do
 
 	check_var "$var" "$val"
 
+	# Assign new value
+	eval $(echo $SETVAR | sed 's/\./__/g')
 done
 
 for i in $GETVAR; do
@@ -51,6 +54,21 @@ for i in $GETVAR; do
 
 	check_var "$var"
 
+	# Output values read
+	eval echo \$$(echo ${i%=*} | sed 's/\./__/g')
+done
+
+# If we do not set something, exit before post value validation
+if [ -z "$SETVAR" ]; then
+	exit 0
+fi
+
+for i in $BAREBOX_STATE_VARS_POST; do
+	comp=$(echo ${i%=*} | sed 's/\./__/g')
+	if [ "${i#*=}" != "${!comp}" ]; then
+		echo "${i%=*} should be ${i#*=} but was ${!comp}" 1>&2
+		exit 2
+	fi
 done
 
 exit 0

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -79,7 +79,7 @@ bootstate.system0.priority=20\n\
 bootstate.system1.remaining_attempts=3\n\
 bootstate.system1.priority=10\n\
 ", TRUE);
-	g_assert_true(r_boot_set_state(slot, TRUE));
+	g_assert_true(r_boot_set_state(slot, TRUE, NULL));
 
 	/* check rootfs-0 is marked bad (prio and attempts 0) */
 	g_setenv ("BAREBOX_STATE_VARS_PRE", " \
@@ -94,7 +94,7 @@ bootstate.system0.priority=0\n\
 bootstate.system1.remaining_attempts=3\n\
 bootstate.system1.priority=10\n\
 ", TRUE);
-	g_assert_true(r_boot_set_state(slot, FALSE));
+	g_assert_true(r_boot_set_state(slot, FALSE, NULL));
 
 	slot = find_config_slot_by_device(r_context()->config, "/dev/sda1");
 	g_assert_nonnull(slot);
@@ -112,7 +112,7 @@ bootstate.system0.priority=10\n\
 bootstate.system1.remaining_attempts=3\n\
 bootstate.system1.priority=20\n\
 ", TRUE);
-	g_assert_true(r_boot_set_primary(slot));
+	g_assert_true(r_boot_set_primary(slot, NULL));
 
 	/* check rootfs-1 is marked primary while current remains disabled (prio set to 20, others to 10) */
 	g_setenv ("BAREBOX_STATE_VARS_PRE", " \
@@ -127,7 +127,7 @@ bootstate.system0.priority=0\n\
 bootstate.system1.remaining_attempts=3\n\
 bootstate.system1.priority=20\n\
 ", TRUE);
-	g_assert_true(r_boot_set_primary(slot));
+	g_assert_true(r_boot_set_primary(slot, NULL));
 }
 
 static void bootchooser_grub(BootchooserFixture *fixture,
@@ -171,13 +171,13 @@ bootname=B\n";
 	slot = find_config_slot_by_device(r_context()->config, "/dev/sda0");
 	g_assert_nonnull(slot);
 
-	g_assert_true(r_boot_set_state(slot, TRUE));
-	g_assert_true(r_boot_set_state(slot, FALSE));
+	g_assert_true(r_boot_set_state(slot, TRUE, NULL));
+	g_assert_true(r_boot_set_state(slot, FALSE, NULL));
 
 	slot = find_config_slot_by_device(r_context()->config, "/dev/sda1");
 	g_assert_nonnull(slot);
 
-	g_assert_true(r_boot_set_primary(slot));
+	g_assert_true(r_boot_set_primary(slot, NULL));
 }
 
 static void bootchooser_uboot(BootchooserFixture *fixture,
@@ -220,13 +220,13 @@ bootname=B\n";
 	slot = find_config_slot_by_device(r_context()->config, "/dev/sda0");
 	g_assert_nonnull(slot);
 
-	g_assert_true(r_boot_set_state(slot, TRUE));
-	g_assert_true(r_boot_set_state(slot, FALSE));
+	g_assert_true(r_boot_set_state(slot, TRUE, NULL));
+	g_assert_true(r_boot_set_state(slot, FALSE, NULL));
 
 	slot = find_config_slot_by_device(r_context()->config, "/dev/sda1");
 	g_assert_nonnull(slot);
 
-	g_assert_true(r_boot_set_primary(slot));
+	g_assert_true(r_boot_set_primary(slot, NULL));
 }
 
 int main(int argc, char *argv[])

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -113,6 +113,29 @@ bootstate.system1.remaining_attempts=3\n\
 bootstate.system1.priority=20\n\
 ", TRUE);
 	g_assert_true(r_boot_set_primary(slot));
+
+	/* check rootfs-1 is marked primary while current remains disabled (prio set to 20, others to 10) */
+	g_setenv ("BAREBOX_STATE_VARS_PRE", " \
+bootstate.system0.remaining_attempts=3\n\
+bootstate.system0.priority=0\n\
+bootstate.system1.remaining_attempts=0\n\
+bootstate.system1.priority=10\n\
+", TRUE);
+	g_setenv ("BAREBOX_STATE_VARS_POST", " \
+bootstate.system0.remaining_attempts=3\n\
+bootstate.system0.priority=0\n\
+bootstate.system1.remaining_attempts=3\n\
+bootstate.system1.priority=20\n\
+", TRUE);
+	/* ATM we expect this to fail as we do not read barebox-state prior to
+	 * writing it. */
+        g_test_expect_message (G_LOG_DOMAIN,
+                        G_LOG_LEVEL_WARNING,
+                        "setting state failed: Child process exited with code 2");
+        g_test_expect_message (G_LOG_DOMAIN,
+                        G_LOG_LEVEL_WARNING,
+                        "failed marking as primary");
+	g_assert_false(r_boot_set_primary(slot));
 }
 
 static void bootchooser_grub(BootchooserFixture *fixture,

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -40,10 +40,10 @@ mountprefix=/mnt/myrauc/\n\
 [keyring]\n\
 path=/etc/rauc/keyring/\n\
 \n\
-[slot.rescue.0]\n\
-device=/dev/mtd4\n\
+[slot.recovery.0]\n\
+device=/dev/recovery-0\n\
 type=raw\n\
-bootname=factory0\n\
+bootname=recovery\n\
 readonly=true\n\
 \n\
 [slot.rootfs.0]\n\

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -66,12 +66,52 @@ bootname=system1\n";
 	slot = find_config_slot_by_device(r_context()->config, "/dev/sda0");
 	g_assert_nonnull(slot);
 
+	/* check rootfs-0 is marked good (has remaining attempts reset 1->3) */
+	g_setenv ("BAREBOX_STATE_VARS_PRE", " \
+bootstate.system0.remaining_attempts=1\n\
+bootstate.system0.priority=20\n\
+bootstate.system1.remaining_attempts=3\n\
+bootstate.system1.priority=10\n\
+", TRUE);
+	g_setenv ("BAREBOX_STATE_VARS_POST", " \
+bootstate.system0.remaining_attempts=3\n\
+bootstate.system0.priority=20\n\
+bootstate.system1.remaining_attempts=3\n\
+bootstate.system1.priority=10\n\
+", TRUE);
 	g_assert_true(r_boot_set_state(slot, TRUE));
+
+	/* check rootfs-0 is marked bad (prio and attempts 0) */
+	g_setenv ("BAREBOX_STATE_VARS_PRE", " \
+bootstate.system0.remaining_attempts=3\n\
+bootstate.system0.priority=20\n\
+bootstate.system1.remaining_attempts=3\n\
+bootstate.system1.priority=10\n\
+", TRUE);
+	g_setenv ("BAREBOX_STATE_VARS_POST", " \
+bootstate.system0.remaining_attempts=0\n\
+bootstate.system0.priority=0\n\
+bootstate.system1.remaining_attempts=3\n\
+bootstate.system1.priority=10\n\
+", TRUE);
 	g_assert_true(r_boot_set_state(slot, FALSE));
 
 	slot = find_config_slot_by_device(r_context()->config, "/dev/sda1");
 	g_assert_nonnull(slot);
 
+	/* check rootfs-1 is marked primary (prio set to 20, others to 10) */
+	g_setenv ("BAREBOX_STATE_VARS_PRE", " \
+bootstate.system0.remaining_attempts=3\n\
+bootstate.system0.priority=20\n\
+bootstate.system1.remaining_attempts=3\n\
+bootstate.system1.priority=10\n\
+", TRUE);
+	g_setenv ("BAREBOX_STATE_VARS_POST", " \
+bootstate.system0.remaining_attempts=3\n\
+bootstate.system0.priority=10\n\
+bootstate.system1.remaining_attempts=3\n\
+bootstate.system1.priority=20\n\
+", TRUE);
 	g_assert_true(r_boot_set_primary(slot));
 }
 

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -127,15 +127,7 @@ bootstate.system0.priority=0\n\
 bootstate.system1.remaining_attempts=3\n\
 bootstate.system1.priority=20\n\
 ", TRUE);
-	/* ATM we expect this to fail as we do not read barebox-state prior to
-	 * writing it. */
-        g_test_expect_message (G_LOG_DOMAIN,
-                        G_LOG_LEVEL_WARNING,
-                        "setting state failed: Child process exited with code 2");
-        g_test_expect_message (G_LOG_DOMAIN,
-                        G_LOG_LEVEL_WARNING,
-                        "failed marking as primary");
-	g_assert_false(r_boot_set_primary(slot));
+	g_assert_true(r_boot_set_primary(slot));
 }
 
 static void bootchooser_grub(BootchooserFixture *fixture,

--- a/test/install-content/custom_handler.sh
+++ b/test/install-content/custom_handler.sh
@@ -24,6 +24,14 @@ done
 exit_if_empty $RAUC_MOUNT_PREFIX
 mkdir -p $RAUC_MOUNT_PREFIX/image
 
+# This is only for testing
+export BAREBOX_STATE_VARS_PRE="\
+bootstate.system0.priority=20 \
+bootstate.system0.remaining_attempts=3 \
+bootstate.system1.priority=10 \
+bootstate.system1.remaining_attempts=3 \
+"
+
 # deactivate current slot
 barebox-state -s bootstate.$RAUC_CURRENT_BOOTNAME.priority=0
 


### PR DESCRIPTION
This series targets different issues in Barebox bootchooser (boot selection layer) implementation.

The two main ones are:

* This is one of the components that still lacks appropriate GError handling, giving us only insufficient information about failures
* barebox-state backend did not properly handle disabled slots for setting slots as primary. This also additionally requires reading state info instead of only writing it
