### PR TITLE
service: add system info properties

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -465,6 +465,12 @@ Properties
 
 :ref:`Progress <gdbus-property-de-pengutronix-rauc-Installer.Progress>` readable   (isi)
 
+:ref:`Compatible <gdbus-property-de-pengutronix-rauc-Installer.Compatible>` readable   s
+
+:ref:`Variant <gdbus-property-de-pengutronix-rauc-Installer.Variant>` readable   s
+
+:ref:`BootSlot <gdbus-property-de-pengutronix-rauc-Installer.BootSlot>` readable   s
+
 Description
 ~~~~~~~~~~~
 
@@ -610,6 +616,45 @@ The "Progress" Property
 Provides installation progress informations in the form
 
 (percentage, message, nesting depth)
+
+.. _gdbus-property-de-pengutronix-rauc-Installer.Compatible:
+
+The "Compatible" Property
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+  de.pengutronix.rauc.Installer:Compatible
+  Compatible  readable   s
+
+Represents the system's compatible. This can be used to check for usable bundels.
+
+
+.. _gdbus-property-de-pengutronix-rauc-Installer.Variant:
+
+The "Variant" Property
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+  de.pengutronix.rauc.Installer:Variant
+  Variant  readable   s
+
+Represents the system's variant. This can be used to select parts of an bundle.
+
+
+.. _gdbus-property-de-pengutronix-rauc-Installer.BootSlot:
+
+The "BootSlot" Property
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+  de.pengutronix.rauc.Installer:BootSlot
+  BootSlot  readable   s
+
+Represents the used boot slot.
+
 
 RAUC's Basic Update Procedure
 -----------------------------

--- a/src/rauc-installer.xml
+++ b/src/rauc-installer.xml
@@ -59,6 +59,12 @@
     <!-- Progress: Provides installation progress informations in the form
          (percentage, message, nesting depth) -->
     <property name="Progress" type="(isi)" access="read"/>
+    <!-- Compatible: Represents the system's compatible -->
+    <property name="Compatible" type="s" access="read"/>
+    <!-- Variant: Represents the system's variant -->
+    <property name="Variant" type="s" access="read"/>
+    <!-- BootSlot: Represents the slot booted from -->
+    <property name="BootSlot" type="s" access="read"/>
 
     <!--
          Completed:

--- a/src/service.c
+++ b/src/service.c
@@ -437,6 +437,10 @@ static void r_on_bus_acquired(GDBusConnection *connection,
 		g_error_free(ierror);
 	}
 
+	r_installer_set_compatible(r_installer, r_context()->config->system_compatible);
+	r_installer_set_variant(r_installer, r_context()->config->system_variant);
+	r_installer_set_boot_slot(r_installer, r_context()->bootslot);
+
 	return;
 }
 

--- a/test/service.c
+++ b/test/service.c
@@ -127,6 +127,9 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 	GQueue *args = g_queue_new();
 	const gchar *operation = NULL, *last_error = NULL;
 	GVariant *progress = NULL;
+	const gchar *compatible = NULL;
+	const gchar *variant = NULL;
+	const gchar *bootslot = NULL;
 	gchar *bundlepath;
 	GError *error = NULL;
 	gboolean ret = FALSE;
@@ -186,6 +189,13 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 
 	progress = r_installer_get_progress(installer);
 	assert_progress(progress, 0, "", 0);
+
+	compatible = r_installer_get_compatible(installer);
+	g_assert_cmpstr(compatible, ==, "Test Config");
+	variant = r_installer_get_variant(installer);
+	g_assert_cmpstr(variant, ==, "Default Variant");
+	bootslot = r_installer_get_boot_slot(installer);
+	g_assert_cmpstr(bootslot, ==, "system0");
 
 	r_context();
 

--- a/test/test.conf
+++ b/test/test.conf
@@ -4,6 +4,7 @@
 compatible=Test Config
 bootloader=grub
 grubenv=grubenv.test
+variant-name=Default Variant
 
 [handlers]
 system-info=bin/systeminfo.sh


### PR DESCRIPTION
Make system information availabile via dbus. This adds the properties
Compatible, Variant, and Bootslot

Signed-off-by: Jan Remmet <j.remmet@phytec.de>