### PR TITLE
Strict parsing of RAUC config files

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -77,3 +77,7 @@ gboolean rm_tree(const gchar *path, GError **error);
  * @return An absolute path name, determined as described above, NULL if undeterminable
  */
 gchar *resolve_path(const gchar *basefile, gchar *path);
+
+
+gboolean check_remaining_groups(GKeyFile *key_file, GError **error);
+gboolean check_remaining_keys(GKeyFile *key_file, const gchar *groupname, GError **error);

--- a/include/utils.h
+++ b/include/utils.h
@@ -81,3 +81,9 @@ gchar *resolve_path(const gchar *basefile, gchar *path);
 
 gboolean check_remaining_groups(GKeyFile *key_file, GError **error);
 gboolean check_remaining_keys(GKeyFile *key_file, const gchar *groupname, GError **error);
+
+gchar * key_file_consume_string(
+		GKeyFile *key_file,
+		const gchar *group_name,
+		const gchar *key,
+		GError **error);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -91,13 +91,13 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	}
 
 	/* parse [system] section */
-	c->system_compatible = g_key_file_get_string(key_file, "system", "compatible", &ierror);
+	c->system_compatible = key_file_consume_string(key_file, "system", "compatible", &ierror);
 	if (!c->system_compatible) {
 		g_propagate_error(error, ierror);
 		res = FALSE;
 		goto free;
 	}
-	bootloader = g_key_file_get_string(key_file, "system", "bootloader", NULL);
+	bootloader = key_file_consume_string(key_file, "system", "bootloader", NULL);
 	if (!bootloader) {
 		g_set_error_literal(
 				error,
@@ -128,7 +128,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	}
 
 	if (g_strcmp0(c->system_bootloader, "barebox") == 0) {
-		c->system_bb_statename = g_key_file_get_string(key_file, "system", "barebox-statename", NULL);
+		c->system_bb_statename = key_file_consume_string(key_file, "system", "barebox-statename", NULL);
 	}
 
 	c->max_bundle_download_size = g_key_file_get_uint64(key_file, "system", "max-bundle-download-size", &ierror);
@@ -151,8 +151,9 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		res = FALSE;
 		goto free;
 	}
+	g_key_file_remove_key(key_file, "system", "max-bundle-download-size", NULL);
 
-	c->mount_prefix = g_key_file_get_string(key_file, "system", "mountprefix", NULL);
+	c->mount_prefix = key_file_consume_string(key_file, "system", "mountprefix", NULL);
 	if (!c->mount_prefix) {
 		g_debug("No mount prefix provided, using /mnt/rauc/ as default");
 		c->mount_prefix = g_strdup("/mnt/rauc/");
@@ -160,7 +161,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 
 	if (g_strcmp0(c->system_bootloader, "grub") == 0) {
 		c->grubenv_path = resolve_path(filename,
-				g_key_file_get_string(key_file, "system", "grubenv", NULL));
+				key_file_consume_string(key_file, "system", "grubenv", NULL));
 		if (!c->grubenv_path) {
 			g_debug("No grubenv path provided, using /boot/grub/grubenv as default");
 			c->grubenv_path = g_strdup("/boot/grub/grubenv");
@@ -176,6 +177,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		res = FALSE;
 		goto free;
 	}
+	g_key_file_remove_key(key_file, "system", "activate-installed", NULL);
 
 	c->system_variant_type = R_CONFIG_SYS_VARIANT_NONE;
 
@@ -189,11 +191,12 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		res = FALSE;
 		goto free;
 	}
+	g_key_file_remove_key(key_file, "system", "variant-dtb", NULL);
 	if (dtbvariant)
 		c->system_variant_type = R_CONFIG_SYS_VARIANT_DTB;
 
 	/* parse 'variant-file' key */
-	variant_data = g_key_file_get_string(key_file, "system", "variant-file", &ierror);
+	variant_data = key_file_consume_string(key_file, "system", "variant-file", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
 		variant_data = NULL;
 		g_clear_error(&ierror);
@@ -218,7 +221,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	}
 
 	/* parse 'variant-name' key */
-	variant_data = g_key_file_get_string(key_file, "system", "variant-name", &ierror);
+	variant_data = key_file_consume_string(key_file, "system", "variant-name", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
 		variant_data = NULL;
 		g_clear_error(&ierror);
@@ -243,32 +246,57 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	}
 
 	c->statusfile_path = resolve_path(filename,
-			g_key_file_get_string(key_file, "system", "statusfile", NULL));
+			key_file_consume_string(key_file, "system", "statusfile", NULL));
+	if (!check_remaining_keys(key_file, "system", &ierror)) {
+		g_propagate_error(error, ierror);
+		res = FALSE;
+		goto free;
+	}
 	g_key_file_remove_group(key_file, "system", NULL);
 
 	/* parse [keyring] section */
 	c->keyring_path = resolve_path(filename,
-			g_key_file_get_string(key_file, "keyring", "path", NULL));
+			key_file_consume_string(key_file, "keyring", "path", NULL));
+	if (!check_remaining_keys(key_file, "keyring", &ierror)) {
+		g_propagate_error(error, ierror);
+		res = FALSE;
+		goto free;
+	}
 	g_key_file_remove_group(key_file, "keyring", NULL);
 
 	/* parse [casync] section */
-	c->store_path = g_key_file_get_string(key_file, "casync", "storepath", NULL);
+	c->store_path = key_file_consume_string(key_file, "casync", "storepath", NULL);
+	if (!check_remaining_keys(key_file, "casync", &ierror)) {
+		g_propagate_error(error, ierror);
+		res = FALSE;
+		goto free;
+	}
 	g_key_file_remove_group(key_file, "casync", NULL);
 
 	/* parse [autoinstall] section */
 	c->autoinstall_path = resolve_path(filename,
-			g_key_file_get_string(key_file, "autoinstall", "path", NULL));
+			key_file_consume_string(key_file, "autoinstall", "path", NULL));
+	if (!check_remaining_keys(key_file, "autoinstall", &ierror)) {
+		g_propagate_error(error, ierror);
+		res = FALSE;
+		goto free;
+	}
 	g_key_file_remove_group(key_file, "autoinstall", NULL);
 
 	/* parse [handlers] section */
 	c->systeminfo_handler = resolve_path(filename,
-			g_key_file_get_string(key_file, "handlers", "system-info", NULL));
+			key_file_consume_string(key_file, "handlers", "system-info", NULL));
 
 	c->preinstall_handler = resolve_path(filename,
-			g_key_file_get_string(key_file, "handlers", "pre-install", NULL));
+			key_file_consume_string(key_file, "handlers", "pre-install", NULL));
 
 	c->postinstall_handler = resolve_path(filename,
-			g_key_file_get_string(key_file, "handlers", "post-install", NULL));
+			key_file_consume_string(key_file, "handlers", "post-install", NULL));
+	if (!check_remaining_keys(key_file, "handlers", &ierror)) {
+		g_propagate_error(error, ierror);
+		res = FALSE;
+		goto free;
+	}
 	g_key_file_remove_group(key_file, "handlers", NULL);
 
 	/* parse [slot.*.#] sections */
@@ -309,14 +337,14 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 			slot->name = g_intern_string(value);
 			g_free(value);
 
-			slot->description = g_key_file_get_string(key_file, groups[i], "description", NULL);
+			slot->description = key_file_consume_string(key_file, groups[i], "description", NULL);
 			if (!slot->description)
 				slot->description = g_strdup("");
 
 			slot->sclass = g_intern_string(groupsplit[1]);
 
 			value = resolve_path(filename,
-					g_key_file_get_string(key_file, groups[i], "device", &ierror));
+					key_file_consume_string(key_file, groups[i], "device", &ierror));
 			if (!value) {
 				g_propagate_error(error, ierror);
 				res = FALSE;
@@ -324,12 +352,12 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 			}
 			slot->device = value;
 
-			value = g_key_file_get_string(key_file, groups[i], "type", NULL);
+			value = key_file_consume_string(key_file, groups[i], "type", NULL);
 			if (!value)
 				value = g_strdup("raw");
 			slot->type = value;
 
-			value = g_key_file_get_string(key_file, groups[i], "bootname", NULL);
+			value = key_file_consume_string(key_file, groups[i], "bootname", NULL);
 			slot->bootname = value;
 
 			slot->readonly = g_key_file_get_boolean(key_file, groups[i], "readonly", &ierror);
@@ -341,6 +369,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 				res = FALSE;
 				goto free;
 			}
+			g_key_file_remove_key(key_file, groups[i], "readonly", NULL);
 
 			slot->force_install_same = g_key_file_get_boolean(key_file, groups[i], "force-install-same", &ierror);
 			if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
@@ -362,6 +391,8 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 				res = FALSE;
 				goto free;
 			}
+			g_key_file_remove_key(key_file, groups[i], "force-install-same", NULL);
+			g_key_file_remove_key(key_file, groups[i], "ignore-checksum", NULL);
 
 			g_hash_table_insert(slots, (gchar*)slot->name, slot);
 		}
@@ -376,7 +407,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		gchar* value;
 
 		group_name = g_strconcat(RAUC_SLOT_PREFIX ".", l->data, NULL);
-		value = g_key_file_get_string(key_file, group_name, "parent", NULL);
+		value = key_file_consume_string(key_file, group_name, "parent", NULL);
 		if (!value) {
 			g_key_file_remove_group(key_file, group_name, NULL);
 			continue;
@@ -395,6 +426,12 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 
 		((RaucSlot*)g_hash_table_lookup(slots, l->data))->parent = s;
 
+
+		if (!check_remaining_keys(key_file, group_name, &ierror)) {
+			g_propagate_error(error, ierror);
+			res = FALSE;
+			goto free;
+		}
 		g_key_file_remove_group(key_file, group_name, NULL);
 	}
 	g_list_free(slotlist);
@@ -473,20 +510,20 @@ static void status_file_get_slot_status(GKeyFile *key_file, const gchar *group, 
 	g_free(slotstatus->installed_timestamp);
 	g_free(slotstatus->activated_timestamp);
 
-	slotstatus->bundle_compatible = g_key_file_get_string(key_file, group, "bundle.compatible", NULL);
-	slotstatus->bundle_version = g_key_file_get_string(key_file, group, "bundle.version", NULL);
-	slotstatus->bundle_description = g_key_file_get_string(key_file, group, "bundle.description", NULL);
-	slotstatus->bundle_build = g_key_file_get_string(key_file, group, "bundle.build", NULL);
-	slotstatus->status = g_key_file_get_string(key_file, group, "status", NULL);
+	slotstatus->bundle_compatible = key_file_consume_string(key_file, group, "bundle.compatible", NULL);
+	slotstatus->bundle_version = key_file_consume_string(key_file, group, "bundle.version", NULL);
+	slotstatus->bundle_description = key_file_consume_string(key_file, group, "bundle.description", NULL);
+	slotstatus->bundle_build = key_file_consume_string(key_file, group, "bundle.build", NULL);
+	slotstatus->status = key_file_consume_string(key_file, group, "status", NULL);
 
-	digest = g_key_file_get_string(key_file, group, "sha256", NULL);
+	digest = key_file_consume_string(key_file, group, "sha256", NULL);
 	if (digest) {
 		slotstatus->checksum.type = G_CHECKSUM_SHA256;
 		slotstatus->checksum.digest = digest;
 		slotstatus->checksum.size = g_key_file_get_uint64(key_file, group, "size", NULL);
 	}
 
-	slotstatus->installed_timestamp = g_key_file_get_string(key_file, group, "installed.timestamp", NULL);
+	slotstatus->installed_timestamp = key_file_consume_string(key_file, group, "installed.timestamp", NULL);
 	count = g_key_file_get_uint64(key_file, group, "installed.count", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE)) {
 		g_message("Value of key \"installed.count\" in group [%s] "
@@ -501,7 +538,7 @@ static void status_file_get_slot_status(GKeyFile *key_file, const gchar *group, 
 	}
 	slotstatus->installed_count = count;
 
-	slotstatus->activated_timestamp = g_key_file_get_string(key_file, group, "activated.timestamp", NULL);
+	slotstatus->activated_timestamp = key_file_consume_string(key_file, group, "activated.timestamp", NULL);
 	count = g_key_file_get_uint64(key_file, group, "activated.count", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE)) {
 		g_message("Value of key \"activated.count\" in group [%s] "

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -21,7 +21,7 @@ static gboolean check_remaining_groups(GKeyFile *key_file, GError **error)
 
 	rem_groups = g_key_file_get_groups(key_file, &rem_num_groups);
 	if (rem_num_groups != 0) {
-		g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_PARSE_ERROR,
+		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
 				"Invalid group '[%s]'", rem_groups[0]);
 		return FALSE;
 	}
@@ -36,7 +36,7 @@ static gboolean check_remaining_keys(GKeyFile *key_file, const gchar *groupname,
 
 	rem_keys = g_key_file_get_keys(key_file, groupname, &rem_num_keys, NULL);
 	if (rem_keys && rem_num_keys != 0) {
-		g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_PARSE_ERROR,
+		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
 				"Invalid key '%s' in group '[%s]'", rem_keys[0],
 				groupname);
 		return FALSE;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -14,33 +14,6 @@ GQuark r_manifest_error_quark(void)
 	return g_quark_from_static_string("r_manifest_error_quark");
 }
 
-/* get string argument from key and remove key from key_file */
-static gchar * key_file_consume_string(
-		GKeyFile *key_file,
-		const gchar *group_name,
-		const gchar *key,
-		GError **error)
-{
-	gchar *result = NULL;
-	GError *ierror = NULL;
-
-	result = g_key_file_get_string(key_file, group_name, key, &ierror);
-	if (!result) {
-		g_propagate_error(error, ierror);
-		return NULL;
-	}
-
-	g_key_file_remove_key(key_file, group_name, key, NULL);
-
-	if (result[0] == '\0') {
-		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
-				"Missing value for key '%s'", key);
-		return NULL;
-	}
-
-	return result;
-}
-
 static gboolean parse_image(GKeyFile *key_file, const gchar *group, RaucImage **image, GError **error)
 {
 	g_autoptr(RaucImage) iimage = g_new0(RaucImage, 1);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -14,37 +14,6 @@ GQuark r_manifest_error_quark(void)
 	return g_quark_from_static_string("r_manifest_error_quark");
 }
 
-static gboolean check_remaining_groups(GKeyFile *key_file, GError **error)
-{
-	gsize rem_num_groups;
-	gchar **rem_groups;
-
-	rem_groups = g_key_file_get_groups(key_file, &rem_num_groups);
-	if (rem_num_groups != 0) {
-		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
-				"Invalid group '[%s]'", rem_groups[0]);
-		return FALSE;
-	}
-
-	return TRUE;
-}
-
-static gboolean check_remaining_keys(GKeyFile *key_file, const gchar *groupname, GError **error)
-{
-	gsize rem_num_keys;
-	gchar **rem_keys;
-
-	rem_keys = g_key_file_get_keys(key_file, groupname, &rem_num_keys, NULL);
-	if (rem_keys && rem_num_keys != 0) {
-		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
-				"Invalid key '%s' in group '[%s]'", rem_keys[0],
-				groupname);
-		return FALSE;
-	}
-
-	return TRUE;
-}
-
 /* get string argument from key and remove key from key_file */
 static gchar * manifest_consume_string(
 		GKeyFile *key_file,

--- a/src/utils.c
+++ b/src/utils.c
@@ -142,3 +142,31 @@ gboolean check_remaining_keys(GKeyFile *key_file, const gchar *groupname, GError
 
 	return TRUE;
 }
+
+/* get string argument from key and remove key from key_file */
+gchar * key_file_consume_string(
+		GKeyFile *key_file,
+		const gchar *group_name,
+		const gchar *key,
+		GError **error)
+{
+	gchar *result = NULL;
+	GError *ierror = NULL;
+
+	result = g_key_file_get_string(key_file, group_name, key, &ierror);
+	if (!result) {
+		g_propagate_error(error, ierror);
+		return NULL;
+	}
+
+	g_key_file_remove_key(key_file, group_name, key, NULL);
+
+	if (result[0] == '\0') {
+		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
+				"Missing value for key '%s'", key);
+		return NULL;
+	}
+
+	return result;
+}
+

--- a/src/utils.c
+++ b/src/utils.c
@@ -111,3 +111,34 @@ gchar *resolve_path(const gchar *basefile, gchar *path)
 	cwd = g_get_current_dir();
 	return g_build_filename(cwd, dir, path, NULL);
 }
+
+gboolean check_remaining_groups(GKeyFile *key_file, GError **error)
+{
+	gsize rem_num_groups;
+	gchar **rem_groups;
+
+	rem_groups = g_key_file_get_groups(key_file, &rem_num_groups);
+	if (rem_num_groups != 0) {
+		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
+				"Invalid group '[%s]'", rem_groups[0]);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+gboolean check_remaining_keys(GKeyFile *key_file, const gchar *groupname, GError **error)
+{
+	gsize rem_num_keys;
+	gchar **rem_keys;
+
+	rem_keys = g_key_file_get_keys(key_file, groupname, &rem_num_keys, NULL);
+	if (rem_keys && rem_num_keys != 0) {
+		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
+				"Invalid key '%s' in group '[%s]'", rem_keys[0],
+				groupname);
+		return FALSE;
+	}
+
+	return TRUE;
+}

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -177,6 +177,48 @@ ignore-checksum=true\n";
 	free_config(config);
 }
 
+static void config_file_invalid_items(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	RaucConfig *config;
+	GError *ierror = NULL;
+	gchar* pathname;
+
+	const gchar *unknown_group_cfg_file = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+\n\
+[unknown]\n\
+foo=bar\n\
+";
+	const gchar *unknown_key_cfg_file = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+foo=bar\n\
+";
+
+	pathname = write_tmp_file(fixture->tmpdir, "unknown_group.conf", unknown_group_cfg_file, NULL);
+	g_assert_nonnull(pathname);
+
+	g_assert_false(load_config(pathname, &config, &ierror));
+	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE);
+	g_assert_cmpstr(ierror->message, ==, "Invalid group '[unknown]'");
+	g_clear_error(&ierror);
+
+
+	pathname = write_tmp_file(fixture->tmpdir, "unknown_key.conf", unknown_key_cfg_file, NULL);
+	g_assert_nonnull(pathname);
+
+	g_assert_false(load_config(pathname, &config, &ierror));
+	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE);
+	g_assert_cmpstr(ierror->message, ==, "Invalid key 'foo' in group '[system]'");
+	g_clear_error(&ierror);
+}
+
 static void config_file_bootloaders(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
@@ -697,6 +739,9 @@ int main(int argc, char *argv[])
 
 	g_test_add("/config-file/full-config", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_full_config,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/invalid-items", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_invalid_items,
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/bootloaders", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_bootloaders,

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -510,7 +510,7 @@ compatible=FooCorp Super BarBazzer\n\
 bootloader=barebox\n\
 mountprefix=/mnt/myrauc/\n\
 variant-dtb=true\n\
-variant-name=";
+variant-name=xxx";
 
 	pathname = write_tmp_file(fixture->tmpdir, "no_variant.conf", cfg_file_no_variant, NULL);
 	g_assert_nonnull(pathname);

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -364,7 +364,7 @@ compatible=SuperBazzer\n\
 
 	data = g_bytes_new_static(MANIFEST3, sizeof(MANIFEST3));
 	g_assert_false(load_manifest_mem(data, &rm, &error));
-	g_assert_error(error, R_MANIFEST_ERROR, R_MANIFEST_EMPTY_STRING);
+	g_assert_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE);
 	g_clear_error(&error);
 	g_assert_null(rm);
 	g_clear_pointer(&data, g_byte_array_free);

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -371,14 +371,14 @@ compatible=SuperBazzer\n\
 
 	data = g_bytes_new_static(MANIFEST4, sizeof(MANIFEST4));
 	g_assert_false(load_manifest_mem(data, &rm, &error));
-	g_assert_error(error, R_MANIFEST_ERROR, R_MANIFEST_PARSE_ERROR);
+	g_assert_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE);
 	g_clear_error(&error);
 	g_assert_null(rm);
 	g_clear_pointer(&data, g_byte_array_free);
 
 	data = g_bytes_new_static(MANIFEST5, sizeof(MANIFEST5));
 	g_assert_false(load_manifest_mem(data, &rm, &error));
-	g_assert_error(error, R_MANIFEST_ERROR, R_MANIFEST_PARSE_ERROR);
+	g_assert_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE);
 	g_clear_error(&error);
 	g_assert_null(rm);
 	g_clear_pointer(&data, g_byte_array_free);


### PR DESCRIPTION
This Fixes #225 by applying the same checking for inavlid groups and keys as we do for bundle manifests already.