### PR TITLE
src: open device path with O_EXCL to assure exclusive access on block device

### DIFF
--- a/src/emmc.c
+++ b/src/emmc.c
@@ -91,7 +91,7 @@ gboolean r_emmc_write_bootpart(const gchar *device, gint bootpart_active, GError
 
 	g_return_val_if_fail(bootpart_active == 0 || bootpart_active == 1, FALSE);
 
-	fd = g_open(device, O_RDWR);
+	fd = g_open(device, O_RDWR | O_EXCL);
 	if (fd == -1) {
 		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
 				"opening eMMC device failed: %s", g_strerror(errno));

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -35,7 +35,7 @@ static GOutputStream* open_slot_device(RaucSlot *slot, int *fd, GError **error)
 
 	destslotfile = g_file_new_for_path(slot->device);
 
-	fd_out = open(g_file_get_path(destslotfile), O_WRONLY);
+	fd_out = open(g_file_get_path(destslotfile), O_WRONLY | O_EXCL);
 
 	if (fd_out == -1) {
 		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,


### PR DESCRIPTION
From `open()` man page:

| on Linux 2.6 and later, O_EXCL can be used without O_CREAT if pathname
| refers to a block device.  If the block device is in use by the system
| (e.g., mounted), open() fails with the error EBUSY.

This will prevent us from erroneously writing devices that are already
mounted or used at the moment of opening.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>