### PR TITLE
src/config_file: do not unmount when mounting fails in save_slot_status()

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -487,7 +487,6 @@ gboolean save_slot_status(RaucSlot *dest_slot, RaucImage *mfimage, GError **erro
 	res = r_mount_slot(dest_slot, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
-		r_umount_slot(dest_slot, NULL);
 		goto free;
 	}
 


### PR DESCRIPTION
When we cannot mount, the should be no need for umounting. Furthermore,
if we call r_umount_slot() without having successfully passed
r_mount_slot() results in not having slot->mount_point set and makes
RAUC crash because of a sanity check on slot->mount_point being non-NULL
in r_umount_slot().

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>