### PR TITLE
src/install: fix invalid return value in case of failed mark_active()

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -969,12 +969,14 @@ image_out:
 				g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_BOOTABLE,
 						"Failed marking slot %s bootable", dest_slot->name);
 				g_clear_error(&ierror);
+				res = FALSE;
 				goto out;
 			} else if (g_error_matches(ierror, R_INSTALL_ERROR, R_INSTALL_ERROR_FAILED)) {
 				g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_FAILED,
 						"Marked slot %s bootable, but failed to write status file: %s",
 						dest_slot->name, ierror->message);
 				g_clear_error(&ierror);
+				res = FALSE;
 				goto out;
 			}
 			g_clear_error(&ierror);


### PR DESCRIPTION
935346f replaced the function `r_boot_set_primary()` with the function
`mark_active()`. While `r_boot_set_primary()` returned a gboolean that was
assigned to the return variable 'res', mark_active() does not.
As `res` will have been set to `TRUE` by the code flow before, this
absolutely requires to set 'res' manually to `FALSE` in case of an error
of `mark_active()`.
As this was missing, the installation was reported successfully even if
the actual slot activation failed.

This patch now fixes the return value of
`launch_and_wait_default_handler()` in case of a failed `mark_active()`
call by setting `res` to `FALSE` manually.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>