### PR TITLE
Add support for updating eMMC boot partitions 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,7 @@ librauc_la_SOURCES = \
 	src/checksum.c \
 	src/config_file.c \
 	src/context.c \
+	src/emmc.c \
 	src/install.c \
 	src/manifest.c \
 	src/mark.c \
@@ -52,6 +53,7 @@ librauc_la_SOURCES = \
 	include/checksum.h \
 	include/config_file.h \
 	include/context.h \
+	include/emmc.h \
 	include/install.h \
 	include/manifest.h \
 	include/mark.h \

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ Features
 * Storage support:
 
   * ext2/3/4 filesystem
+  * eMMC boot partitions (atomic update)
   * vfat filesystem
   * UBI volumes
   * UBIFS

--- a/include/emmc.h
+++ b/include/emmc.h
@@ -1,0 +1,79 @@
+#include <glib.h>
+#include <linux/types.h>
+
+#define EMMC_BOOT_PARTITIONS			2
+#define INACTIVE_BOOT_PARTITION(part_active)	((part_active + 1) % EMMC_BOOT_PARTITIONS)
+
+#define EXT_CSD_PART_CONFIG			179
+#define EXT_CSD_CMD_SET_NORMAL			(1 << 0)
+#define EXT_CSD_BOOT_CFG_ACC			(0x07)
+
+/* From kernel linux/mmc/mmc.h */
+#define MMC_SWITCH				6               /* ac	[31:0] See below	R1b */
+#define MMC_SEND_EXT_CSD			8               /* adtc				R1  */
+#define MMC_SWITCH_MODE_WRITE_BYTE		0x03            /* Set target to value */
+
+/* From kernel linux/mmc/core.h */
+#define MMC_RSP_PRESENT				(1 << 0)
+#define MMC_RSP_CRC				(1 << 2)        /* expect valid crc */
+#define MMC_RSP_BUSY				(1 << 3)        /* card may send busy */
+#define MMC_RSP_OPCODE				(1 << 4)        /* response contains opcode */
+
+#define MMC_CMD_AC				(0 << 5)
+#define MMC_CMD_ADTC				(1 << 5)
+
+#define MMC_RSP_SPI_S1				(1 << 7)        /* one status byte */
+#define MMC_RSP_SPI_BUSY			(1 << 10)       /* card may send busy */
+
+#define MMC_RSP_SPI_R1				(MMC_RSP_SPI_S1)
+#define MMC_RSP_SPI_R1B				(MMC_RSP_SPI_S1|MMC_RSP_SPI_BUSY)
+
+#define MMC_RSP_R1				(MMC_RSP_PRESENT|MMC_RSP_CRC|MMC_RSP_OPCODE)
+#define MMC_RSP_R1B				(MMC_RSP_PRESENT|MMC_RSP_CRC|MMC_RSP_OPCODE|MMC_RSP_BUSY)
+
+
+/**
+ * Reads the active eMMC boot partition index of given eMMC device into the
+ * given variable.
+ *
+ * @param device eMMC /dev path (/dev/mmcblkX)
+ * @param bootpart_active will contain the active boot partition
+ * (0 for mmcblkXboot0, 1 for mmcblkXboot1, 6 for mmcblkX user partition and
+ * -1 for no active boot partition)
+ * for user partition)
+ * @param error return location for a GError, or NULL
+ *
+ * @return True if succeeded, False if failed
+ */
+gboolean r_emmc_read_bootpart(const gchar *device, gint *bootpart_active, GError **error);
+
+/**
+ * Set the given boot partition (by index) active.
+ *
+ * @param device eMMC /dev path (/dev/mmcblkX)
+ * @param bootpart_active boot partition to set active (0 or 1)
+ * @param error return location for a GError, or NULL
+ *
+ * @return True if succeeded, False if failed
+ */
+gboolean r_emmc_write_bootpart(const gchar *device, gint bootpart_active, GError **error);
+
+/**
+ * Set eMMC boot partition to read-only.
+ *
+ * @param device eMMC boot partition /dev path (/dev/mmcblkXbootY)
+ * @param error return location for a GError, or NULL
+ *
+ * @return True if succeeded, False if failed
+ */
+gboolean r_emmc_force_part_ro(const gchar *device, GError **error);
+
+/**
+ * Set eMMC boot partition to read-write.
+ *
+ * @param device eMMC boot partition /dev path (/dev/mmcblkXbootY)
+ * @param error return location for a GError, or NULL
+ *
+ * @return True if succeeded, False if failed
+ */
+gboolean r_emmc_force_part_rw(const gchar *device, GError **error);

--- a/src/emmc.c
+++ b/src/emmc.c
@@ -1,0 +1,178 @@
+#include <config.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <glib/gstdio.h>
+#include <linux/major.h>
+#include <linux/mmc/ioctl.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "emmc.h"
+#include "update_handler.h"
+
+
+static int r_emmc_read_extcsd(int fd, guint8 extcsd[512]) {
+	struct mmc_ioc_cmd cmd = {};
+
+	cmd.write_flag = 0;
+	cmd.opcode = MMC_SEND_EXT_CSD;
+	cmd.arg = 0;
+	cmd.flags = MMC_RSP_SPI_R1 | MMC_RSP_R1 | MMC_CMD_ADTC;
+	cmd.blksz = 512;
+	cmd.blocks = 1;
+	mmc_ioc_cmd_set_data(cmd, extcsd);
+
+	return ioctl(fd, MMC_IOC_CMD, &cmd);
+}
+
+gboolean r_emmc_read_bootpart(const gchar *device, gint *bootpart_active, GError **error) {
+	gint ret;
+	gboolean res = FALSE;
+	guint8 extcsd[512];
+	int fd;
+	/* count from 1 */
+	gint active_partition = -1;
+
+	fd = g_open(device, O_RDONLY);
+	if (fd == -1) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"opening eMMC device failed: %s", g_strerror(errno));
+		goto out;
+	}
+
+	ret = r_emmc_read_extcsd(fd, extcsd);
+	if (ret) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Could not read from extcsd register %d in %s\n",
+				EXT_CSD_PART_CONFIG, device);
+		goto out;
+	}
+
+	/* retrieve active partition from BOOT_PART register */
+	active_partition = (extcsd[EXT_CSD_PART_CONFIG] & 0x38) >> 3;
+
+	/* return the partitions counted from 0 */
+	*bootpart_active = active_partition - 1;
+
+	res = TRUE;
+
+out:
+	if (fd >= 0)
+		g_close(fd, NULL);
+
+	return res;
+}
+
+static gint r_emmc_write_extcsd(int fd, guint8 index, guint8 value) {
+	struct mmc_ioc_cmd cmd;
+
+	memset(&cmd, 0, sizeof(cmd));
+
+	cmd.write_flag = 1;
+	cmd.opcode = MMC_SWITCH;
+	cmd.arg = (MMC_SWITCH_MODE_WRITE_BYTE << 24) | (index << 16) |
+	          (value << 8) | EXT_CSD_CMD_SET_NORMAL;
+	cmd.flags = MMC_RSP_SPI_R1B | MMC_RSP_R1B | MMC_CMD_AC;
+
+	return ioctl(fd, MMC_IOC_CMD, &cmd);
+}
+
+gboolean r_emmc_write_bootpart(const gchar *device, gint bootpart_active, GError **error) {
+	gint ret;
+	gboolean res = FALSE;
+	int fd;
+	guint8 value = 0;
+
+	g_return_val_if_fail(bootpart_active == 0 || bootpart_active == 1, FALSE);
+
+	fd = g_open(device, O_RDWR);
+	if (fd == -1) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"opening eMMC device failed: %s", g_strerror(errno));
+		goto out;
+	}
+
+	/* write [5:3] : BOOT_PARTITION_ENABLE of PARTITION_CONFIG */
+	if (bootpart_active == 0)
+		value = 0x08;
+	else if (bootpart_active == 1)
+		value = 0x10;
+
+	ret = r_emmc_write_extcsd(fd, EXT_CSD_PART_CONFIG, value);
+	if (ret) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Could not write 0x%02x to extcsd register %d in %s\n",
+				value, EXT_CSD_PART_CONFIG, device);
+		goto out;
+	}
+
+	res = TRUE;
+
+out:
+	if (fd >= 0)
+		g_close(fd, NULL);
+
+	return res;
+}
+
+static gboolean r_emmc_force_part_write(const gchar *device, gchar value, GError **error) {
+	gboolean ret = FALSE;
+	gchar *device_basename = g_path_get_basename(device);
+	gchar *sysfs_path = NULL;
+	FILE *f = NULL;
+
+	g_return_val_if_fail(value == '0' || value == '1', FALSE);
+
+	sysfs_path = g_strdup_printf("/sys/block/%s/force_ro", device_basename);
+	if (!g_file_test(sysfs_path, G_FILE_TEST_EXISTS)) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Block device does not have force_ro attribute: %s does not exist",
+				sysfs_path);
+		goto out;
+	}
+
+	f = g_fopen(sysfs_path, "w");
+
+	if (fwrite(&value, 1, 1, f) != 1) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Could not write to %s", sysfs_path);
+		goto out;
+	}
+
+	ret = TRUE;
+
+out:
+	if (f)
+		fclose(f);
+
+	g_free(device_basename);
+	g_free(sysfs_path);
+
+	return ret;
+}
+
+gboolean r_emmc_force_part_ro(const gchar *device, GError **error) {
+	gboolean ret = FALSE;
+	GError *ierror = NULL;
+
+	ret = r_emmc_force_part_write(device, '1', &ierror);
+	if (!ret)
+		g_propagate_prefixed_error(error, ierror,
+				"failed forcing ro: ");
+
+	return ret;
+}
+
+gboolean r_emmc_force_part_rw(const gchar *device, GError **error) {
+	gboolean ret = FALSE;
+	GError *ierror = NULL;
+
+	ret = r_emmc_force_part_write(device, '0', &ierror);
+	if (!ret)
+		g_propagate_prefixed_error(error, ierror,
+				"failed forcing rw: ");
+
+	return ret;
+}


### PR DESCRIPTION
This enables atomic updates of eMMC boot partitions for bootloaders:

- read active boot partition
- empty the inactive boot partition
- set inactive boot partition rw
- write bootloader to inactive partition
- set inactive boot partition ro
- set inactive boot partition active
- check that the previous inactive boot partition is active now

Also the docs were restructured and now reflect the first bootloader update possibility via RAUC.