### PR TITLE
src/mark: do not check for ierror twice

### DIFF
--- a/src/mark.c
+++ b/src/mark.c
@@ -160,8 +160,7 @@ out:
 	if (res && slot_name)
 		*slot_name = g_strdup(slot->name);
 
-	if (ierror)
-		g_clear_error(&ierror);
+	g_clear_error(&ierror);
 
 	return res;
 }


### PR DESCRIPTION
Discard the explicit check as g_clear_error() does it implicitly.

Signed-off-by: Ulrich Ölmann <u.oelmann@pengutronix.de>