### PR TITLE
Dbus getslotstatus entries

### DIFF
--- a/include/config_file.h
+++ b/include/config_file.h
@@ -211,3 +211,12 @@ void r_free_slot(gpointer value);
  * @return TRUE if mountable, otherwise FALSE
  */
 gboolean is_slot_mountable(RaucSlot *slot);
+
+/**
+ * Get string representation of slot state
+ *
+ * @param slotstate state to turn into string
+ *
+ * @return string representation of slot state
+ */
+gchar* slotstate_to_str(SlotState slotstate);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -751,3 +751,27 @@ void free_slot_status(RaucSlotStatus *slotstatus) {
 	g_free(slotstatus->activated_timestamp);
 	g_free(slotstatus);
 }
+
+/* returns string representation of slot state */
+gchar* slotstate_to_str(SlotState slotstate)
+{
+	gchar *state = NULL;
+
+	switch (slotstate) {
+	case ST_ACTIVE:
+		state = g_strdup("active");
+		break;
+	case ST_INACTIVE:
+		state = g_strdup("inactive");
+		break;
+	case ST_BOOTED:
+		state = g_strdup("booted");
+		break;
+	case ST_UNKNOWN:
+	default:
+		g_error("invalid slot status %d", slotstate);
+		break;
+	}
+
+	return state;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -883,31 +883,6 @@ out:
 	return TRUE;
 }
 
-/* returns string representation of slot state */
-static gchar* slotstate_to_str(SlotState slotstate)
-{
-	gchar *state = NULL;
-
-	switch (slotstate) {
-	case ST_ACTIVE:
-		state = g_strdup("active");
-		break;
-	case ST_INACTIVE:
-		state = g_strdup("inactive");
-		break;
-	case ST_BOOTED:
-		state = g_strdup("booted");
-		break;
-	case ST_UNKNOWN:
-	default:
-		g_error("invalid slot status %d", slotstate);
-		break;
-	}
-
-	return state;
-}
-
-
 static gchar* r_status_formatter_readable(void)
 {
 	GHashTableIter iter;


### PR DESCRIPTION
I want to get the output from "rauc status" also vie dbus.
GetSlotStatus sends only the "detailed" status information in terms of "rauc status --detailed"

Is this the right place for this information or should it go to an own method?