### PR TITLE
Use GError messages now provided by bootchooser layer

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -788,11 +788,12 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 			continue;
 		}
 
-		res = r_boot_set_state(dest_slot, FALSE, NULL);
+		res = r_boot_set_state(dest_slot, FALSE, &ierror);
 
 		if (!res) {
 			g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_NONBOOTABLE,
-					"Failed marking slot %s non-bootable", dest_slot->name);
+					"Failed marking slot %s non-bootable: %s", dest_slot->name, ierror->message);
+			g_clear_error(&ierror);
 			goto early_out;
 		}
 	}
@@ -943,11 +944,12 @@ image_out:
 			if (dest_slot->parent || !dest_slot->bootname)
 				continue;
 
-			res = r_boot_set_primary(dest_slot, NULL);
+			res = r_boot_set_primary(dest_slot, &ierror);
 
 			if (!res) {
 				g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_BOOTABLE,
-						"Failed marking slot %s bootable", dest_slot->name);
+						"Failed marking slot %s bootable: %s", dest_slot->name, ierror->message);
+				g_clear_error(&ierror);
 				goto out;
 			}
 		}
@@ -1028,11 +1030,12 @@ static gboolean launch_and_wait_network_handler(const gchar* base_url,
 			break;
 		}
 
-		res = r_boot_set_state(slot, FALSE, NULL);
+		res = r_boot_set_state(slot, FALSE, &ierror);
 
 		if (!res) {
 			g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_NONBOOTABLE,
-					"Failed marking slot %s non-bootable", slot->name);
+					"Failed marking slot %s non-bootable: %s", slot->name, ierror->message);
+			g_clear_error(&ierror);
 			goto out;
 		}
 	}
@@ -1146,10 +1149,12 @@ slot_out:
 			if (slot->parent || !slot->bootname)
 				continue;
 
-			res = r_boot_set_primary(slot, NULL);
+			res = r_boot_set_primary(slot, &ierror);
 
 			if (!res) {
-				g_warning("Failed marking slot %s bootable", slot->name);
+				g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_BOOTABLE,
+						"Failed marking slot %s bootable: %s", slot->name, ierror->message);
+				g_clear_error(&ierror);
 				goto out;
 			}
 		}

--- a/src/mark.c
+++ b/src/mark.c
@@ -96,14 +96,14 @@ gboolean mark_run(const gchar *state,
 	}
 
 	if (!g_strcmp0(state, "good")) {
-		res = r_boot_set_state(slot, TRUE, NULL);
-		*message = g_strdup_printf((res) ? "marked slot %s as good" : "failed to mark slot %s as good", slot->name);
+		res = r_boot_set_state(slot, TRUE, &ierror);
+		*message = res ? g_strdup_printf("marked slot %s as good", slot->name) : g_strdup(ierror->message);
 	} else if (!g_strcmp0(state, "bad")) {
-		res = r_boot_set_state(slot, FALSE, NULL);
-		*message = g_strdup_printf((res) ? "marked slot %s as bad" : "failed to mark slot %s as bad", slot->name);
+		res = r_boot_set_state(slot, FALSE, &ierror);
+		*message = res ? g_strdup_printf("marked slot %s as bad", slot->name) : g_strdup(ierror->message);
 	} else if (!g_strcmp0(state, "active")) {
-		res = r_boot_set_primary(slot, NULL);
-		*message = g_strdup_printf((res) ? "activated slot %s" : "failed to activate slot %s", slot->name);
+		res = r_boot_set_primary(slot, &ierror);
+		*message = res ? g_strdup_printf("activated slot %s", slot->name) : g_strdup(ierror->message);
 	} else {
 		res = FALSE;
 		*message = g_strdup_printf("unknown subcommand %s", state);
@@ -112,6 +112,9 @@ gboolean mark_run(const gchar *state,
 out:
 	if (res && slot_name)
 		*slot_name = g_strdup(slot->name);
+
+	if (ierror)
+		g_clear_error(&ierror);
 
 	return res;
 }


### PR DESCRIPTION
Adds printout and returning of new error messages provided by the bootchooser layer to `rauc status mark-{good,bad,active}` and the normal installation process.