### PR TITLE
src: replace RaucSlot mount_internal by ext_mount_point

### DIFF
--- a/include/config_file.h
+++ b/include/config_file.h
@@ -81,7 +81,7 @@ typedef struct _RaucSlot {
 	SlotState state;
 	struct _RaucSlot *parent;
 	gchar *mount_point;
-	gboolean mount_internal;
+	gchar *ext_mount_point;
 } RaucSlot;
 
 typedef struct {

--- a/src/install.c
+++ b/src/install.c
@@ -89,8 +89,8 @@ gboolean determine_slot_states(GError **error) {
 		RaucSlot *s = find_config_slot_by_device(r_context()->config,
 				devicepath);
 		if (s) {
-			s->mount_point = g_strdup(g_unix_mount_get_mount_path(m));
-			g_debug("Found mountpoint for slot %s at %s", s->name, s->mount_point);
+			s->ext_mount_point = g_strdup(g_unix_mount_get_mount_path(m));
+			g_debug("Found external mountpoint for slot %s at %s", s->name, s->ext_mount_point);
 		}
 		g_free(devicepath);
 	}
@@ -841,7 +841,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 			goto out;
 		}
 
-		if (dest_slot->mount_point) {
+		if (dest_slot->mount_point || dest_slot->ext_mount_point) {
 			res = FALSE;
 			g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MOUNTED,
 					"Destination device '%s' already mounted", dest_slot->device);
@@ -878,7 +878,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 
 				/* In case we failed unmounting while reading status
 				 * file, abort here */
-				if (dest_slot->mount_internal) {
+				if (dest_slot->mount_point) {
 					res = FALSE;
 					g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MOUNTED,
 							"Slot '%s' still mounted", dest_slot->device);

--- a/src/mount.c
+++ b/src/mount.c
@@ -138,7 +138,6 @@ gboolean r_mount_slot(RaucSlot *slot, GError **error) {
 
 	g_assert_nonnull(slot);
 	g_assert_null(slot->mount_point);
-	g_assert_false(slot->mount_internal);
 
 	if (!g_file_test(slot->device, G_FILE_TEST_EXISTS)) {
 		g_set_error(
@@ -173,7 +172,6 @@ gboolean r_mount_slot(RaucSlot *slot, GError **error) {
 	}
 
 	slot->mount_point = mount_point;
-	slot->mount_internal = TRUE;
 
 out:
 	return res;
@@ -185,7 +183,6 @@ gboolean r_umount_slot(RaucSlot *slot, GError **error) {
 
 	g_assert_nonnull(slot);
 	g_assert_nonnull(slot->mount_point);
-	g_assert_true(slot->mount_internal);
 
 	res = r_umount(slot->mount_point, &ierror);
 	if (!res) {
@@ -199,7 +196,6 @@ gboolean r_umount_slot(RaucSlot *slot, GError **error) {
 
 	g_rmdir(slot->mount_point);
 	g_clear_pointer(&slot->mount_point, g_free);
-	slot->mount_internal = FALSE;
 
 out:
 	return res;


### PR DESCRIPTION
This makes mount handling more explicit and also allows to (bind) mount
slots that are already mounted which will be required by further RAUC
features.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>