### PR TITLE
Add Support for Verifying Signature During Bundle Creation

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -31,7 +31,7 @@ sub-command:
 
 .. code-block:: sh
 
-  rauc bundle --cert=<certfile> --key=<keyfile> <input-dir> <output-file>
+  rauc bundle --cert=<certfile> --key=<keyfile> --keyring=<keyringfile> <input-dir> <output-file>
 
 Where ``<input-dir>`` must be a directory containing all images and scripts the
 bundle should include, as well as a manifest file ``manifest.raucm`` that
@@ -45,6 +45,13 @@ Instead of the ``certfile`` and ``keyfile`` arguments, PKCS#11 URLs such as
 ``'pkcs11:token=rauc;object=autobuilder-1'`` can be used to avoid storing
 sensitive key material as files (see :ref:`PKCS#11 Support <pkcs11-support>`
 for details).
+
+While the ``--cert`` and ``--key`` argument are mandatory for signing and must
+provide the certificate and private key that should be used for creating the
+signature, the ``--keyring`` argument is optional and (if given) will be used
+for verifying the trust chain validity of the signature after creation.
+Note that this is very useful to prevent from signing with obsolete
+certificates, etc.
 
 Obtaining Bundle Information
 ----------------------------

--- a/include/signature.h
+++ b/include/signature.h
@@ -3,6 +3,9 @@
 #include <openssl/cms.h>
 #include <glib.h>
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(CMS_ContentInfo, CMS_ContentInfo_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(X509_STORE, X509_STORE_free)
+
 #define R_SIGNATURE_ERROR r_signature_error_quark()
 GQuark r_signature_error_quark(void);
 

--- a/include/signature.h
+++ b/include/signature.h
@@ -137,8 +137,9 @@ gchar* print_cert_chain(STACK_OF(X509) *verified_chain);
  *
  * @param cms CMS_ContentInfo used in cms_verify()
  * @param store Store used in cms_verify()
- * @param verified_chain Return location for the verification chain, or NULL
- * @param error return location for a GError, or NULL
+ * @param[out] verified_chain Return location for the verification chain, or NULL
+ *                            [transfer full]
+ * @param[out] error return location for a GError, or NULL
  *
  * @return TRUE if succeeded, FALSE if failed
  */

--- a/src/signature.c
+++ b/src/signature.c
@@ -616,7 +616,7 @@ gboolean cms_get_cert_chain(CMS_ContentInfo *cms, X509_STORE *store, STACK_OF(X5
 	/* The first element in the chain must be the signer certificate */
 	g_assert(X509_cmp(sk_X509_value(signers, 0), sk_X509_value(*verified_chain, 0)) == 0);
 
-	g_debug("Got %d chain elements", sk_X509_num(*verified_chain));
+	g_debug("Got %d elements for trust chain", sk_X509_num(*verified_chain));
 
 	res = TRUE;
 out:

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -427,6 +427,48 @@ test_expect_success "rauc verfiy with 'use-bundle-signing-time': invalid signing
   rm out.raucb
 "
 
+test_expect_success "rauc sign bundle with expired certificate" "
+  test_must_fail faketime "2019-07-02" \
+  rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
+    bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
+    test ! -f out.raucb
+"
+
+test_expect_success "rauc sign bundle with not yet valid certificate" "
+  test_must_fail faketime "2017-01-01" \
+  rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
+    bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
+    test ! -f out.raucb
+"
+
+test_expect_success "rauc sign bundle with almost expired certificate" "
+  faketime "2019-06-15" \
+  rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
+    bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
+    test -f out.raucb &&
+    rm out.raucb
+"
+
+test_expect_success "rauc sign bundle with valid certificate" "
+  faketime "2019-01-01" \
+  rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
+    bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
+    test -f out.raucb &&
+    rm out.raucb
+"
+
 test_expect_success CASYNC "rauc convert" "
   rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \

--- a/test/signature.c
+++ b/test/signature.c
@@ -280,8 +280,7 @@ static void signature_intermediate(void)
 	/* We sign with the release key */
 	r_context_conf()->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
 	r_context_conf()->keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
-	/* We verify against the provisioning CA */
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/provisioning-ca.pem");
+	r_context_conf()->keyringpath = NULL;
 
 	sig = cms_sign(content,
 			r_context()->certpath,
@@ -291,6 +290,8 @@ static void signature_intermediate(void)
 	g_assert_nonnull(sig);
 	g_assert_no_error(error);
 
+	/* We verify against the provisioning CA */
+	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/provisioning-ca.pem");
 	/* Without explicit intermediate certificate, this must fail */
 	g_assert_false(cms_verify(content, sig, &cms, &store, &error));
 	g_assert_error(error, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
@@ -346,8 +347,7 @@ static void signature_intermediate_file(void)
 	/* We sign with the release key */
 	r_context_conf()->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
 	r_context_conf()->keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
-	/* We verify against the provisioning CA */
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/provisioning-ca.pem");
+	r_context_conf()->keyringpath = NULL;
 
 	sig = cms_sign_file("test/openssl-ca/manifest",
 			r_context()->certpath,
@@ -357,6 +357,8 @@ static void signature_intermediate_file(void)
 	g_assert_nonnull(sig);
 	g_assert_no_error(error);
 
+	/* We verify against the provisioning CA */
+	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/provisioning-ca.pem");
 	/* Without explicit intermediate certificate, this must fail */
 	g_assert_false(cms_verify_file("test/openssl-ca/manifest", sig, 0, &cms, &store, &error));
 	g_assert_error(error, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);


### PR DESCRIPTION
To detect signing errors and expired certificates early, this series adds trust chain verificiation during creation of a bundle if the  `--keyring` argument is provided or a keyring configured.

Additionally a check is implemented to warn the signer about using certificates in the chain that will expire within the period of a month.