### PR TITLE
emmc: add workaround for older kernels

### DIFF
--- a/src/emmc.c
+++ b/src/emmc.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include <glib/gstdio.h>
 #include <linux/major.h>
+#include <linux/types.h> /* kernel < 3.4 forgot that in mmc/ioctl.h */
 #include <linux/mmc/ioctl.h>
 #include <string.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
Kernels up to (and including 3.3) forgot to include types.h in their
mmc/ioctl.h, and thus __u32 (and others) are not defined, causing
compilation errors:

    http://autobuild.buildroot.org/results/621/621587906bd2bb27c43b6fcbb051d75f20e32e7c/build-end.log

Fix that by explicitly including types.h before mmc/ioctl.h.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>