### PR TITLE
Advanced Testing for U-Boot and Minor Boot Selection Fixes

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -18,7 +18,7 @@ GQuark r_bootchooser_error_quark(void)
 #define BAREBOX_STATE_DEFAULT_PRIORITY	10
 #define BAREBOX_STATE_PRIORITY_PRIMARY	20
 #define UBOOT_FWSETENV_NAME "fw_setenv"
-#define UBOOT_FWGETENV_NAME "fw_printenv"
+#define UBOOT_FWPRINTENV_NAME "fw_printenv"
 #define EFIBOOTMGR_NAME "efibootmgr"
 
 static GString *bootchooser_order_primay(RaucSlot *slot)
@@ -467,12 +467,12 @@ static gboolean uboot_env_get(const gchar *key, GString **value, GError **error)
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	sub = g_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE, &ierror,
-			UBOOT_FWGETENV_NAME, key, NULL);
+			UBOOT_FWPRINTENV_NAME, key, NULL);
 	if (!sub) {
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"Failed to start " UBOOT_FWGETENV_NAME ": ");
+				"Failed to start " UBOOT_FWPRINTENV_NAME ": ");
 		goto out;
 	}
 
@@ -481,7 +481,7 @@ static gboolean uboot_env_get(const gchar *key, GString **value, GError **error)
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"Failed to run " UBOOT_FWGETENV_NAME ": ");
+				"Failed to run " UBOOT_FWPRINTENV_NAME ": ");
 		goto out;
 	}
 
@@ -491,7 +491,7 @@ static gboolean uboot_env_get(const gchar *key, GString **value, GError **error)
 				error,
 				G_SPAWN_ERROR,
 				G_SPAWN_ERROR_FAILED,
-				UBOOT_FWGETENV_NAME " did not exit normally");
+				UBOOT_FWPRINTENV_NAME " did not exit normally");
 		goto out;
 	}
 
@@ -501,7 +501,7 @@ static gboolean uboot_env_get(const gchar *key, GString **value, GError **error)
 				error,
 				G_SPAWN_EXIT_ERROR,
 				ret,
-				UBOOT_FWGETENV_NAME " failed with exit code: %i", ret);
+				UBOOT_FWPRINTENV_NAME " failed with exit code: %i", ret);
 		res = FALSE;
 		goto out;
 	}

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -532,7 +532,7 @@ static gboolean uboot_env_set(const gchar *key, const gchar *value, GError **err
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"Failed to start fw_setenv: ");
+				"Failed to start " UBOOT_FWSETENV_NAME ": ");
 		goto out;
 	}
 
@@ -541,7 +541,7 @@ static gboolean uboot_env_set(const gchar *key, const gchar *value, GError **err
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"Failed to run fw_setenv: ");
+				"Failed to run " UBOOT_FWSETENV_NAME ": ");
 		goto out;
 	}
 

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -20,6 +20,7 @@ GQuark r_bootchooser_error_quark(void)
 #define UBOOT_FWSETENV_NAME "fw_setenv"
 #define UBOOT_FWPRINTENV_NAME "fw_printenv"
 #define EFIBOOTMGR_NAME "efibootmgr"
+#define GRUB_EDITENV "grub-editenv"
 
 static GString *bootchooser_order_primay(RaucSlot *slot)
 {
@@ -362,7 +363,7 @@ static gboolean grub_env_set(GPtrArray *pairs, GError **error)
 	g_assert_cmpuint(pairs->len, >, 0);
 	g_assert_nonnull(r_context()->config->grubenv_path);
 
-	g_ptr_array_insert(pairs, 0, g_strdup("grub-editenv"));
+	g_ptr_array_insert(pairs, 0, g_strdup(GRUB_EDITENV));
 	g_ptr_array_insert(pairs, 1, g_strdup(r_context()->config->grubenv_path));
 	g_ptr_array_insert(pairs, 2, g_strdup("set"));
 	g_ptr_array_add(pairs, NULL);
@@ -373,7 +374,7 @@ static gboolean grub_env_set(GPtrArray *pairs, GError **error)
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"Failed to start grub-editenv: ");
+				"Failed to start " GRUB_EDITENV ": ");
 		goto out;
 	}
 
@@ -382,7 +383,7 @@ static gboolean grub_env_set(GPtrArray *pairs, GError **error)
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"Failed to run grub-editenv: ");
+				"Failed to run " GRUB_EDITENV ": ");
 		goto out;
 	}
 

--- a/test/bin/fw_printenv
+++ b/test/bin/fw_printenv
@@ -1,16 +1,40 @@
 #!/bin/bash
 
-# Command line checking
+# Read env file into environment
+eval $(cat $UBOOT_STATE_PATH | sed  "s/\(.*\)=\(.*\)/export \1=\"\2\"/g")
+UBOOT_VARS=$(cat $UBOOT_STATE_PATH | sed  "s/\(.*\)=\(.*\)/\1/g" | tr '\n' ' ')
+
+function check_var {
+	found=0
+	for l in $UBOOT_VARS; do
+		if [ "$1" = "${l%=*}" ]; then
+			found=1
+		fi
+	done
+	if [ "$found" -eq "0" ]; then
+		echo "Invalid variable: $1"
+		exit 1
+	fi
+}
+
+# Print all vars if none specified
 if [ $# -ne 1 ]; then
-	echo "Invalid arguments $*"
-	exit 1
+	for l in ${UBOOT_VARS}; do
+		echo "${l}=${!l}"
+	done
+	exit 0
 fi
 
-if [ "$1" = "BOOT_ORDER" ]; then
-    echo "$1=A B R"
-else
-	echo "Invalid key: '$1'"
-	exit 1
-fi
+# Print specific var if specified
+for i in $1; do
+	var="${i%=*}"
+	val="${i#*=}"
+
+	check_var "$var"
+
+	# Output values read
+	eval echo $(echo ${i%=*})=\$$(echo ${i%=*})
+done
+
 
 exit 0

--- a/test/bin/fw_setenv
+++ b/test/bin/fw_setenv
@@ -1,29 +1,49 @@
 #!/bin/bash
 
+# Read env file into environment
+eval $(cat $UBOOT_STATE_PATH | sed  "s/\(.*\)=\(.*\)/export \1=\"\2\"/g")
+UBOOT_VARS_PRE=$(cat $UBOOT_STATE_PATH | sed  "s/\(.*\)=\(.*\)/\1/g" | tr '\n' ' ')
+
+
+function check_var {
+	found=0
+	for l in $UBOOT_VARS_PRE; do
+		if [ "$1" = "${l%=*}" ]; then
+			found=1
+		fi
+	done
+	if [ "$found" -eq "0" ]; then
+		echo "Invalid variable: $1"
+		exit 1
+	fi
+}
+
 # Command line checking
 if [ $# -ne 2 ]; then
 	echo "Invalid arguments $*"
 	exit 1
 fi
 
-if [ "$1" = "BOOT_ORDER" ]; then
-	if ! [ "$2" = "A B" -o "$2" = "B A R" ]; then
-		echo "Invalid argument for BOOT_ORDER: '$2'"
-		exit 1
-	fi
-elif [ "$1" = "BOOT_A_LEFT" ]; then
-	if ! [ "$2" -ge 0 -a "$2" -le 3 ]; then
-		echo "Invalid argument for BOOT_A_LEFT: '$2'"
-		exit 1
-	fi
-elif [ "$1" = "BOOT_B_LEFT" ]; then
-	if ! [ "$2" -ge 0 -a "$2" -le 3 ]; then
-		echo "Invalid argument for BOOT_B_LEFT: '$2'"
-		exit 1
-	fi
-else
-	echo "Invalid key: '$1'"
-	exit 1
-fi
+# Set var
+while [[ $# -gt 0 ]]
+do
+	var="$1"
+	val="$2"
+	shift
+	shift
+
+	check_var "$var" "$val"
+
+	# Assign new value
+	echo "setting: $var to $val"
+	eval "${var}=\"${val}\""
+done
+
+# write back
+rm $UBOOT_STATE_PATH
+for l in $UBOOT_VARS_PRE; do
+	echo "${l}=${!l}"
+	echo "${l}=${!l}" >> $UBOOT_STATE_PATH
+done
 
 exit 0

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -234,7 +234,8 @@ bootname=B\n";
 static void bootchooser_uboot(BootchooserFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucSlot *slot;
+	RaucSlot *rootfs0 = NULL;
+	RaucSlot *rootfs1 = NULL;
 
 	const gchar *cfg_file = "\
 [system]\n\
@@ -268,16 +269,15 @@ bootname=B\n";
 	r_context_conf()->configpath = pathname;
 	r_context();
 
-	slot = find_config_slot_by_device(r_context()->config, "/dev/rootfs-0");
-	g_assert_nonnull(slot);
+	rootfs0 = find_config_slot_by_device(r_context()->config, "/dev/rootfs-0");
+	g_assert_nonnull(rootfs0);
+	rootfs1 = find_config_slot_by_device(r_context()->config, "/dev/rootfs-1");
+	g_assert_nonnull(rootfs1);
 
-	g_assert_true(r_boot_set_state(slot, TRUE, NULL));
-	g_assert_true(r_boot_set_state(slot, FALSE, NULL));
+	g_assert_true(r_boot_set_state(rootfs0, TRUE, NULL));
+	g_assert_true(r_boot_set_state(rootfs0, FALSE, NULL));
 
-	slot = find_config_slot_by_device(r_context()->config, "/dev/rootfs-1");
-	g_assert_nonnull(slot);
-
-	g_assert_true(r_boot_set_primary(slot, NULL));
+	g_assert_true(r_boot_set_primary(rootfs1, NULL));
 }
 
 static void bootchooser_efi(BootchooserFixture *fixture,

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -231,6 +231,20 @@ bootname=B\n";
 	g_assert_true(r_boot_set_primary(slot, NULL));
 }
 
+/* Write content to state storage for uboot fw_setenv / fw_printenv RAUC mock
+ * tools. Content should be similar to:
+ * "\
+ * BOOT_ORDER=A B\n\
+ * BOOT_A_LEFT=3\n\
+ * BOOT_B_LEFT=3\n\
+ * "
+ */
+static void test_uboot_initialize_state(const gchar *vars) {
+	g_autofree gchar *state_path = g_build_filename(g_get_tmp_dir(), "uboot-test-state", NULL);
+	g_setenv("UBOOT_STATE_PATH", state_path, TRUE);
+	g_assert_true(g_file_set_contents(state_path, vars, -1, NULL));
+}
+
 static void bootchooser_uboot(BootchooserFixture *fixture,
 		gconstpointer user_data)
 {
@@ -273,6 +287,12 @@ bootname=B\n";
 	g_assert_nonnull(rootfs0);
 	rootfs1 = find_config_slot_by_device(r_context()->config, "/dev/rootfs-1");
 	g_assert_nonnull(rootfs1);
+
+	test_uboot_initialize_state("\
+BOOT_ORDER=A B R\n\
+BOOT_A_LEFT=0\n\
+BOOT_B_LEFT=3\n\
+");
 
 	g_assert_true(r_boot_set_state(rootfs0, TRUE, NULL));
 	g_assert_true(r_boot_set_state(rootfs0, FALSE, NULL));

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -69,7 +69,7 @@ bootname=system1\n";
 	rootfs1 = find_config_slot_by_device(r_context()->config, "/dev/rootfs-1");
 	g_assert_nonnull(rootfs1);
 
-	/* check rootfs.0 is considered good */
+	/* check rootfs.0 and rootfs.1 are considered good */
 	g_setenv("BAREBOX_STATE_VARS_PRE", " \
 bootstate.system0.remaining_attempts=3\n\
 bootstate.system0.priority=20\n\
@@ -78,10 +78,13 @@ bootstate.system1.priority=10\n\
 ", TRUE);
 	g_assert_true(r_boot_get_state(rootfs0, &good, NULL));
 	g_assert_true(good);
-
+	g_assert_true(r_boot_get_state(rootfs1, &good, NULL));
+	g_assert_true(good);
+	/* check rootfs.0 is considered as primary */
 	primary = r_boot_get_primary(NULL);
 	g_assert_nonnull(primary);
 	g_assert(primary == rootfs0);
+	g_assert(primary != rootfs1);
 
 	/* check rootfs.0 is considered bad (remaining_attempts = 0) */
 	g_setenv("BAREBOX_STATE_VARS_PRE", " \
@@ -92,6 +95,13 @@ bootstate.system1.priority=10\n\
 ", TRUE);
 	g_assert_true(r_boot_get_state(rootfs0, &good, NULL));
 	g_assert_false(good);
+	g_assert_true(r_boot_get_state(rootfs1, &good, NULL));
+	g_assert_true(good);
+	/* check rootfs.1 is considered as primary */
+	primary = r_boot_get_primary(NULL);
+	g_assert_nonnull(primary);
+	g_assert(primary != rootfs0);
+	g_assert(primary == rootfs1);
 
 	/* check rootfs.0 is considered bad (priority = 0) */
 	g_setenv("BAREBOX_STATE_VARS_PRE", " \
@@ -102,6 +112,13 @@ bootstate.system1.priority=10\n\
 ", TRUE);
 	g_assert_true(r_boot_get_state(rootfs0, &good, NULL));
 	g_assert_false(good);
+	g_assert_true(r_boot_get_state(rootfs1, &good, NULL));
+	g_assert_true(good);
+	/* check rootfs.1 is considered as primary */
+	primary = r_boot_get_primary(NULL);
+	g_assert_nonnull(primary);
+	g_assert(primary != rootfs0);
+	g_assert(primary == rootfs1);
 
 	/* check rootfs.0 is marked good (has remaining attempts reset 1->3) */
 	g_setenv("BAREBOX_STATE_VARS_PRE", " \


### PR DESCRIPTION
This fixes some minor inconsistencies in RAUC'S boot selection code but mainly adds support for stateful `fw_setenv`/`fw_printenv` testing as preparation for further implementation and fixes, e.g. as introduced by #293.