### PR TITLE
update: add squashfs to raw handling.

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1306,6 +1306,7 @@ RaucUpdatePair updatepairs[] = {
 	{"*.ext4", "ext4", img_to_fs_handler},
 	{"*.ext4", "raw", img_to_raw_handler},
 	{"*.vfat", "raw", img_to_raw_handler},
+	{"*.squashfs", "raw", img_to_raw_handler},
 	{"*.vfat", "vfat", img_to_fs_handler},
 	{"*.tar*", "ext4", archive_to_ext4_handler},
 	{"*.catar", "ext4", archive_to_ext4_handler},


### PR DESCRIPTION
My image is formatted as `squashfs` and at first I could not perform an update via `rauc install`.
With the help of this changeset, setting `RAUC_IMAGE_FSTYPE=squashfs` and setting the slots type to `raw`, it was then possible to update the slot.

Do you have any experience using `casync` to update a `squashfs`-based slot ?
