### PR TITLE
Clarify bundle installation D-Bus API

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -482,6 +482,8 @@ The Install() Method
   Install (IN  s source);
 
 Triggers the installation of a bundle.
+This method call is non-blocking.
+After completion, the :ref:`"Completed" <gdbus-signal-de-pengutronix-rauc-Installer.Completed>` signal will be emitted.
 
 IN s *source*:
     Path to bundle to be installed

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -67,7 +67,7 @@ To actually install an update bundle on your target hardware, RAUC provides the
 
   rauc install <input-file>
 
-Alternatively you can trigger a bundle installation via D-Bus.
+Alternatively you can trigger a bundle installation `using the D-Bus API`_.
 
 Viewing the System Status
 -------------------------

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -490,13 +490,22 @@ project-specific applications, incorporation with bridge services such as the
 The API's service domain is ``de.pengutronix.rauc`` while the object path is
 ``/``.
 
+Installing a Bundle
+~~~~~~~~~~~~~~~~~~~
+
 The D-Bus API's main purpose is to trigger and monitor the installation
 process via its ``Installer`` interface.
-While the ``Install`` operation starts the installation progress, constant
-progress information will be emitted in form of changes to the ``Progress``
-property.
-Upon completing the installation RAUC emits the ``Completed`` signal indicating
-either successful or failed installation.
+
+The ``Install`` method call triggers the installation of a given bundle in the
+background and returns immediately.
+Upon completion of the installation RAUC emits the ``Completed`` signal,
+indicating either successful or failed installation.
+For details on triggering the installation process, see the
+:ref:`gdbus-method-de-pengutronix-rauc-Installer.Install` chapter in the
+reference documentation.
+
+While the installation is in progress, constant progress information will be
+emitted in form of changes to the ``Progress`` property.
 
 Processing Progress Data
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Point the reader towards the D-Bus API from the installation chapter, add a separate D-Bus API subchapter to explain bundle installation, and add pointers to the API reference from there.
Stress that the Install() is non-blocking and the installation is finished when the "Completed" signal is emitted in both places.