### PR TITLE
Bootloader Interface Fixes, Enhancements and Documentation

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -688,7 +688,7 @@ static gboolean uboot_set_primary(RaucSlot *slot, GError **error)
 
 	res = uboot_env_get("BOOT_ORDER", &order_current, &ierror);
 	if (!res) {
-		g_message("Unable to obtain BOOT_ORDER, using defaults");
+		g_message("Unable to obtain BOOT_ORDER (%s), using defaults", ierror->message);
 		g_clear_error(&ierror);
 
 		order_current = bootchooser_order_primay(slot);

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -56,7 +56,7 @@ typedef struct {
 
 static gboolean barebox_state_get(const gchar* bootname, BareboxSlotState *bb_state, GError **error)
 {
-	GSubprocess *sub;
+	g_autoptr(GSubprocess) sub = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	GInputStream *instream;
@@ -151,7 +151,7 @@ out:
 /* names: list of gchar, values: list of gint */
 static gboolean barebox_state_set(GPtrArray *pairs, GError **error)
 {
-	GSubprocess *sub;
+	g_autoptr(GSubprocess) sub = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(2*pairs->len+2, g_free);
@@ -353,7 +353,7 @@ out:
 
 static gboolean grub_env_set(GPtrArray *pairs, GError **error)
 {
-	GSubprocess *sub;
+	g_autoptr(GSubprocess) sub = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
@@ -454,7 +454,7 @@ out:
 
 static gboolean uboot_env_get(const gchar *key, GString **value, GError **error)
 {
-	GSubprocess *sub;
+	g_autoptr(GSubprocess) sub = NULL;
 	GError *ierror = NULL;
 	g_autoptr(GBytes) stdout_buf = NULL;
 	const char *data;
@@ -519,7 +519,7 @@ out:
 
 static gboolean uboot_env_set(const gchar *key, const gchar *value, GError **error)
 {
-	GSubprocess *sub;
+	g_autoptr(GSubprocess) sub = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
@@ -734,7 +734,7 @@ typedef struct {
 
 static gboolean efi_bootorder_set(gchar *order, GError **error)
 {
-	GSubprocess *sub;
+	g_autoptr(GSubprocess) sub = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
@@ -769,7 +769,7 @@ out:
 
 static gboolean efi_set_bootnext(gchar *bootnumber, GError **error)
 {
-	GSubprocess *sub;
+	g_autoptr(GSubprocess) sub = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
@@ -831,7 +831,7 @@ static efi_bootentry* get_efi_entry_by_bootnum(GList *entries, const gchar *boot
  */
 static gboolean efi_bootorder_get(GList **bootorder_entries, GList **all_entries, efi_bootentry **bootnext, GError **error)
 {
-	GSubprocess *sub = NULL;
+	g_autoptr(GSubprocess) sub = NULL;
 	GError *ierror = NULL;
 	g_autoptr(GBytes) stdout_buf = NULL;
 	gboolean res = FALSE;

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -398,7 +398,7 @@ out:
 /* Set slot status values */
 static gboolean grub_set_state(RaucSlot *slot, gboolean good, GError **error)
 {
-	g_autoptr(GPtrArray) pairs = g_ptr_array_new_full(10, g_free);
+	g_autoptr(GPtrArray) pairs = g_ptr_array_new_full(6, g_free);
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
@@ -427,7 +427,7 @@ out:
 /* Set slot as primary boot slot */
 static gboolean grub_set_primary(RaucSlot *slot, GError **error)
 {
-	g_autoptr(GPtrArray) pairs = g_ptr_array_new_full(10, g_free);
+	g_autoptr(GPtrArray) pairs = g_ptr_array_new_full(7, g_free);
 	g_autoptr(GString) order = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -13,14 +13,14 @@ GQuark r_bootchooser_error_quark(void)
 }
 
 #define BAREBOX_STATE_NAME "barebox-state"
-#define BAREBOX_STATE_DEFAULT_ATTEMPS	3
-#define BAREBOX_STATE_ATTEMPS_PRIMARY	3
+#define BAREBOX_STATE_DEFAULT_ATTEMPTS	3
+#define BAREBOX_STATE_ATTEMPTS_PRIMARY	3
 #define BAREBOX_STATE_DEFAULT_PRIORITY	10
 #define BAREBOX_STATE_PRIORITY_PRIMARY	20
 #define UBOOT_FWSETENV_NAME "fw_setenv"
 #define UBOOT_FWPRINTENV_NAME "fw_printenv"
-#define UBOOT_DEFAULT_ATTEMPS		"3"
-#define UBOOT_ATTEMPS_PRIMARY		"3"
+#define UBOOT_DEFAULT_ATTEMPTS		"3"
+#define UBOOT_ATTEMPTS_PRIMARY		"3"
 #define EFIBOOTMGR_NAME "efibootmgr"
 #define GRUB_EDITENV "grub-editenv"
 
@@ -202,7 +202,7 @@ static gboolean barebox_set_state(RaucSlot *slot, gboolean good, GError **error)
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	if (good) {
-		attempts = BAREBOX_STATE_DEFAULT_ATTEMPS;
+		attempts = BAREBOX_STATE_DEFAULT_ATTEMPTS;
 	} else {
 		/* for marking bad, also set priority to 0 */
 		attempts = 0;
@@ -323,7 +323,7 @@ static gboolean barebox_set_primary(RaucSlot *slot, GError **error)
 	}
 
 	g_ptr_array_add(pairs, g_strdup_printf(BOOTSTATE_PREFIX ".%s.remaining_attempts=%i",
-					slot->bootname, BAREBOX_STATE_ATTEMPS_PRIMARY));
+					slot->bootname, BAREBOX_STATE_ATTEMPTS_PRIMARY));
 
 	if (!barebox_state_set(pairs, &ierror)) {
 		g_propagate_error(error, ierror);
@@ -608,7 +608,7 @@ set_left:
 
 	key = g_strdup_printf("BOOT_%s_LEFT", slot->bootname);
 
-	if (!uboot_env_set(key, good ? UBOOT_DEFAULT_ATTEMPS : "0", &ierror)) {
+	if (!uboot_env_set(key, good ? UBOOT_DEFAULT_ATTEMPTS : "0", &ierror)) {
 		g_propagate_error(error, ierror);
 		return FALSE;
 	}
@@ -705,7 +705,7 @@ static gboolean uboot_set_primary(RaucSlot *slot, GError **error)
 
 	key = g_strdup_printf("BOOT_%s_LEFT", slot->bootname);
 
-	if (!uboot_env_set(key, UBOOT_ATTEMPS_PRIMARY, &ierror)) {
+	if (!uboot_env_set(key, UBOOT_ATTEMPTS_PRIMARY, &ierror)) {
 		g_propagate_error(error, ierror);
 		return FALSE;
 	}

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -24,12 +24,12 @@ GQuark r_bootchooser_error_quark(void)
 
 static GString *bootchooser_order_primay(RaucSlot *slot)
 {
-	GString *order = g_string_sized_new(10);
+	GString *order = NULL;
 	GList *slots;
 
 	g_return_val_if_fail(slot, NULL);
 
-	g_string_append(order, slot->bootname);
+	order = g_string_new(slot->bootname);
 
 	/* Iterate over class members */
 	slots = g_hash_table_get_values(r_context()->config->slots);
@@ -673,7 +673,7 @@ static RaucSlot* uboot_get_primary(GError **error)
 /* Set slot as primary boot slot */
 static gboolean uboot_set_primary(RaucSlot *slot, GError **error)
 {
-	g_autoptr(GString) order_new = g_string_sized_new(10);
+	g_autoptr(GString) order_new = NULL;
 	g_autoptr(GString) order_current = NULL;
 	g_auto(GStrv) bootnames = NULL;
 	GError *ierror = NULL;
@@ -684,7 +684,7 @@ static gboolean uboot_set_primary(RaucSlot *slot, GError **error)
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* Add updated slot as first entry in new boot order */
-	g_string_append(order_new, slot->bootname);
+	order_new = g_string_new(slot->bootname);
 
 	res = uboot_env_get("BOOT_ORDER", &order_current, &ierror);
 	if (!res) {

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -964,7 +964,7 @@ static gboolean efi_set_temp_primary(RaucSlot *slot, GError **error)
 
 	res = efi_bootorder_get(NULL, &entries, NULL, &ierror);
 	if (!res) {
-		g_propagate_prefixed_error(error, ierror, "Obtaining bootorder failed: ");
+		g_propagate_error(error, ierror);
 		goto out;
 	}
 
@@ -1015,7 +1015,7 @@ static gboolean efi_modify_persistent_bootorder(RaucSlot *slot, gboolean prepend
 
 	res = efi_bootorder_get(&entries, &all_entries, NULL, &ierror);
 	if (!res) {
-		g_propagate_prefixed_error(error, ierror, "Modifying bootorder failed: ");
+		g_propagate_error(error, ierror);
 		goto out;
 	}
 

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -19,6 +19,8 @@ GQuark r_bootchooser_error_quark(void)
 #define BAREBOX_STATE_PRIORITY_PRIMARY	20
 #define UBOOT_FWSETENV_NAME "fw_setenv"
 #define UBOOT_FWPRINTENV_NAME "fw_printenv"
+#define UBOOT_DEFAULT_ATTEMPS		"3"
+#define UBOOT_ATTEMPS_PRIMARY		"3"
 #define EFIBOOTMGR_NAME "efibootmgr"
 #define GRUB_EDITENV "grub-editenv"
 
@@ -569,7 +571,7 @@ static gboolean uboot_set_state(RaucSlot *slot, gboolean good, GError **error)
 
 	key = g_strdup_printf("BOOT_%s_LEFT", slot->bootname);
 
-	if (!uboot_env_set(key, good ? "3" : "0", &ierror)) {
+	if (!uboot_env_set(key, good ? UBOOT_DEFAULT_ATTEMPS : "0", &ierror)) {
 		g_propagate_error(error, ierror);
 		return FALSE;
 	}
@@ -666,7 +668,7 @@ static gboolean uboot_set_primary(RaucSlot *slot, GError **error)
 
 	key = g_strdup_printf("BOOT_%s_LEFT", slot->bootname);
 
-	if (!uboot_env_set(key, "3", &ierror)) {
+	if (!uboot_env_set(key, UBOOT_ATTEMPS_PRIMARY, &ierror)) {
 		g_propagate_error(error, ierror);
 		return FALSE;
 	}

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -362,7 +362,7 @@ BOOT_B_LEFT=3\n\
 	/* check rootfs.0 is marked bad (BOOT_A_LEFT set to 0) */
 	g_assert_true(r_boot_set_state(rootfs0, FALSE, NULL));
 	g_assert_true(test_uboot_post_state("\
-BOOT_ORDER=A B R\n\
+BOOT_ORDER=B R\n\
 BOOT_A_LEFT=0\n\
 BOOT_B_LEFT=3\n\
 "));
@@ -373,7 +373,7 @@ BOOT_B_LEFT=3\n\
 	/* check rootfs.0 is marked good again (BOOT_A_LEFT reset to 3) */
 	g_assert_true(r_boot_set_state(rootfs0, TRUE, NULL));
 	g_assert_true(test_uboot_post_state("\
-BOOT_ORDER=A B R\n\
+BOOT_ORDER=B R\n\
 BOOT_A_LEFT=3\n\
 BOOT_B_LEFT=3\n\
 "));


### PR DESCRIPTION
This is a collection of several patches related to the bootchooser.c code as a result of originally only trying to add `BOOT_ORDER` handling to the U-Boot implementation.

As some of the design decisions of bootloader interaction are not that intuitive, I decided to add a new section to the reference part of the RAUC documentation for at least bringing a little light into the darkness.

The return handling fixes are part of the rework I promised (but still owe) @michaelolbrich when he acknowledged the g_autoptr patches of @pH5. 