### PR TITLE
contrib: fix uboot.sh example script

### DIFF
--- a/contrib/uboot.sh
+++ b/contrib/uboot.sh
@@ -8,14 +8,14 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
     # skip remaining slots
   elif test "x${BOOT_SLOT}" = "xA"; then
     if test ${BOOT_A_LEFT} -gt 0; then
-      expr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
+      setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
       setenv load_kernel "nand read ${kernel_loadaddr} ${kernel_a_nandoffset} ${kernel_size}"
       setenv bootargs "${default_bootargs} root=/dev/mmcblk0p1 rauc.slot=A"
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
     if test ${BOOT_B_LEFT} -gt 0; then
-      expr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
+      setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
       setenv load_kernel "nand read ${kernel_loadaddr} ${kernel_b_nandoffset} ${kernel_size}"
       setenv bootargs "${default_bootargs} root=/dev/mmcblk0p2 rauc.slot=B"


### PR DESCRIPTION
Command 'expr' is not available, use setexpr instead.

Signed-off-by: Michael Heimpold <michael.heimpold@i2se.com>