### PR TITLE
docs: add minimal hint on --disable-service in RAUC faq

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -11,3 +11,14 @@ Especially in cases where the same bundle will be installed on devices which use
 different partition sizes, tar archives are preferable to filesystem images.
 When RAUC installs from a tar archive, it will first create a new filesystem on
 the target partition, allowing use of the full size.
+
+Is it possible to use RAUC without D-Bus (Client/Server mode)?
+--------------------------------------------------------------
+
+Yes. If you compile RAUC using the ``--disable-service`` configure option, you
+will be able to compile RAUC without service mode and without D-Bus support::
+
+  ./configure --disable-service
+
+Then every call of the command line tool will be executed directly rather than
+being forwarded to the RAUC service process running on your machine.


### PR DESCRIPTION
The ability to use RAUC in non-D-Bus mode is not very well documented.
Thus we add at least a little hint in the FAQ to mention it despite we
do not want to encourage people to use RAUC that way if not mandatory.

Fixes #227

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>