### PR TITLE
src/install: actually handle readonly slots

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -321,6 +321,12 @@ static gboolean write_slot_start(int argc, char **argv)
 		goto out;
 	}
 
+	if (slot->readonly) {
+		g_printerr("Reject writing to readonly slot\n");
+		r_exit_status = 1;
+		goto out;
+	}
+
 	/* retrieve update handler */
 	update_handler = get_update_handler(image, slot, &ierror);
 	if (update_handler == NULL) {

--- a/test/install.c
+++ b/test/install.c
@@ -785,6 +785,67 @@ device=/dev/null\n\
 	g_hash_table_unref(tgrp);
 }
 
+static void test_install_image_readonly(void)
+{
+	gchar *tmpdir = NULL;
+	gchar* sysconfpath = NULL;
+	GBytes *data = NULL;
+	RaucManifest *rm = NULL;
+	GHashTable *tgrp = NULL;
+	GError *error = NULL;
+	GList *selected_images = NULL;
+
+#define MANIFEST "\
+[update]\n\
+compatible=foo\n\
+\n\
+[image.rescuefs]\n\
+filename=rootfs.img\n\
+"
+
+	const gchar *system_conf = "\
+[system]\n\
+compatible=foo\n\
+bootloader=barebox\n\
+\n\
+[slot.rootfs.0]\n\
+bootname=system0\n\
+device=/dev/null\n\
+\n\
+[slot.rescuefs.0]\n\
+device=/dev/null\n\
+readonly=true\n\
+";
+	tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+
+	sysconfpath = write_tmp_file(tmpdir, "test.conf", system_conf, NULL);
+	g_assert_nonnull(sysconfpath);
+
+	/* Set up context */
+	r_context_conf()->configpath = sysconfpath;
+	r_context_conf()->bootslot = g_strdup("system0");
+	r_context();
+
+	data = g_bytes_new_static(MANIFEST, sizeof(MANIFEST));
+	load_manifest_mem(data, &rm, &error);
+	g_assert_no_error(error);
+
+	determine_slot_states(&error);
+	g_assert_no_error(error);
+
+	tgrp = determine_target_install_group();
+	g_assert_nonnull(tgrp);
+
+	/* we expect the image mapping to fail as there is an image for a
+	 * readonly slot */
+	selected_images = get_install_images(rm, tgrp, &error);
+	g_assert_null(selected_images);
+	g_assert_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_FAILED);
+
+	g_hash_table_unref(tgrp);
+}
+
+
 static void test_install_image_variants(void)
 {
 	gchar *tmpdir = NULL;
@@ -1254,6 +1315,8 @@ int main(int argc, char *argv[])
 	g_test_add_func("/install/image-selection/redundant", test_install_image_selection);
 
 	g_test_add_func("/install/image-selection/non-matching", test_install_image_selection_no_matching_slot);
+
+	g_test_add_func("/install/image-selection/readonly", test_install_image_readonly);
 
 	g_test_add_func("/install/image-mapping/variants", test_install_image_variants);
 

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -394,6 +394,10 @@ test_expect_success "rauc write-slot invalid slot" "
   test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test.conf write-slot system0 /path/to/foo.img
 "
 
+test_expect_success "rauc write-slot readonly" "
+  test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test.conf write-slot rescue.0 $SHARNESS_TEST_DIRECTORY/install-content/appfs.img
+"
+
 echo "\
 [system]
 compatible=Test Config


### PR DESCRIPTION
So far we had the slot config booloan key `readonly` that allows to mark
a slot as being detected but not being writable by RAUC.

But, this option was only of informational nature and did not really
prevent from accidently installing content to a slot marked as readonly.

This patch now slightly extends the target slot selection algorithm to
actually care about the readonly flag by not adding the slot to the
hash map of target slots.

This way it will not be possible to install data to 'readonly' slots,
but they are still considered e.g. for parent slot detection, etc.
An extra test to assure this was added.

Fixes #161

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>