### PR TITLE
build: make eMMC boot partition support optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,6 @@ librauc_la_SOURCES = \
 	src/checksum.c \
 	src/config_file.c \
 	src/context.c \
-	src/emmc.c \
 	src/install.c \
 	src/manifest.c \
 	src/mark.c \
@@ -62,6 +61,10 @@ librauc_la_SOURCES = \
 	include/signature.h \
 	include/update_handler.h \
 	include/utils.h
+
+if WANT_EMMC_BOOT_SUPPORT
+librauc_la_SOURCES += src/emmc.c
+endif
 
 if WANT_NETWORK
 librauc_la_SOURCES += src/network.c include/network.h

--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,12 @@ AC_SUBST(DBUS_SYSTEMSERVICEDIR)
 
 # Checks for header files.
 
+AC_CHECK_HEADER([linux/mmc/ioctl.h],
+	AC_DEFINE([ENABLE_EMMC_BOOT_SUPPORT], [1], [Define to 1 to enable eMMC boot support]),
+	AC_DEFINE([ENABLE_EMMC_BOOT_SUPPORT], [0]))
+
+AM_CONDITIONAL([WANT_EMMC_BOOT_SUPPORT], [test x$ac_cv_header_linux_mmc_ioctl_h != xno])
+
 # Checks for typedefs, structures, and compiler characteristics.
 
 # Checks for library functions.

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -57,6 +57,7 @@ out:
 	return outstream;
 }
 
+#if ENABLE_EMMC_BOOT_SUPPORT == 1
 static gboolean clear_slot(RaucSlot *slot, GError **error)
 {
 	GError *ierror = NULL;
@@ -98,6 +99,7 @@ static gboolean clear_slot(RaucSlot *slot, GError **error)
 out:
 	return res;
 }
+#endif
 
 static gboolean ubifs_ioctl(RaucImage *image, int fd, GError **error)
 {
@@ -1076,6 +1078,7 @@ out:
 	return res;
 }
 
+#if ENABLE_EMMC_BOOT_SUPPORT == 1
 static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, const gchar *hook_name, GError **error)
 {
 
@@ -1232,6 +1235,7 @@ out:
 
 	return res;
 }
+#endif
 
 static gboolean img_to_raw_handler(RaucImage *image, RaucSlot *dest_slot, const gchar *hook_name, GError **error)
 {
@@ -1316,7 +1320,9 @@ RaucUpdatePair updatepairs[] = {
 	{"*.img", "nand", img_to_nand_handler},
 	{"*.img", "ubivol", img_to_ubivol_handler},
 	{"*.squashfs", "ubivol", img_to_ubivol_handler},
+#if ENABLE_EMMC_BOOT_SUPPORT == 1
 	{"*.img", "boot-emmc", img_to_boot_emmc_handler},
+#endif
 	{"*.img", "*", img_to_raw_handler}, /* fallback */
 	{0}
 };


### PR DESCRIPTION
The eMMC boot partition support, added in commit
ea5cc7ff606c65536da218bd1ef6d0ca279c9b17 ("src/update_handler: add
support for updating eMMC boot partitions"), requires
<linux/mmc/ioctl.h>, only available starting from kernel headers 3.0.

Even though it is pretty likely that people are going to use Linux >=
3.0 on their embedded systems these days, RAUC also needs to be built
natively on the build machine to produce update artifacts, and the
build machine is sometimes using an ancient Linux system, especially
in an enterprise contexts.

In order to make sure that RAUC builds fine in this context, this
commit makes the eMMC boot partition support optional, by verifying
the availability of <linux/mmc/ioctl.h>.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>