### PR TITLE
Add EFI bootchooser backend for x86

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,9 +55,11 @@ Features
   * `grub <https://www.gnu.org/software/grub/>`_
   * `barebox <http://barebox.org/>`_
   * `u-boot <http://www.denx.de/wiki/U-Boot>`_
+  * `EFI <https://de.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface>`_
 * Storage support:
 
   * ext2/3/4 filesystem
+  * vfat filesystem
   * UBI volumes
   * UBIFS
   * raw NAND (using nandwrite)
@@ -98,6 +100,7 @@ Target Requirements
   * GRUB: environment file on SD/eMMC/SSD/disk
   * Barebox: State partition on EEPROM/FRAM/MRAM or NAND flash
   * U-Boot: environment variable
+  * EFI: EFI variables
 * Boot target selection support in the bootloader
 * Enough mass storage for two symmetric/asymmetric/custom slots
 * For bundle mode:

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,7 @@ AC_SUBST(DBUS_SYSTEMSERVICEDIR)
 
 AC_CONFIG_LINKS([test/test.conf:test/test.conf])
 AC_CONFIG_LINKS([test/bin/postinstall.sh:test/bin/postinstall.sh])
+AC_CONFIG_LINKS([test/bin/efibootmgr:test/bin/efibootmgr])
 AC_CONFIG_LINKS([test/bin/fw_setenv:test/bin/fw_setenv])
 AC_CONFIG_LINKS([test/bin/fw_printenv:test/bin/fw_printenv])
 AC_CONFIG_LINKS([test/bin/grub-editenv:test/bin/grub-editenv])

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,16 +135,18 @@ Key Features of RAUC
 
     * Well integrated with `bootchooser <http://barebox.de/doc/latest/user/bootchooser.html?highlight=bootchooser>`_ framework
   * `u-boot <http://www.denx.de/wiki/U-Boot>`_
+  * `EFI <https://de.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface>`_
 
 * Storage support:
 
   * ext2/3/4 filesystem
+  * vfat filesystem
   * UBI volumes
   * UBIFS
   * raw NAND (using nandwrite)
   * squashfs
 
-* Independent from update source
+* Independent from update sources
 
   * **USB Stick**
   * Software provisioning server (e.g. **Hawkbit**)

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -59,7 +59,7 @@ gboolean is_slot_mountable(RaucSlot *slot) {
 	return FALSE;
 }
 
-static const gchar *supported_bootloaders[] = {"barebox", "grub", "uboot", "noop", NULL};
+static const gchar *supported_bootloaders[] = {"barebox", "grub", "uboot", "efi", "noop", NULL};
 
 gboolean load_config(const gchar *filename, RaucConfig **config, GError **error) {
 	GError *ierror = NULL;

--- a/test/bin/efibootmgr
+++ b/test/bin/efibootmgr
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Command line checking
+if [ $# -eq 0 ]; then
+	echo "\
+BootCurrent: 0002
+Timeout: 0 seconds
+BootOrder: 0001,0002,0003,0000
+Boot0000* invalid
+Boot0001* system0
+Boot0002* system1
+Boot0003  recovery"
+exit 0
+fi
+
+if [ "$1" = "--bootorder" ]; then
+	# Test code must move system1 to primary position. Assert this!
+	echo "--bootorder: $2"
+	#if [ "$2" != "0002,0001,0003,0000" ]; then
+	#	exit 1
+	#fi
+elif [ "$1" = "--bootnext" ]; then
+	# Test code must move system1 to primary position. Assert this!
+	echo "--bootnext: $2"
+	if [ "$2" != "0002" ]; then
+		exit 1
+	fi
+else
+	echo "Invalid key: '$1'"
+	exit 1
+fi
+
+exit 0

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -48,12 +48,12 @@ bootname=recovery\n\
 readonly=true\n\
 \n\
 [slot.rootfs.0]\n\
-device=/dev/sda0\n\
+device=/dev/rootfs-0\n\
 type=ext4\n\
 bootname=system0\n\
 \n\
 [slot.rootfs.1]\n\
-device=/dev/sda1\n\
+device=/dev/rootfs-1\n\
 type=ext4\n\
 bootname=system1\n";
 
@@ -64,7 +64,7 @@ bootname=system1\n";
 	r_context_conf()->configpath = pathname;
 	r_context();
 
-	slot = find_config_slot_by_device(r_context()->config, "/dev/sda0");
+	slot = find_config_slot_by_device(r_context()->config, "/dev/rootfs-0");
 	g_assert_nonnull(slot);
 
 	/* check rootfs is considered good */
@@ -131,7 +131,7 @@ bootstate.system1.priority=10\n\
 ", TRUE);
 	g_assert_true(r_boot_set_state(slot, FALSE, NULL));
 
-	slot = find_config_slot_by_device(r_context()->config, "/dev/sda1");
+	slot = find_config_slot_by_device(r_context()->config, "/dev/rootfs-1");
 	g_assert_nonnull(slot);
 
 	/* check rootfs-1 is marked primary (prio set to 20, others to 10) */
@@ -181,18 +181,18 @@ mountprefix=/mnt/myrauc/\n\
 path=/etc/rauc/keyring/\n\
 \n\
 [slot.rescue.0]\n\
-device=/dev/mtd4\n\
+device=/dev/rescue-0\n\
 type=raw\n\
 bootname=R\n\
 readonly=true\n\
 \n\
 [slot.rootfs.0]\n\
-device=/dev/sda0\n\
+device=/dev/rootfs-0\n\
 type=ext4\n\
 bootname=A\n\
 \n\
 [slot.rootfs.1]\n\
-device=/dev/sda1\n\
+device=/dev/rootfs-1\n\
 type=ext4\n\
 bootname=B\n";
 
@@ -203,13 +203,13 @@ bootname=B\n";
 	r_context_conf()->configpath = pathname;
 	r_context();
 
-	slot = find_config_slot_by_device(r_context()->config, "/dev/sda0");
+	slot = find_config_slot_by_device(r_context()->config, "/dev/rootfs-0");
 	g_assert_nonnull(slot);
 
 	g_assert_true(r_boot_set_state(slot, TRUE, NULL));
 	g_assert_true(r_boot_set_state(slot, FALSE, NULL));
 
-	slot = find_config_slot_by_device(r_context()->config, "/dev/sda1");
+	slot = find_config_slot_by_device(r_context()->config, "/dev/rootfs-1");
 	g_assert_nonnull(slot);
 
 	g_assert_true(r_boot_set_primary(slot, NULL));
@@ -236,12 +236,12 @@ bootname=R\n\
 readonly=true\n\
 \n\
 [slot.rootfs.0]\n\
-device=/dev/sda0\n\
+device=/dev/rootfs-0\n\
 type=ext4\n\
 bootname=A\n\
 \n\
 [slot.rootfs.1]\n\
-device=/dev/sda1\n\
+device=/dev/rootfs-1\n\
 type=ext4\n\
 bootname=B\n";
 
@@ -252,13 +252,13 @@ bootname=B\n";
 	r_context_conf()->configpath = pathname;
 	r_context();
 
-	slot = find_config_slot_by_device(r_context()->config, "/dev/sda0");
+	slot = find_config_slot_by_device(r_context()->config, "/dev/rootfs-0");
 	g_assert_nonnull(slot);
 
 	g_assert_true(r_boot_set_state(slot, TRUE, NULL));
 	g_assert_true(r_boot_set_state(slot, FALSE, NULL));
 
-	slot = find_config_slot_by_device(r_context()->config, "/dev/sda1");
+	slot = find_config_slot_by_device(r_context()->config, "/dev/rootfs-1");
 	g_assert_nonnull(slot);
 
 	g_assert_true(r_boot_set_primary(slot, NULL));

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -47,14 +47,14 @@ path=/etc/rauc/keyring/\n\
 \n\
 [slot.rescue.0]\n\
 description=Rescue partition\n\
-device=/dev/mtd4\n\
+device=/dev/rescue-0\n\
 type=raw\n\
 bootname=factory0\n\
 readonly=true\n\
 \n\
 [slot.rootfs.0]\n\
 description=Root filesystem partition 0\n\
-device=/dev/sda0\n\
+device=/dev/rootfs-0\n\
 type=ext4\n\
 bootname=system0\n\
 readonly=false\n\
@@ -62,7 +62,7 @@ ignore-checksum=false\n\
 \n\
 [slot.rootfs.1]\n\
 description=Root filesystem partition 1\n\
-device=/dev/sda1\n\
+device=/dev/rootfs-1\n\
 type=ext4\n\
 bootname=system1\n\
 readonly=false\n\
@@ -70,14 +70,14 @@ ignore-checksum=false\n\
 \n\
 [slot.appfs.0]\n\
 description=Application filesystem partition 0\n\
-device=/dev/sda2\n\
+device=/dev/appfs-0\n\
 type=ext4\n\
 parent=rootfs.0\n\
 ignore-checksum=true\n\
 \n\
 [slot.appfs.1]\n\
 description=Application filesystem partition 1\n\
-device=/dev/sda3\n\
+device=/dev/appfs-1\n\
 type=ext4\n\
 parent=rootfs.1\n\
 ignore-checksum=true\n";
@@ -98,57 +98,57 @@ ignore-checksum=true\n";
 	slot = g_hash_table_lookup(config->slots, "rescue.0");
 	g_assert_cmpstr(slot->name, ==, "rescue.0");
 	g_assert_cmpstr(slot->description, ==, "Rescue partition");
-	g_assert_cmpstr(slot->device, ==, "/dev/mtd4");
+	g_assert_cmpstr(slot->device, ==, "/dev/rescue-0");
 	g_assert_cmpstr(slot->bootname, ==, "factory0");
 	g_assert_cmpstr(slot->type, ==, "raw");
 	g_assert_true(slot->readonly);
 	g_assert_false(slot->ignore_checksum);
 	g_assert_null(slot->parent);
-	g_assert(find_config_slot_by_device(config, "/dev/mtd4") == slot);
+	g_assert(find_config_slot_by_device(config, "/dev/rescue-0") == slot);
 
 	slot = g_hash_table_lookup(config->slots, "rootfs.0");
 	g_assert_cmpstr(slot->name, ==, "rootfs.0");
 	g_assert_cmpstr(slot->description, ==, "Root filesystem partition 0");
-	g_assert_cmpstr(slot->device, ==, "/dev/sda0");
+	g_assert_cmpstr(slot->device, ==, "/dev/rootfs-0");
 	g_assert_cmpstr(slot->bootname, ==, "system0");
 	g_assert_cmpstr(slot->type, ==, "ext4");
 	g_assert_false(slot->readonly);
 	g_assert_false(slot->ignore_checksum);
 	g_assert_null(slot->parent);
-	g_assert(find_config_slot_by_device(config, "/dev/sda0") == slot);
+	g_assert(find_config_slot_by_device(config, "/dev/rootfs-0") == slot);
 
 	slot = g_hash_table_lookup(config->slots, "rootfs.1");
 	g_assert_cmpstr(slot->name, ==, "rootfs.1");
 	g_assert_cmpstr(slot->description, ==, "Root filesystem partition 1");
-	g_assert_cmpstr(slot->device, ==, "/dev/sda1");
+	g_assert_cmpstr(slot->device, ==, "/dev/rootfs-1");
 	g_assert_cmpstr(slot->bootname, ==, "system1");
 	g_assert_cmpstr(slot->type, ==, "ext4");
 	g_assert_false(slot->readonly);
 	g_assert_false(slot->ignore_checksum);
 	g_assert_null(slot->parent);
-	g_assert(find_config_slot_by_device(config, "/dev/sda1") == slot);
+	g_assert(find_config_slot_by_device(config, "/dev/rootfs-1") == slot);
 
 	slot = g_hash_table_lookup(config->slots, "appfs.0");
 	g_assert_cmpstr(slot->name, ==, "appfs.0");
 	g_assert_cmpstr(slot->description, ==, "Application filesystem partition 0");
-	g_assert_cmpstr(slot->device, ==, "/dev/sda2");
+	g_assert_cmpstr(slot->device, ==, "/dev/appfs-0");
 	g_assert_null(slot->bootname);
 	g_assert_cmpstr(slot->type, ==, "ext4");
 	g_assert_false(slot->readonly);
 	g_assert_true(slot->ignore_checksum);
 	g_assert_nonnull(slot->parent);
-	g_assert(find_config_slot_by_device(config, "/dev/sda2") == slot);
+	g_assert(find_config_slot_by_device(config, "/dev/appfs-0") == slot);
 
 	slot = g_hash_table_lookup(config->slots, "appfs.1");
 	g_assert_cmpstr(slot->name, ==, "appfs.1");
 	g_assert_cmpstr(slot->description, ==, "Application filesystem partition 1");
-	g_assert_cmpstr(slot->device, ==, "/dev/sda3");
+	g_assert_cmpstr(slot->device, ==, "/dev/appfs-1");
 	g_assert_null(slot->bootname);
 	g_assert_cmpstr(slot->type, ==, "ext4");
 	g_assert_false(slot->readonly);
 	g_assert_true(slot->ignore_checksum);
 	g_assert_nonnull(slot->parent);
-	g_assert(find_config_slot_by_device(config, "/dev/sda3") == slot);
+	g_assert(find_config_slot_by_device(config, "/dev/appfs-1") == slot);
 
 	g_assert_cmpuint(g_list_length(slotlist), ==, 5);
 

--- a/test/system.conf
+++ b/test/system.conf
@@ -9,28 +9,28 @@ mountprefix=/mnt/myrauc/
 path=/etc/rauc/keyring/
 
 [slot.rescue.0]
-device=/dev/mtd4
+device=/dev/rescue-0
 type=raw
 bootname=factory0
 readonly=true
 
 [slot.rootfs.0]
-device=/dev/sda0
+device=/dev/rootfs-0
 type=ext4
 bootname=system0
 
 [slot.rootfs.1]
-device=/dev/sda1
+device=/dev/rootfs-1
 type=ext4
 bootname=system1
 
 [slot.appfs.0]
-device=/dev/sda2
+device=/dev/appfs-0
 type=ext4
 parent=rootfs.0
 
 [slot.appfs.1]
-device=/dev/sda3
+device=/dev/appfs-1
 type=ext4
 parent=rootfs.1
 


### PR DESCRIPTION
This series adds support for handling EFI-based booting on x86 machines.

It calls and parses output of the `efibootmgr` tool to modify and read the EFI variables required for boot order modification.