### PR TITLE
Try to unmount mounted target slots instead of straight failure

### DIFF
--- a/data/rauc.service.in
+++ b/data/rauc.service.in
@@ -6,4 +6,3 @@ Type=dbus
 BusName=de.pengutronix.rauc
 ExecStart=@bindir@/rauc --mount=/run/rauc service
 RuntimeDirectory=rauc
-MountFlags=slave


### PR DESCRIPTION
**Summary**: This tries to work around a case where a targeted destination partition might be mounted when rauc (service) was started for some reason (`rauc status mark-good`).

**Old behavior**: rauc aborts.

**New behavior**: rauc tries to `umount` the slot's device before giving up.

**Note**: rauc *should* watch mtab during runtime so that an unmount could be handled via a hook script. It breaks the mount iso-/(insu?)lation.