### PR TITLE
src/bootchooser: support re-sorted EFI boot entries in efi_get_primary()

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -995,33 +995,26 @@ static RaucSlot *efi_get_primary(GError **error) {
 		goto out;
 	}
 
-	/* We only need to look further if bootnext is not set */
+	/* We prepend the content of BootNext if set */
 	if (bootnext) {
-		g_debug("Skip scanning for primary as Bootnext is set to %s", bootnext->name);
-		goto get_slot;
+		g_debug("Detected BootNext set to %s", bootnext->name);
+		bootorder_entries = g_list_prepend(bootorder_entries, bootnext);
 	}
 
-	if (g_list_first(bootorder_entries) == NULL) {
-		g_set_error_literal(
-				error,
-				R_BOOTCHOOSER_ERROR,
-				R_BOOTCHOOSER_ERROR_PARSE_FAILED,
-				"Unable to obtain primary element");
-		res = FALSE;
-		goto out;
-	}
+	for (GList *entry = bootorder_entries; entry != NULL; entry = entry->next) {
+		efi_bootentry *bootentry = entry->data;
 
-	bootnext = g_list_nth_data(bootorder_entries, 0);
-
-get_slot:
-
-	/* find matching slot entry */
-	g_hash_table_iter_init(&iter, r_context()->config->slots);
-	while (g_hash_table_iter_next(&iter, NULL, (gpointer *)&slot)) {
-		if (g_strcmp0(bootnext->name, slot->bootname) == 0) {
-			primary = slot;
-			break;
+		/* find matching slot entry */
+		g_hash_table_iter_init(&iter, r_context()->config->slots);
+		while (g_hash_table_iter_next(&iter, NULL, (gpointer *)&slot)) {
+			if (g_strcmp0(bootentry->name, slot->bootname) == 0) {
+				primary = slot;
+				break;
+			}
 		}
+
+		if (primary)
+			break;
 	}
 
 	if (!primary) {


### PR DESCRIPTION
Some EFI implementations might choose to have a default EFI boot entry
always placed on first position in order to execute it first and then
continue selecting the next boot target to boot the actual system.

In this case, the simple approach on looking at the first element in
EFI BootOrder for finding the primary slot will not work.
Also having BootNext set must not necessarily mean that this will match
one of the bootnames handeled by RAUC.

A more generic approach for this would be to scan the entire BootOrder
list until finding the first element we know as a bootname for any of
our slots configured and consider this to be the primary one.

The patch changes the efi_get_primary() method to gain this behavior.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>