### PR TITLE
Introduce max-download-size config setting (fixes #287)

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -87,6 +87,11 @@ Example configuration:
   key not exists, the bootchooser framework searches per default for ``/state``
   or ``/aliases/state``.
 
+``max-bundle-download-size``
+  Defines the maximum downloadable bundle size in bytes, and thus must be
+  a simple integer value (without unit) greater than zero.
+  It overwrites the compiled-in default value of 8 MiB.
+
 **[keyring] section**
 
 The ``keyring`` section refers to the trusted keyring used for signature

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -5,10 +5,14 @@
 #include <checksum.h>
 #include "manifest.h"
 
+/* Default maximum downloadable bundle size (8 MiB) */
+#define DEFAULT_MAX_BUNDLE_DOWNLOAD_SIZE 8*1024*1024
+
 typedef enum {
 	R_CONFIG_ERROR_INVALID_FORMAT,
 	R_CONFIG_ERROR_BOOTLOADER,
-	R_CONFIG_ERROR_PARENT
+	R_CONFIG_ERROR_PARENT,
+	R_CONFIG_ERROR_MAX_BUNDLE_DOWNLOAD_SIZE
 } RConfigError;
 
 #define R_CONFIG_ERROR r_config_error_quark()
@@ -28,6 +32,8 @@ typedef struct {
 	gchar *system_variant;
 	gchar *system_bootloader;
 	gchar *system_bb_statename;
+	/* maximum filesize to download in bytes */
+	guint64 max_bundle_download_size;
 	/* path prefix where rauc may create mount directories */
 	gchar *mount_prefix;
 	gchar *store_path;

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -10,9 +10,6 @@
 #include "utils.h"
 #include "network.h"
 
-/* Maximum downloadable bundle size (8MB) */
-#define BUNDLE_DL_MAX_SIZE 8*1024*1024
-
 GQuark
 r_bundle_error_quark(void)
 {
@@ -646,7 +643,7 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, gboolean ver
 		ibundle->path = g_build_filename(g_get_tmp_dir(), "_download.raucb", NULL);
 
 		g_message("Remote URI detected, downloading bundle to %s...", ibundle->path);
-		res = download_file(ibundle->path, ibundle->origpath, BUNDLE_DL_MAX_SIZE, &ierror);
+		res = download_file(ibundle->path, ibundle->origpath, r_context()->config->max_bundle_download_size, &ierror);
 		if (!res) {
 			g_propagate_prefixed_error(error, ierror, "Failed to download bundle %s: ", ibundle->origpath);
 			goto out;


### PR DESCRIPTION
At the moment, a hard-coded BUNDLE_DL_MAX_SIZE define is
used for a safety check when a bundle is downloaded.
To be more flexible at runtime, introduce a new config
parameter 'max-download-size'.
The current define is used as default value when the
config setting is not specified.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>