### PR TITLE
src/update_handler: support vfat to vfat

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1105,6 +1105,7 @@ RaucUpdatePair updatepairs[] = {
 	{"*.ext4", "ext4", img_to_fs_handler},
 	{"*.ext4", "raw", img_to_raw_handler},
 	{"*.vfat", "raw", img_to_raw_handler},
+	{"*.vfat", "vfat", img_to_fs_handler},
 	{"*.tar*", "ext4", archive_to_ext4_handler},
 	{"*.catar", "ext4", archive_to_ext4_handler},
 	{"*.tar*", "ubifs", archive_to_ubifs_handler},


### PR DESCRIPTION
This adds support for writing a .vfat image (which should be a valid
extension for a vfat image) to a vfat slot by using the img_to_fs_handler.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>