### PR TITLE
export slot type to handlers and hooks

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -416,6 +416,9 @@ variables.
   ``RAUC_SLOT_CLASS_<N>``
     The class of slot number <N>, e.g. ``rootfs``
 
+  ``RAUC_SLOT_TYPE_<N>``
+    The type of slot number <N>, e.g. ``raw``
+
   ``RAUC_SLOT_DEVICE_<N>``
     The device path of slot number <N>, e.g. ``/dev/sda1``
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -362,6 +362,9 @@ The following environment variables will be passed to the hook executable:
   ``RAUC_SLOT_CLASS``
     The class of the currently installed slot
 
+  ``RAUC_SLOT_TYPE``
+    The type of the currently installed slot
+
   ``RAUC_SLOT_DEVICE``
     The device of the currently installed slot
 

--- a/src/install.c
+++ b/src/install.c
@@ -567,6 +567,10 @@ static void prepare_environment(GSubprocessLauncher *launcher, gchar *update_sou
 		g_subprocess_launcher_setenv(launcher, varname, slot->sclass, TRUE);
 		g_clear_pointer(&varname, g_free);
 
+		varname = g_strdup_printf("RAUC_SLOT_TYPE_%i", slotcnt);
+		g_subprocess_launcher_setenv(launcher, varname, slot->type, TRUE);
+		g_clear_pointer(&varname, g_free);
+
 		varname = g_strdup_printf("RAUC_SLOT_DEVICE_%i", slotcnt);
 		g_subprocess_launcher_setenv(launcher, varname, slot->device, TRUE);
 		g_clear_pointer(&varname, g_free);

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -650,6 +650,7 @@ static gboolean mount_and_run_slot_hook(const gchar *hook_name, const gchar *hoo
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	g_assert_nonnull(hook_name);
 	g_assert_nonnull(hook_cmd);
 
@@ -672,7 +673,7 @@ static gboolean mount_and_run_slot_hook(const gchar *hook_name, const gchar *hoo
 	g_message("Unmounting slot %s", slot->device);
 	if (!r_umount_slot(slot, &ierror)) {
 		res = FALSE;
-		if (error) {
+		if (error && *error) {
 			/* the slot hook error is more relevant here */
 			g_warning("Ignoring umount error after slot hook error: %s", ierror->message);
 			g_clear_error(&ierror);
@@ -794,6 +795,8 @@ static gboolean archive_to_ubifs_handler(RaucImage *image, RaucSlot *dest_slot, 
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
 	/* run slot pre install hook if enabled */
 	if (hook_name && image->hooks.pre_install) {
 		res = mount_and_run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, dest_slot, &ierror);
@@ -841,7 +844,7 @@ unmount_out:
 	g_message("Unmounting ubifs slot %s", dest_slot->device);
 	if (!r_umount_slot(dest_slot, &ierror)) {
 		res = FALSE;
-		if (error) {
+		if (error && *error) {
 			/* the previous error is more relevant here */
 			g_warning("Ignoring umount error after previous error: %s", ierror->message);
 			g_clear_error(&ierror);
@@ -858,6 +861,8 @@ static gboolean archive_to_ext4_handler(RaucImage *image, RaucSlot *dest_slot, c
 {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
+
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* run slot pre install hook if enabled */
 	if (hook_name && image->hooks.pre_install) {
@@ -906,7 +911,7 @@ unmount_out:
 	g_message("Unmounting ext4 slot %s", dest_slot->device);
 	if (!r_umount_slot(dest_slot, &ierror)) {
 		res = FALSE;
-		if (error) {
+		if (error && *error) {
 			/* the previous error is more relevant here */
 			g_warning("Ignoring umount error after previous error: %s", ierror->message);
 			g_clear_error(&ierror);
@@ -923,6 +928,8 @@ static gboolean archive_to_vfat_handler(RaucImage *image, RaucSlot *dest_slot, c
 {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
+
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* run slot pre install hook if enabled */
 	if (hook_name && image->hooks.pre_install) {
@@ -971,7 +978,7 @@ unmount_out:
 	g_message("Unmounting vfat slot %s", dest_slot->device);
 	if (!r_umount_slot(dest_slot, &ierror)) {
 		res = FALSE;
-		if (error) {
+		if (error && *error) {
 			/* the previous error is more relevant here */
 			g_warning("Ignoring umount error after previous error: %s", ierror->message);
 			g_clear_error(&ierror);

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1029,7 +1029,6 @@ out:
 
 static gboolean img_to_fs_handler(RaucImage *image, RaucSlot *dest_slot, const gchar *hook_name, GError **error)
 {
-	g_autoptr(GOutputStream) outstream = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -594,6 +594,7 @@ static gboolean run_slot_hook(const gchar *hook_name, const gchar *hook_cmd, Rau
 
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_NAME", slot->name, TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_CLASS", slot->sclass, TRUE);
+	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_TYPE", slot->type, TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_DEVICE", slot->device, TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_BOOTNAME", slot->bootname ?: "", TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_PARENT", slot->parent ? slot->parent->name : "", TRUE);

--- a/test/install-content/hook.sh
+++ b/test/install-content/hook.sh
@@ -20,6 +20,7 @@ case "$1" in
 	slot-post-install)
 		test -n "$RAUC_SLOT_NAME" || die_error "missing RAUC_SLOT_NAME"
 		test -n "$RAUC_SLOT_CLASS" || die_error "missing RAUC_SLOT_CLASS"
+		test -n "$RAUC_SLOT_TYPE" || die_error "missing RAUC_SLOT_TYPE"
 
 		# only rootfs needs to be handled
 		test "$RAUC_SLOT_CLASS" = "rootfs" || exit 0
@@ -32,6 +33,7 @@ case "$1" in
 	slot-install)
 		test -n "$RAUC_SLOT_NAME" || die_error "missing RAUC_SLOT_NAME"
 		test -n "$RAUC_SLOT_CLASS" || die_error "missing RAUC_SLOT_CLASS"
+		test -n "$RAUC_SLOT_TYPE" || die_error "missing RAUC_SLOT_TYPE"
 
 		echo "RAUC_IMAGE_PATH: $RAUC_IMAGE_PATH"
 		echo "RAUC_SLOT_DEVICE: $RAUC_SLOT_DEVICE"


### PR DESCRIPTION
I wrote a post-install handler and was a little surprised to find that there was not RAUC_SLOT_TYPE_x variables. While figuring out where to add such logic I stumbled on some unrelated stuff; I'm happy to make those into a separate PR if requested.