### PR TITLE
Support resolving device symlinks using `realpath()` for more flexible matching

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -108,6 +108,9 @@ gboolean determine_slot_states(GError **error) {
 	slotlist = g_hash_table_get_keys(r_context()->config->slots);
 
 	for (GList *l = slotlist; l != NULL; l = l->next) {
+		gchar buf[PATH_MAX + 1];
+		gchar *realdev = NULL;
+
 		RaucSlot *s = (RaucSlot*) g_hash_table_lookup(r_context()->config->slots, l->data);
 		if (!s->bootname) {
 			continue;
@@ -118,7 +121,13 @@ gboolean determine_slot_states(GError **error) {
 			break;
 		}
 
-		if (g_strcmp0(s->device, r_context()->bootslot) == 0) {
+		realdev = realpath(s->device, buf);
+		if (realdev == NULL) {
+			g_message("Failed to resolve realpath for '%s'", s->device);
+			realdev = s->device;
+		}
+
+		if (g_strcmp0(realdev, r_context()->bootslot) == 0) {
 			booted = s;
 			break;
 		}


### PR DESCRIPTION
Especially in cases where standard device paths (such as /dev/sdb) are
not persistent over reboots, one might need to use symlink pathes
generated by standard or custom udev rules. A good example for this are
the /dev/disk-by-* symlinked device paths.

As RAUC uses the device path to string-compare against the `root=`
kernel command line argument it will not match against a system config
slot entry with a symlink device path such as

    [slot.rootfs.0]
    device=/dev/disk/by-path/pci-0000:00:17.0-ata-1-part1
    ...

This patch resolves this by calling `realpath()` to always get the
canonicalized absolute pathname of the `device` parameter when comparing
against boot slot device name as provided by root= kernel command line.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>