### PR TITLE
src/install: Not finding an appropriate target slot must be fatal

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -749,8 +749,8 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 
 	install_images = get_install_images(manifest, target_group, &ierror);
 	if (install_images == NULL) {
-		g_warning("%s", ierror->message);
-		g_clear_error(&ierror);
+		g_propagate_error(error, ierror);
+		goto early_out;
 	}
 
 	/* Allow overriding compatible check by hook */


### PR DESCRIPTION
Otherwise, a manifest containing an image for e.g. both a rootfs and an
appfs will install successfully also if the target system does not have
an appfs configured.

This is against the rule of RAUC of being unambiguous in the
installation description.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>