### PR TITLE
service: report system status via GetSlotStatus

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -451,7 +451,7 @@ Methods
 
 :ref:`Mark <gdbus-method-de-pengutronix-rauc-Installer.Mark>` (IN  s state, IN  s slot_identifier, s slot_name, s message);
 
-:ref:`GetSlotStatus <gdbus-method-de-pengutronix-rauc-Installer.GetSlotStatus>` (a(sa{sv}) slot_status_array);
+:ref:`GetSlotStatus <gdbus-method-de-pengutronix-rauc-Installer.GetSlotStatus>` (a{sv} system_status_dict, a(sa{sv}) slot_status_array);
 
 Signals
 ~~~~~~~
@@ -541,9 +541,12 @@ The GetSlotStatus() Method
 .. code::
 
   de.pengutronix.rauc.Installer.GetSlotStatus()
-  GetSlotStatus (a(sa{sv}) slot_status_array);
+  GetSlotStatus (a{sv} system_status_dict, a(sa{sv}) slot_status_array);
 
 Access method to get all slots' status.
+
+a{sv} *system_status_dict*;
+    Dictionary representing the system status
 
 a(sa{sv}) *slot_status_array*:
     Array of (slotname, dict) tuples with each dictionary representing the

--- a/src/main.c
+++ b/src/main.c
@@ -1236,7 +1236,7 @@ static gboolean retrieve_slot_states_via_dbus(GError **error)
 	                    ? G_BUS_TYPE_SESSION : G_BUS_TYPE_SYSTEM;
 	GError *ierror = NULL;
 	RInstaller *proxy;
-	GVariant *slot_status_array, *vardict;
+	GVariant *system_status_dict, *slot_status_array, *vardict;
 	GHashTable *slots = r_context()->config->slots;
 	GVariantIter *iter;
 	gchar *slot_name;
@@ -1257,7 +1257,7 @@ static gboolean retrieve_slot_states_via_dbus(GError **error)
 	}
 
 	g_debug("Trying to contact rauc service");
-	if (!r_installer_call_get_slot_status_sync(proxy, &slot_status_array, NULL, &ierror)) {
+	if (!r_installer_call_get_slot_status_sync(proxy, &system_status_dict, &slot_status_array, NULL, &ierror)) {
 		g_set_error(error,
 				G_IO_ERROR,
 				G_IO_ERROR_FAILED,
@@ -1280,6 +1280,7 @@ static gboolean retrieve_slot_states_via_dbus(GError **error)
 
 	g_variant_iter_free(iter);
 	g_variant_unref(slot_status_array);
+	g_variant_unref(system_status_dict);
 
 	return TRUE;
 }

--- a/src/rauc-installer.xml
+++ b/src/rauc-installer.xml
@@ -43,12 +43,14 @@
 
     <!--
          GetSlotStatus:
+         @system_status: dict representing the system status
          @slot_status_array: array of (slotname, dict) tuples with each
              dictionary representing the status of the corresponding slot
 
          Access method to get all slots' status.
     -->
     <method name="GetSlotStatus">
+      <arg name="system_status_dict" type="a{sv}" direction="out"/>
       <arg name="slot_status_array" type="a(sa{sv})" direction="out"/>
     </method>
 

--- a/test/service.c
+++ b/test/service.c
@@ -246,6 +246,7 @@ static void service_test_slot_status(ServiceFixture *fixture, gconstpointer user
 {
 	GError *error = NULL;
 	GVariant *slot_status_array = NULL;
+	GVariant *system_status_dict = NULL;
 
 	if (!ENABLE_SERVICE) {
 		g_test_skip("Test requires RAUC being configured with \"--enable-service\".");
@@ -265,16 +266,18 @@ static void service_test_slot_status(ServiceFixture *fixture, gconstpointer user
 	}
 
 	r_installer_call_get_slot_status_sync(installer,
-			&slot_status_array,
+			&system_status_dict, &slot_status_array,
 			NULL,
 			&error);
 	g_assert_no_error(error);
 	g_assert_nonnull(slot_status_array);
 	g_assert_cmpint(g_variant_n_children(slot_status_array), ==, 5);
+	g_assert_nonnull(system_status_dict);
 
 out:
 	g_clear_pointer(&installer, g_object_unref);
 	g_variant_unref(slot_status_array);
+	g_variant_unref(system_status_dict);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
"raus status" reports also status not linked to a single slot:
"compatible", "variant", "booted", "boot_primary"
Add them to GetSlotStatus. This adds a extra parameter to the method.

Signed-off-by: Jan Remmet <j.remmet@phytec.de>