### PR TITLE
gitignore: fix location of rauc-installer-generated.[ch]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 !/build-aux/git-version-gen
 /test/*.test
 /test/services/de.pengutronix.rauc.service
-/src/*-generated.[ch]
+/*-generated.[ch]
 Makefile
 Makefile.in
 aclocal.m4


### PR DESCRIPTION
In 23a287f ("Makefile.am: Fix gdbus-codegen for VPATH builds") the
generated D-BUS interface code was moved from ./src to ./ .

Signed-off-by: Bastian Stender <bst@pengutronix.de>