### PR TITLE
docs/using: remove bogus 'Install Handler' rubric

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -216,20 +216,6 @@ target group has been determined successfully.
 If calling the handler fails or the handler returns a non-zero exit code, RAUC
 will abort installation with an error.
 
-.. rubric:: Install Handler
-
-.. code-block:: cfg
-
-  [handlers]
-  install=/usr/lib/rauc/install
-
-The install handler is the most powerful one RAUC provides. If you use
-this, you replace the entire default update procedure of RAUC. It will be
-executed between the pre-install and post-install handlers.
-
-If calling the handler fails or the handler returns a non-zero exit code, RAUC
-will abort installation with an error.
-
 .. rubric:: Post-Install Handler
 
 .. code-block:: cfg


### PR DESCRIPTION
There simply is no handler called 'install' defined. The description
refers to the full custom handler that can be specified in the bundle
manifest. Intentionally, there is no equivalent in system.conf

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>