### PR TITLE
Introduce casync support

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -291,6 +291,11 @@ are listed below:
 RAUC casync Support
 -------------------
 
+.. warning:: casync support is still experimental and lacks some unit tests.
+
+  When evaluating, make sure to compile a recent casync version from the
+  `git <https://github.com/systemd/casync>`_ for testing.
+
 Using the Content-Addressable Data Synchronization tool `casync` for updating
 embedded / IoT devices provides a couple of benefits.
 By splitting and chunking the update artifacts into reusable pieces, casync

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -85,7 +85,8 @@ verification.
 **[casync] section**
 
 The ``casync`` section contains casync-related settings.
-For more information about using casync support of RAUC, refer to `todo`_.
+For more information about using casync support of RAUC, refer to
+:ref:`casync-support`.
 
 ``storepath``
   Allows to set the path to use as chunk store path for casync to a fixed one.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -82,6 +82,18 @@ verification.
   Path to the keyring file in PEM format. Either absolute or relative to the
   system.conf file.
 
+**[casync] section**
+
+The ``casync`` section contains casync-related settings.
+For more information about using casync support of RAUC, refer to `todo`_.
+
+``storepath``
+  Allows to set the path to use as chunk store path for casync to a fixed one.
+  This is useful if your chunk store is on a dedicated server and will be the
+  same pool for each update you perform.
+  By default, the chunk store path is derived from the location of the RAUC
+  bundle you install.
+
 **[autoinstall] section**
 
 The auto-install feature allows to configure a path that will be checked upon

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -14,6 +14,7 @@ typedef enum {
 typedef struct {
 	gchar *path;
 	gchar *origpath;
+	gchar *storepath;
 	gsize size;
 	gchar *mount_point;
 	STACK_OF(X509) *verified_chain;

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -13,6 +13,7 @@ typedef enum {
 
 typedef struct {
 	gchar *path;
+	gchar *origpath;
 	gsize size;
 	gchar *mount_point;
 	STACK_OF(X509) *verified_chain;

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -98,6 +98,15 @@ gboolean extract_bundle(RaucBundle *bundle, const gchar *outputdir, GError **err
 gboolean extract_file_from_bundle(RaucBundle *bundle, const gchar *outputdir, const gchar *file, GError **error);
 
 /**
+ * Create casync bundle.
+ *
+ * @param bundle RaucBundle struct as returned by check_bundle()
+ * @param outbundle output location for converted casync bundle
+ * @param error Return location for a GError
+ */
+gboolean create_casync_bundle(RaucBundle *bundle, const gchar *outbundle, GError **error);
+
+/**
  * Mount a bundle.
  *
  * Note that check_bundle() must be called prior to this, to obtain a

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -29,6 +29,7 @@ typedef struct {
 	gchar *system_bootloader;
 	/* path prefix where rauc may create mount directories */
 	gchar *mount_prefix;
+	gchar *store_path;
 	gchar *grubenv_path;
 	gboolean activate_installed;
 	gchar *keyring_path;

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -568,6 +568,21 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, gboolean ver
 		ibundle->path = g_strdup(bundlename);
 	}
 
+	/* Determine store path for casync, defaults to bundle */
+	if (r_context()->config->store_path) {
+		ibundle->storepath = r_context()->config->store_path;
+	} else {
+		gchar *strprfx;
+
+		if (ibundle->origpath)
+			strprfx = g_strndup(ibundle->origpath, strlen(ibundle->origpath) - 6);
+		else
+			strprfx = g_strndup(ibundle->path, strlen(ibundle->path) - 6);
+		ibundle->storepath = g_strconcat(strprfx, ".castr", NULL);
+
+		g_free(strprfx);
+	}
+
 	if (verify && !r_context()->config->keyring_path) {
 		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_KEYRING, "No keyring file provided");
 		res = FALSE;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -215,6 +215,9 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	c->keyring_path = resolve_path(filename,
 		g_key_file_get_string(key_file, "keyring", "path", NULL));
 
+	/* parse [casync] section */
+	c->store_path = g_key_file_get_string(key_file, "casync", "storepath", NULL);
+
 	/* parse [autoinstall] section */
 	c->autoinstall_path = resolve_path(filename,
 		g_key_file_get_string(key_file, "autoinstall", "path", NULL));
@@ -384,6 +387,7 @@ void free_config(RaucConfig *config) {
 	g_free(config->system_compatible);
 	g_free(config->system_bootloader);
 	g_free(config->mount_prefix);
+	g_free(config->store_path);
 	g_free(config->grubenv_path);
 	g_free(config->keyring_path);
 	g_free(config->autoinstall_path);

--- a/src/install.c
+++ b/src/install.c
@@ -848,11 +848,13 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 			goto out;
 		}
 
-		/* Verify image checksum */
-		res = verify_checksum(&mfimage->checksum, mfimage->filename, &ierror);
-		if (!res) {
-			g_propagate_prefixed_error(error, ierror, "Failed verifying checksum: ");
-			goto out;
+		/* Verify image checksum (for non-casync images) */
+		if (!g_str_has_suffix(mfimage->filename, ".caibx") && !g_str_has_suffix(mfimage->filename, ".caidx")) {
+			res = verify_checksum(&mfimage->checksum, mfimage->filename, &ierror);
+			if (!res) {
+				g_propagate_prefixed_error(error, ierror, "Failed verifying checksum: ");
+				goto out;
+			}
 		}
 
 		/* determine whether update image type is compatible with destination slot type */

--- a/src/main.c
+++ b/src/main.c
@@ -356,6 +356,59 @@ out:
 	return TRUE;
 }
 
+static gboolean convert_start(int argc, char **argv)
+{
+	RaucBundle *bundle = NULL;
+	GError *ierror = NULL;
+	g_debug("convert start");
+
+	if (r_context()->certpath == NULL ||
+	    r_context()->keypath == NULL) {
+		g_printerr("Cert and key files must be provided\n");
+		r_exit_status = 1;
+		goto out;
+	}
+
+	if (argc < 3) {
+		g_printerr("An input bundle must be provided\n");
+		r_exit_status = 1;
+		goto out;
+	}
+
+	if (argc < 4) {
+		g_printerr("An output bundle name must be provided\n");
+		r_exit_status = 1;
+		goto out;
+	}
+
+	if (argc > 4) {
+		g_printerr("Excess argument: %s\n", argv[4]);
+		goto out;
+	}
+
+	g_debug("input bundle: %s", argv[2]);
+	g_debug("output bundle: %s", argv[3]);
+
+	if (!check_bundle(argv[2], &bundle, TRUE, &ierror)) {
+		g_printerr("%s\n", ierror->message);
+		g_clear_error(&ierror);
+		r_exit_status = 1;
+		goto out;
+	}
+
+	if (!create_casync_bundle(bundle, argv[3], &ierror)) {
+		g_printerr("Failed to create bundle: %s\n", ierror->message);
+		g_clear_error(&ierror);
+		r_exit_status = 1;
+		goto out;
+	}
+
+	g_print("Bundle written to %s\n", argv[3]);
+
+out:
+	return TRUE;
+}
+
 static gboolean checksum_start(int argc, char **argv)
 {
 	GError *error = NULL;
@@ -1106,6 +1159,7 @@ typedef enum  {
 	BUNDLE,
 	RESIGN,
 	EXTRACT,
+	CONVERT,
 	CHECKSUM,
 	STATUS,
 	INFO,
@@ -1173,6 +1227,7 @@ static void cmdline_handler(int argc, char **argv)
 		{BUNDLE, "bundle", "bundle <INPUTDIR> <BUNDLENAME>", "Create a bundle from a content directory", bundle_start, NULL, FALSE},
 		{RESIGN, "resign", "resign <BUNDLENAME>", "Resign an already signed bundle", resign_start, NULL, FALSE},
 		{EXTRACT, "extract", "extract <BUNDLENAME> <OUTPUTDIR>", "Extract the bundle content", extract_start, NULL, FALSE},
+		{CONVERT, "convert", "convert <INBUNDLE> <OUTBUNDLE>", "Convert to casync index bundle and store", convert_start, NULL, FALSE},
 		{CHECKSUM, "checksum", "checksum <DIRECTORY>", "Deprecated", checksum_start, NULL, FALSE},
 		{INFO, "info", "info <FILE>", "Print bundle info", info_start, info_group, FALSE},
 		{STATUS, "status", "status", "Show system status", status_start, status_group, TRUE},
@@ -1197,6 +1252,7 @@ static void cmdline_handler(int argc, char **argv)
 			"  bundle\tCreate a bundle\n" \
 			"  resign\tResign an already signed bundle\n" \
 			"  extract\tExtract the bundle content\n" \
+			"  convert\tConvert classic to casync bundle\n" \
 			"  checksum\tUpdate a manifest with checksums (and optionally sign it)\n" \
 			"  install\tInstall a bundle\n" \
 			"  info\t\tShow file information\n" \

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -531,6 +531,8 @@ static gboolean unpack_archive(RaucImage *image, gchar *dest, GError **error)
 {
 	if (g_str_has_suffix(image->filename, ".caidx" ))
 		return casync_extract_image(image, dest, error);
+	else if (g_str_has_suffix(image->filename, ".catar" ))
+		return casync_extract_image(image, dest, error);
 	else
 		return untar_image(image, dest, error);
 }
@@ -1104,6 +1106,7 @@ RaucUpdatePair updatepairs[] = {
 	{"*.ext4", "raw", img_to_raw_handler},
 	{"*.vfat", "raw", img_to_raw_handler},
 	{"*.tar*", "ext4", archive_to_ext4_handler},
+	{"*.catar", "ext4", archive_to_ext4_handler},
 	{"*.tar*", "ubifs", archive_to_ubifs_handler},
 	{"*.tar*", "vfat", archive_to_vfat_handler},
 	{"*.ubifs", "ubivol", img_to_ubivol_handler},

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -108,7 +108,7 @@ out:
 	return res;
 }
 
-static gboolean casync_extract(RaucImage *image, gchar *dest, gchar *seed, GError **error)
+static gboolean casync_extract(RaucImage *image, gchar *dest, const gchar *seed, const gchar *store, GError **error)
 {
 	GSubprocess *sproc = NULL;
 	GError *ierror = NULL;
@@ -120,6 +120,10 @@ static gboolean casync_extract(RaucImage *image, gchar *dest, gchar *seed, GErro
 	if (seed) {
 		g_ptr_array_add(args, g_strdup("--seed"));
 		g_ptr_array_add(args, g_strdup(seed));
+	}
+	if (store) {
+		g_ptr_array_add(args, g_strdup("--store"));
+		g_ptr_array_add(args, g_strdup(store));
 	}
 	g_ptr_array_add(args, g_strdup("--seed-output=no"));
 	g_ptr_array_add(args, g_strdup(image->filename));
@@ -176,6 +180,7 @@ static gboolean casync_extract_image(RaucImage *image, gchar *dest, GError **err
 	gboolean res = FALSE;
 	RaucSlot *seedslot = NULL;
 	gchar *seed = NULL;
+	gchar *store = NULL;
 
 	/* Prepare Seed */
 	seedslot = get_active_slot_class_member(image->slotclass);
@@ -187,9 +192,12 @@ static gboolean casync_extract_image(RaucImage *image, gchar *dest, GError **err
 	g_debug("Adding as casync blob seed: %s", seedslot->device);
 	seed = g_strdup(seedslot->device);
 
+	store = r_context()->install_info->mounted_bundle->storepath;
+	g_debug("Using store path: '%s'", store);
+
 extract:
 	/* Call casync to extract */
-	res = casync_extract(image, dest, seed, &ierror);
+	res = casync_extract(image, dest, seed, store, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;


### PR DESCRIPTION
This series of patches adds support for using the [casync](https://github.com/systemd/casync) tool for image and archive installation.

By using casync, way we gain a couple of cool new capabilities:

 * Direct streaming of Updates from remote servers (without intermediate download of images)
 * Binary Delta-like Updating to reduce network load (e.g. for constrained links)
 * Simpilified and storage friendly artifact pooling on deployment server side
 * CDN friendly chunk fetching

Creating a casync-supporting bundle is a two-step process:

1. Create your conventional RAUC bundle
2. Convert it

       rauc convert old-bundle-raucb casync-bundle.raucb

This will create a `casync-bundle.raucb` bundle file (only containing index files instead of real images)  and a separate casync chunk store `casync-bundle-castr/`.

Place these two on a web server or start one (such as `python3 -m http.server`) in the directory you extracted them to.

Then you can install it remotely on your target device by running

    rauc install http://192.168.0.1:8000/casync-bundle.raucb

This will install the images described by the index files placed in the bundle with using appropriate slots as seeds on target side and only fetching chunks remotely that cannot be obtained from the target itself.

Note that you have to have casync compiled an in your path, both on target as well as on host side!

PR is based on PR's #214 and #215