### PR TITLE
Obtain and Display bootchooser status

### DIFF
--- a/include/bootchooser.h
+++ b/include/bootchooser.h
@@ -31,3 +31,24 @@ gboolean r_boot_set_state(RaucSlot *slot, gboolean good, GError **error);
  * @return TRUE if successful, FALSE if failed
  */
 gboolean r_boot_set_primary(RaucSlot *slot, GError **error);
+
+/**
+ * Get primary boot slot.
+ *
+ * @param error return location for a GError, or NULL
+ *
+ * @return Primary slot, NULL if detection failed
+ */
+RaucSlot* r_boot_get_primary(GError **error);
+
+/**
+ * Get bootloader state.
+ *
+ * @param slot Slot to get boot state from
+ * @param good return location for slot status.
+ *             TRUE means 'good', FALSE means 'bad')
+ * @param error return location for a GError, or NULL
+ *
+ * @return TRUE if successful, FALSE if failed
+ */
+gboolean r_boot_get_state(RaucSlot* slot, gboolean *good, GError **error);


### PR DESCRIPTION
A long-living inconsistency in RAUC is the behavior and purpose of `rauc status`.

While the sub-commands of `rauc status`, which are `mark-good`, `mark-bad` and `activate` all deal with changing the state of the underlying boot selection implementation, a call of `rauc status` does not provide any hints on the state of the bootloader.
Instead it only prints out the base system configuration with a few runtime info, such as mount points.

This series (based on #191 and #179) adds support for obtaining and displaying bootloader status as provided by the RAUC boot selection abstraction layer.
The information provided is:
* slot currently selected as primary (i.e. the one that will boot the next time)
* status of each slot (if they will potentially booted), referred to as 'good' or 'bad' at the moment