### PR TITLE
Rework manifest verification handling

### DIFF
--- a/include/manifest.h
+++ b/include/manifest.h
@@ -122,14 +122,11 @@ gboolean update_manifest(const gchar *dir, gboolean signature, GError **error);
  * @param output Returns newly allocated manifest if RaucManifest pointerpointer
  *        is provided.
  *        If output is NULL, manifest will be freed an nothing returned.
- * @param signature If true, manifest ist validated using the provided signature
- *        file.
- *        If false, no further signature validation is performed.
  * @param error return location for a GError, or NULL
  *
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean verify_manifest(const gchar *dir, RaucManifest **output, gboolean signature, GError **error);
+gboolean verify_manifest(const gchar *dir, RaucManifest **output, GError **error);
 
 /**
  * Frees a rauc image

--- a/src/install.c
+++ b/src/install.c
@@ -1231,7 +1231,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error) {
 
 	r_context()->install_info->mounted_bundle = bundle;
 
-	res = verify_manifest(bundle->mount_point, &manifest, FALSE, &ierror);
+	res = verify_manifest(bundle->mount_point, &manifest, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -659,22 +659,6 @@ out:
 	return res;
 }
 
-static gboolean check_compatible(RaucManifest *manifest, GError **error) {
-	gboolean res = FALSE;
-	g_assert_nonnull(r_context()->config);
-	g_assert_nonnull(r_context()->config->system_compatible);
-
-	res = (g_strcmp0(r_context()->config->system_compatible, manifest->update_compatible) == 0);
-	if (!res) {
-		g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_ERROR_COMPATIBLE,
-				"'%s' (mf) does not match '%s' (sys)",
-				manifest->update_compatible,
-				r_context()->config->system_compatible);
-	}
-
-	return res;
-}
-
 gboolean verify_manifest(const gchar *dir, RaucManifest **output, gboolean signature, GError **error) {
 	GError *ierror = NULL;
 	gchar* manifestpath = g_build_filename(dir, "manifest.raucm", NULL);
@@ -704,12 +688,6 @@ gboolean verify_manifest(const gchar *dir, RaucManifest **output, gboolean signa
 	res = load_manifest_file(manifestpath, &manifest, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(error, ierror, "Failed opening manifest: ");
-		goto out;
-	}
-
-	res = check_compatible(manifest, &ierror);
-	if (!res) {
-		g_propagate_prefixed_error(error, ierror, "Invalid compatible: ");
 		goto out;
 	}
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -659,7 +659,7 @@ out:
 	return res;
 }
 
-gboolean verify_manifest(const gchar *dir, RaucManifest **output, gboolean signature, GError **error) {
+gboolean verify_manifest(const gchar *dir, RaucManifest **output, GError **error) {
 	GError *ierror = NULL;
 	gchar* manifestpath = g_build_filename(dir, "manifest.raucm", NULL);
 	gchar* signaturepath = g_build_filename(dir, "manifest.raucm.sig", NULL);
@@ -667,23 +667,7 @@ gboolean verify_manifest(const gchar *dir, RaucManifest **output, gboolean signa
 	GBytes *sig = NULL;
 	gboolean res = FALSE;
 
-	r_context_begin_step("verify_manifest", "Verifying manifest",
-			     2 + signature);
-
-	if (signature) {
-		sig = read_file(signaturepath, &ierror);
-		if (sig == NULL) {
-			g_propagate_error(error, ierror);
-			goto out;
-		}
-
-		res = cms_verify_file(manifestpath, sig, 0, NULL, NULL, &ierror);
-		if (!res) {
-			g_propagate_error(error, ierror);
-			goto out;
-		}
-
-	}
+	r_context_begin_step("verify_manifest", "Verifying manifest", 2);
 
 	res = load_manifest_file(manifestpath, &manifest, &ierror);
 	if (!res) {

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -101,7 +101,7 @@ static void bundle_test_create_extract(BundleFixture *fixture,
 	g_assert_nonnull(bundle);
 
 	g_assert_true(extract_bundle(bundle, outputdir, NULL));
-	g_assert_true(verify_manifest(outputdir, NULL, FALSE, NULL));
+	g_assert_true(verify_manifest(outputdir, NULL, NULL));
 
 	free_bundle(bundle);
 }
@@ -126,7 +126,7 @@ static void bundle_test_create_mount_extract(BundleFixture *fixture,
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
-	res = verify_manifest(bundle->mount_point, NULL, FALSE, &ierror);
+	res = verify_manifest(bundle->mount_point, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -392,8 +392,7 @@ static void manifest_test_verify(ManifestFixture *fixture,
 	g_assert_nonnull(appfsimage);
 
 	g_assert_true(update_manifest(fixture->contentdir, TRUE, NULL));
-	g_assert_true(verify_manifest(fixture->contentdir, NULL, FALSE, NULL));
-	g_assert_true(verify_manifest(fixture->contentdir, NULL, TRUE, NULL));
+	g_assert_true(verify_manifest(fixture->contentdir, NULL, NULL));
 
 	/* Test with invalid checksum */
 	g_assert(test_prepare_dummy_file(fixture->tmpdir, "content/appfs.ext4",
@@ -401,12 +400,7 @@ static void manifest_test_verify(ManifestFixture *fixture,
 	g_test_expect_message (G_LOG_DOMAIN,
 			G_LOG_LEVEL_WARNING,
 			"Failed verifying checksum: Digests do not match");
-	g_assert_false(verify_manifest(fixture->contentdir, NULL, FALSE, NULL));
-
-	g_test_expect_message (G_LOG_DOMAIN,
-			G_LOG_LEVEL_WARNING,
-			"Failed verifying checksum: Digests do not match");
-	g_assert_false(verify_manifest(fixture->contentdir, NULL, TRUE, NULL));
+	g_assert_false(verify_manifest(fixture->contentdir, NULL, NULL));
 
 	/* Test with non-existing image */
 	g_assert_cmpint(g_unlink(appfsimage), ==, 0);
@@ -414,11 +408,7 @@ static void manifest_test_verify(ManifestFixture *fixture,
 	g_test_expect_message (G_LOG_DOMAIN,
 			G_LOG_LEVEL_WARNING,
 			"Failed verifying checksum: Failed to open file * No such file or directory");
-	g_assert_false(verify_manifest(fixture->contentdir, NULL, FALSE, NULL));
-	g_test_expect_message (G_LOG_DOMAIN,
-			G_LOG_LEVEL_WARNING,
-			"Failed verifying checksum: Failed to open file * No such file or directory");
-	g_assert_false(verify_manifest(fixture->contentdir, NULL, TRUE, NULL));
+	g_assert_false(verify_manifest(fixture->contentdir, NULL, NULL));
 	g_test_assert_expected_messages();
 
 	g_free(appfsimage);

--- a/test/service.c
+++ b/test/service.c
@@ -149,12 +149,8 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  20, "Verifying signature", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Verifying signature done.", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Checking bundle done.", 2));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Verifying manifest", 2));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Loading manifest file", 3));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  50, "Loading manifest file done.", 3));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  50, "Verifying manifest checksums", 3));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  60, "Verifying manifest checksums done.", 3));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  60, "Verifying manifest done.", 2));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Loading manifest file", 2));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  60, "Loading manifest file done.", 2));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  60, "Determining target install group", 2));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  80, "Determining target install group done.", 2));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  80, "Updating slots", 2));


### PR DESCRIPTION
Step by step this removes the code from `verify_manifest()` by either moving or simply dropping it.

While doing this, some drawbacks and issues of the current handling are resolved while preparing code for cool new features.