### PR TITLE
Some unrelated fixes and enhancements

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -371,6 +371,7 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 	res = sign_bundle(bundlename, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
+		g_remove(bundlename);
 		goto out;
 	}
 
@@ -450,6 +451,7 @@ gboolean resign_bundle(RaucBundle *bundle, const gchar *outpath, GError **error)
 	res = sign_bundle(outpath, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
+		g_remove(outpath);
 		goto out;
 	}
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -204,7 +204,7 @@ gchar* get_pubkey_hash(X509 *cert)
 
 	len = i2d_X509_PUBKEY(X509_get_X509_PUBKEY(cert), NULL);
 	if (len <= 0) {
-		g_warning("DER Encoding failed\n");
+		g_warning("DER Encoding failed");
 		goto out;
 	}
 	/* As i2d_X509_PUBKEY() moves pointer after end of data,
@@ -215,7 +215,7 @@ gchar* get_pubkey_hash(X509 *cert)
 	g_assert(((unsigned int)(tmp_buf - der_buf)) == len);
 
 	if (!EVP_Digest(der_buf, len, md, &n, EVP_sha256(), NULL)) {
-		g_warning("Error in EVP_Digest\n");
+		g_warning("Error in EVP_Digest");
 		goto out;
 	}
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -275,6 +275,23 @@ gchar* print_signer_cert(STACK_OF(X509) *verified_chain)
 	return ret;
 }
 
+static gchar* get_cert_time(ASN1_TIME *time) {
+	BIO *mem;
+	gchar *data, *ret;
+	gsize size;
+
+	mem = BIO_new(BIO_s_mem());
+	ASN1_TIME_print(mem, time);
+
+	size = BIO_get_mem_data(mem, &data);
+	ret = g_strndup(data, size);
+
+	BIO_set_close(mem, BIO_CLOSE);
+	BIO_free(mem);
+
+	return ret;
+}
+
 gchar* print_cert_chain(STACK_OF(X509) *verified_chain)
 {
 	GString *text = NULL;
@@ -291,6 +308,8 @@ gchar* print_cert_chain(STACK_OF(X509) *verified_chain)
 				buf, sizeof buf);
 		g_string_append_printf(text, "   Issuer: %s\n", buf);
 		g_string_append_printf(text, "   SPKI sha256: %s\n", get_pubkey_hash(sk_X509_value(verified_chain, i)));
+		g_string_append_printf(text, "   Not Before: %s\n", get_cert_time(X509_get_notBefore(sk_X509_value(verified_chain, i))));
+		g_string_append_printf(text, "   Not After:  %s\n", get_cert_time(X509_get_notAfter(sk_X509_value(verified_chain, i))));
 	}
 
 	return g_string_free(text, FALSE);

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -148,7 +148,9 @@ test_expect_success "rauc bundle" "
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
     bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
-  rauc -c $SHARNESS_TEST_DIRECTORY/test.conf info out.raucb
+  rauc -c $SHARNESS_TEST_DIRECTORY/test.conf info out.raucb &&
+  test -f out.raucb &&
+  rm out.raucb
 "
 
 test_expect_success !SERVICE "rauc --override-boot-slot=system0 status: internally" "


### PR DESCRIPTION
* adds certificate validity times to chain printout
* removes incomplete (unsigned) bundles on error
* avoids extra newlines in g_warning() outputs
* removes bundle created in tests