### PR TITLE
Fix out-of-tree build and temporary disable coverity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,6 @@ addons:
     sources: &sources
       - ubuntu-toolchain-r-test
       - sourceline: 'deb http://archive.ubuntu.com/ubuntu/ trusty main restricted universe multiverse'
-  coverity_scan:
-    project:
-      name: "jluebbe/rauc"
-      description: "Robust Auto-Update Controller"
-    notification_email: jluebbe@lasnet.de
-    build_command_prepend: "cov-configure --comptype gcc --compiler gcc-7 --template && ./autogen.sh && ./configure"
-    build_command: "make -j2"
-    branch_pattern: master
 script:
   - ./autogen.sh
   - ./configure --enable-code-coverage

--- a/Makefile.am
+++ b/Makefile.am
@@ -195,8 +195,8 @@ data/%: data/%.in
 SPHINXOPTS          =
 SPHINXBUILD         = sphinx-build
 PAPER               =
-DOCDIR              = docs
-SPHINXBUILDDIR      = $(DOCDIR)/build
+DOCDIR              = $(top_srcdir)/docs
+SPHINXBUILDDIR      = $(top_builddir)/docs/build
 
 .PHONY: check-valgrind check-valgrind-tool
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,7 @@ CODE_COVERAGE_IGNORE_PATTERN = "*-generated.c"
 
 AM_CFLAGS = -DG_LOG_DOMAIN=\"rauc\" $(WARN_CFLAGS) $(GLIB_CFLAGS) $(CURL_CFLAGS)
 AM_LDFLAGS = $(WARN_LDFLAGS) $(GLIB_LDFLAGS) $(CURL_LDFLAGS) $(OPENSSL_LDFLAGS)
-AM_CPPFLAGS = -I${top_srcdir}/include -include ${top_srcdir}/config.h $(OPENSSL_INCLUDES)
+AM_CPPFLAGS = -I${top_srcdir}/include -include ${top_builddir}/config.h $(OPENSSL_INCLUDES)
 
 gdbus_installer_generated = \
 	rauc-installer-generated.c \


### PR DESCRIPTION
Fixes out-of-tree builds for newly introduced config.h handling and disables coverity that showed some strange behavior in Travis over the last builds.