### PR TITLE
Makefile.am: do not package data/rauc-service.sh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,7 +90,7 @@ dbuspolicydir = $(DBUS_POLICYDIR)
 dist_dbuspolicy_DATA = data/de.pengutronix.rauc.conf
 
 dbuswrapperdir = $(libexecdir)
-dist_dbuswrapper_SCRIPTS = data/rauc-service.sh
+nodist_dbuswrapper_SCRIPTS = data/rauc-service.sh
 
 EXTRA_DIST += data/rauc.service.in \
 	      data/de.pengutronix.rauc.service.in \
@@ -210,7 +210,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = "--without-systemdunitdir"
 CLEANFILES = $(gdbus_installer_generated) \
 	     $(nodist_systemdunit_DATA) \
 	     $(nodist_dbussystem_DATA) \
-	     $(dist_dbuswrapper_SCRIPTS) \
+	     $(nodist_dbuswrapper_SCRIPTS) \
 	     data/rauc.service \
 	     test/empty.dat \
 	     test/test-results/rauc.*.counts \


### PR DESCRIPTION
Packaging the dbus wrapper script renders the corresponding .in file useless.
@bindir@ is ignored making the systemd service fail if the rauc binary
location differs from the packaging host.

e119229 ("Makefile.am: do not package data/*.service") fixed this for
all .in files in data until then. This bug was introduced later on.

Fixes: dcd184d ("dbus: use wrapper when starting rauc service")
Signed-off-by: Bastian Stender <bst@pengutronix.de>