### PR TITLE
.travis.yml: re-add missing cpp-coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 compiler: gcc-7
 dist: xenial
 before_install:
+  - sudo pip install --upgrade cpp-coveralls
   # travis-ci/travis-ci#9037: remove mongodb because the repository key is expired and we don't need it
   - sudo rm -fv /etc/apt/sources.list.d/mongodb*
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
The line installing it was unintentionally deleted in
af015f699d8b1e02ce0068787056d4f462a6e011. Now we re-add it to fix coveralls notification.
