### PR TITLE
Add sub command 'write-slot'

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -368,6 +368,19 @@ RAUC will report an error if for example a booloader image is only present for
 variant A when you try to install on variant B.
 This should prevent from bricking your device by unintentional partial updates.
 
+Manually Writing Images to Slots
+--------------------------------
+
+In order to write an image to a slot without using update mechanics like hooks,
+slot status etc. use:
+
+.. code-block:: sh
+
+  rauc write-slot <slotname> <image>
+
+This uses the correct handler to write the image to the slot. It is useful for
+development scenarios as well as initial provisioning of embedded boards.
+
 Updating the Bootloader
 -----------------------
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -202,6 +202,17 @@ on the next boot. By configuring the kernel and systemd to reboot on
 critical errors and by using a (software) watchdog, hangs in a non-working
 installation can be avoided.
 
+Write Slots Without Update Mechanics
+------------------------------------
+
+Assuming an image has been copied to or exists on the target, a manual slot
+write can be performed by::
+
+  > rauc write-slot rootfs.0 rootfs.ext4
+
+This will write the rootfs image ``rootfs.ext4`` to the slot ``rootfs.0``. Note
+that this bypasses all update mechanics like hooks, slot status etc.
+
 Example BSPs
 ------------
 * Yocto

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -76,6 +76,7 @@ test_expect_success "rauc invalid cmd" "
 
 test_expect_success "rauc missing arg" "
   test_must_fail rauc install &&
+  test_must_fail rauc write-slot &&
   test_must_fail rauc info &&
   test_must_fail rauc bundle &&
   test_must_fail rauc checksum &&
@@ -224,6 +225,18 @@ test_expect_success "rauc install invalid local paths" "
   test_must_fail rauc install foo &&
   test_must_fail rauc install foo.raucb &&
   test_must_fail rauc install /path/to/foo.raucb
+"
+
+test_expect_success "rauc write-slot invalid local paths" "
+  test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test.conf write-slot system0 foo &&
+  test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test.conf write-slot system0 foo.raucb &&
+  test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test.conf write-slot system0 /path/to/foo.raucb
+"
+
+test_expect_success "rauc write-slot invalid slot" "
+  test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test.conf write-slot system0 foo &&
+  test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test.conf write-slot system0 foo.img &&
+  test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test.conf write-slot system0 /path/to/foo.img
 "
 
 test_done


### PR DESCRIPTION
If called with a slot name and image the image is written to the device
corresponding to the slot. This is useful for development purposes and
initial board provisioning.

Signed-off-by: Bastian Stender <bst@pengutronix.de>