### PR TITLE
Makefile.am: include config.h via CPPFLAGS instead of in each file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,7 @@ CODE_COVERAGE_IGNORE_PATTERN = "*-generated.c"
 
 AM_CFLAGS = -DG_LOG_DOMAIN=\"rauc\" $(WARN_CFLAGS) $(GLIB_CFLAGS) $(CURL_CFLAGS)
 AM_LDFLAGS = $(WARN_LDFLAGS) $(GLIB_LDFLAGS) $(CURL_LDFLAGS) $(OPENSSL_LDFLAGS)
-AM_CPPFLAGS = -I${top_srcdir}/include $(OPENSSL_INCLUDES)
+AM_CPPFLAGS = -I${top_srcdir}/include -include ${top_srcdir}/config.h $(OPENSSL_INCLUDES)
 
 gdbus_installer_generated = \
 	rauc-installer-generated.c \

--- a/include/network.h
+++ b/include/network.h
@@ -3,7 +3,6 @@
 #include <glib.h>
 
 #include <checksum.h>
-#include <config.h>
 
 #if ENABLE_NETWORK
 void network_init(void);

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <string.h>
 #include <errno.h>
 #include <gio/gio.h>

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <gio/gio.h>
 #include <glib/gstdio.h>
 #include <string.h>

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include "checksum.h"
 
 #define RAUC_DEFAULT_CHECKSUM G_CHECKSUM_SHA256

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <glib.h>
 #include <string.h>
 

--- a/src/context.c
+++ b/src/context.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <gio/gio.h>
 #include <string.h>
 

--- a/src/install.c
+++ b/src/install.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <errno.h>
 #include <fcntl.h>
 #include <gio/gfiledescriptorbased.h>

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <gio/gio.h>
 #include <glib.h>
 #include <glib/gstdio.h>

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include "checksum.h"
 #include "config_file.h"
 #include "context.h"

--- a/src/mount.c
+++ b/src/mount.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <gio/gio.h>
 #include <glib/gstdio.h>
 #include <unistd.h>

--- a/src/network.c
+++ b/src/network.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <curl/curl.h>
 #include <gio/gio.h>
 #include <glib/gstdio.h>

--- a/src/service.c
+++ b/src/service.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <gio/gio.h>
 #include <glib-unix.h>
 #include <glib.h>

--- a/src/signature.c
+++ b/src/signature.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <openssl/cms.h>
 #include <openssl/conf.h>
 #include <openssl/err.h>

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <errno.h>
 #include <fcntl.h>
 #include <gio/gunixoutputstream.h>

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,3 @@
-#include <config.h>
-
 #include <ftw.h>
 #include <gio/gio.h>
 #include <glib.h>

--- a/test/common.h
+++ b/test/common.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <config.h>
 #include <glib.h>
 
 gchar* random_bytes(gsize size, guint32 seed);

--- a/test/install.c
+++ b/test/install.c
@@ -5,7 +5,6 @@
 #include <gio/gio.h>
 
 #include <context.h>
-#include <config.h>
 #include <install.h>
 #include <manifest.h>
 #include <mount.h>


### PR DESCRIPTION
This should ensure that we don't forget to include it.

Signed-off-by: Jan Luebbe <jlu@pengutronix.de>