### PR TITLE
src: preserve original uig/gid during tar extraction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,7 @@ For using tar archive in RAUC bundles with Busybox tar, you have to enable the
 following Busybox feature:
 
 -  ``CONFIG_FEATURE_TAR_AUTODETECT=y``
+-  ``CONFIG_FEATURE_TAR_LONG_OPTIONS=y``
 
 Depending on the actual storage type and/or filesystem used, further target
 tool might be required.

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -198,6 +198,8 @@ cannot fully know how you intend to use your system.
 
     * ``CONFIG_FEATURE_TAR_AUTODETECT=y``
     * ``CONFIG_FEATURE_SEAMLESS_XZ=y``
+    * ``CONFIG_FEATURE_TAR_LONG_OPTIONS=y``
+
 :ext2/3/4: mkfs.ext2/3/4 (from `e2fsprogs
   <git://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git>`_)
 :vfat: mkfs.vfat (from `dosfstools

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -132,6 +132,7 @@ static gboolean casync_make_arch(const gchar *idxpath, const gchar *contentpath,
 	g_ptr_array_add(iargs, g_strdup(contentpath));
 	g_ptr_array_add(iargs, g_strdup("-C"));
 	g_ptr_array_add(iargs, g_strdup(tmpdir));
+	g_ptr_array_add(iargs, g_strdup("--numeric-owner"));
 	g_ptr_array_add(iargs, g_strdup("&&"));
 	g_ptr_array_add(iargs, g_strdup("casync"));
 	g_ptr_array_add(iargs, g_strdup("make"));

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -531,6 +531,7 @@ static gboolean untar_image(RaucImage *image, gchar *dest, GError **error)
 	g_ptr_array_add(args, g_strdup(image->filename));
 	g_ptr_array_add(args, g_strdup("-C"));
 	g_ptr_array_add(args, g_strdup(dest));
+	g_ptr_array_add(args, g_strdup("--numeric-owner"));
 	g_ptr_array_add(args, NULL);
 
 	sproc = g_subprocess_newv((const gchar * const *)args->pdata,


### PR DESCRIPTION
Always call tar extract with --numeric-owner option to preserve original
user and group IDs as packed into the archive.
This is required to assure reproducible and deterministic IDs that are
also consistent with the password file and prevent from later user
relabeling that would cause issues in the context of trusted boot.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>