### PR TITLE
allow mounted devices when using custom install handler

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -240,6 +240,11 @@ hierarchical separator.
   active slots, so that the inactive one can be selected as the update target.
   The parent slot is referenced using the form ``<slot-class>.<idx>``.
 
+``allow-mounted=<true/false>``
+  Setting this entry ``true`` tells RAUC that the slot may be updated even if
+  it is already mounted.
+  Such a slot can be updated only by a custom install hook.
+
 ``readonly=<true/false>``
   Marks the slot as existing but not updatable. May be used for sanity checking
   or informative purpose. A ``readonly`` slot cannot be a target slot.

--- a/include/slot.h
+++ b/include/slot.h
@@ -37,6 +37,8 @@ typedef struct _RaucSlot {
 	gchar *type;
 	/** the name this slot is known to the bootloader */
 	gchar *bootname;
+	/** flag to indicate that this slot can be updated even if already mounted */
+	gboolean allow_mounted;
 	/** flag indicating if the slot is updatable */
 	gboolean readonly;
 	/** flag indicating if slot skipping optimization should be used */

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -354,6 +354,16 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 			value = key_file_consume_string(key_file, groups[i], "bootname", NULL);
 			slot->bootname = value;
 
+			slot->allow_mounted = g_key_file_get_boolean(key_file, groups[i], "allow-mounted", &ierror);
+			if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+				slot->allow_mounted = FALSE;
+				g_clear_error(&ierror);
+			} else if (ierror) {
+				g_propagate_error(error, ierror);
+				res = FALSE;
+				goto free;
+			}
+
 			slot->readonly = g_key_file_get_boolean(key_file, groups[i], "readonly", &ierror);
 			if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
 				slot->readonly = FALSE;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -674,6 +674,8 @@ static gboolean run_slot_hook(const gchar *hook_name, const gchar *hook_cmd, Rau
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_PARENT", slot->parent ? slot->parent->name : "", TRUE);
 	if (slot->mount_point) {
 		g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_MOUNT_POINT", slot->mount_point, TRUE);
+	} else if (slot->ext_mount_point) {
+		g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_MOUNT_POINT", slot->ext_mount_point, TRUE);
 	}
 	if (image) {
 		g_subprocess_launcher_setenv(launcher, "RAUC_IMAGE_NAME", image->filename, TRUE);

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -285,14 +285,25 @@ parent=invalid\n\
 	g_clear_error(&ierror);
 }
 
-static void config_file_typo_in_boolean_readonly_key(ConfigFileFixture *fixture,
-		gconstpointer user_data)
+static void config_file_typo(ConfigFileFixture *fixture, const gchar *cfg_file)
 {
 	RaucConfig *config;
 	GError *ierror = NULL;
 	gchar* pathname;
 
-	const gchar *cfg_file = "\
+	pathname = write_tmp_file(fixture->tmpdir, "typo.conf", cfg_file, NULL);
+	g_assert_nonnull(pathname);
+
+	g_assert_false(load_config(pathname, &config, &ierror));
+	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE);
+	g_assert_null(config);
+	g_clear_error(&ierror);
+}
+
+static void config_file_typo_in_boolean_readonly_key(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	config_file_typo(fixture, "\
 [system]\n\
 compatible=FooCorp Super BarBazzer\n\
 bootloader=barebox\n\
@@ -303,25 +314,13 @@ description=Rescue partition\n\
 device=/dev/mtd4\n\
 type=raw\n\
 bootname=factory0\n\
-readonly=typo\n";
-
-
-	pathname = write_tmp_file(fixture->tmpdir, "invalid_bootloader.conf", cfg_file, NULL);
-	g_assert_nonnull(pathname);
-
-	g_assert_false(load_config(pathname, &config, &ierror));
-	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE);
-	g_clear_error(&ierror);
+readonly=typo\n");
 }
 
 static void config_file_typo_in_boolean_install_same_key(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucConfig *config;
-	GError *ierror = NULL;
-	gchar* pathname;
-
-	const gchar *cfg_file = "\
+	config_file_typo(fixture, "\
 [system]\n\
 compatible=FooCorp Super BarBazzer\n\
 bootloader=barebox\n\
@@ -332,25 +331,13 @@ description=Rescue partition\n\
 device=/dev/mtd4\n\
 type=raw\n\
 bootname=factory0\n\
-install-same=typo\n";
-
-
-	pathname = write_tmp_file(fixture->tmpdir, "invalid_bootloader.conf", cfg_file, NULL);
-	g_assert_nonnull(pathname);
-
-	g_assert_false(load_config(pathname, &config, &ierror));
-	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE);
-	g_clear_error(&ierror);
+install-same=typo\n");
 }
 
 static void config_file_typo_in_boolean_force_install_same_key(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucConfig *config;
-	GError *ierror = NULL;
-	gchar* pathname;
-
-	const gchar *cfg_file = "\
+	config_file_typo(fixture, "\
 [system]\n\
 compatible=FooCorp Super BarBazzer\n\
 bootloader=barebox\n\
@@ -361,25 +348,13 @@ description=Rescue partition\n\
 device=/dev/mtd4\n\
 type=raw\n\
 bootname=factory0\n\
-force-install-same=typo\n";
-
-
-	pathname = write_tmp_file(fixture->tmpdir, "invalid_bootloader.conf", cfg_file, NULL);
-	g_assert_nonnull(pathname);
-
-	g_assert_false(load_config(pathname, &config, &ierror));
-	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE);
-	g_clear_error(&ierror);
+force-install-same=typo\n");
 }
 
 static void config_file_typo_in_boolean_ignore_checksum_key(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucConfig *config;
-	GError *ierror = NULL;
-	gchar* pathname;
-
-	const gchar *cfg_file = "\
+	config_file_typo(fixture, "\
 [system]\n\
 compatible=FooCorp Super BarBazzer\n\
 bootloader=barebox\n\
@@ -390,25 +365,13 @@ description=Rescue partition\n\
 device=/dev/mtd4\n\
 type=raw\n\
 bootname=factory0\n\
-ignore-checksum=typo\n";
-
-
-	pathname = write_tmp_file(fixture->tmpdir, "invalid_bootloader.conf", cfg_file, NULL);
-	g_assert_nonnull(pathname);
-
-	g_assert_false(load_config(pathname, &config, &ierror));
-	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE);
-	g_clear_error(&ierror);
+ignore-checksum=typo\n");
 }
 
 static void config_file_typo_in_boolean_resize_key(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucConfig *config;
-	GError *ierror = NULL;
-	gchar* pathname;
-
-	const gchar *cfg_file = "\
+	config_file_typo(fixture, "\
 [system]\n\
 compatible=FooCorp Super BarBazzer\n\
 bootloader=barebox\n\
@@ -418,39 +381,18 @@ mountprefix=/mnt/myrauc/\n\
 description=Rescue partition\n\
 device=/dev/null\n\
 type=ext4\n\
-resize=typo\n";
-
-
-	pathname = write_tmp_file(fixture->tmpdir, "invalid_config.conf", cfg_file, NULL);
-	g_assert_nonnull(pathname);
-
-	g_assert_false(load_config(pathname, &config, &ierror));
-	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE);
-	g_clear_error(&ierror);
+resize=typo\n");
 }
 
 static void config_file_typo_in_boolean_activate_installed_key(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucConfig *config;
-	GError *ierror = NULL;
-	gchar* pathname;
-
-	const gchar *cfg_file = "\
+	config_file_typo(fixture, "\
 [system]\n\
 compatible=FooCorp Super BarBazzer\n\
 bootloader=barebox\n\
 mountprefix=/mnt/myrauc/\n\
-activate-installed=typo\n";
-
-
-	pathname = write_tmp_file(fixture->tmpdir, "invalid_bootloader.conf", cfg_file, NULL);
-	g_assert_nonnull(pathname);
-
-	g_assert_false(load_config(pathname, &config, &ierror));
-	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE);
-	g_assert_null(config);
-	g_clear_error(&ierror);
+activate-installed=typo\n");
 }
 
 static void config_file_no_max_bundle_download_size(ConfigFileFixture *fixture,
@@ -502,24 +444,11 @@ max-bundle-download-size=0\n";
 static void config_file_typo_in_uint64_max_bundle_download_size(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucConfig *config;
-	GError *ierror = NULL;
-	gchar* pathname;
-
-	const gchar *cfg_file = "\
+	config_file_typo(fixture, "\
 [system]\n\
 compatible=FooCorp Super BarBazzer\n\
 bootloader=barebox\n\
-max-bundle-download-size=no-uint64\n";
-
-	pathname = write_tmp_file(fixture->tmpdir, "invalid_max_bundle_download_size.conf", cfg_file, NULL);
-	g_assert_nonnull(pathname);
-
-	g_assert_false(load_config(pathname, &config, &ierror));
-	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE);
-	g_assert_null(config);
-
-	g_clear_error(&ierror);
+max-bundle-download-size=no-uint64\n");
 }
 
 static void config_file_activate_installed_set_to_true(ConfigFileFixture *fixture,

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -317,6 +317,23 @@ bootname=factory0\n\
 readonly=typo\n");
 }
 
+static void config_file_typo_in_boolean_allow_mounted_key(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	config_file_typo(fixture, "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+\n\
+[slot.rescue.0]\n\
+description=Rescue partition\n\
+device=/dev/mtd4\n\
+type=raw\n\
+bootname=factory0\n\
+allow-mounted=typo\n");
+}
+
 static void config_file_typo_in_boolean_install_same_key(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
@@ -807,6 +824,9 @@ int main(int argc, char *argv[])
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/invalid-parent", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_invalid_parent,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/typo-in-boolean-allow-mounted-key", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_typo_in_boolean_allow_mounted_key,
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/typo-in-boolean-readonly-key", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_typo_in_boolean_readonly_key,

--- a/test/install-content/hook.sh
+++ b/test/install-content/hook.sh
@@ -39,13 +39,17 @@ case "$1" in
 		echo "RAUC_SLOT_DEVICE: $RAUC_SLOT_DEVICE"
 		echo "RAUC_SLOT_MOUNT_POINT: $RAUC_SLOT_MOUNT_POINT"
 		echo "RAUC_MOUNT_PREFIX: $RAUC_MOUNT_PREFIX"
-		echo "$RAUC_MOUNT_PREFIX/hook-slot"
-		mkdir "$RAUC_MOUNT_PREFIX/hook-slot"
-		mount "$RAUC_SLOT_DEVICE" "$RAUC_MOUNT_PREFIX/hook-slot"
-		echo "$RAUC_MOUNT_PREFIX/hook-slot/hook-install"
-		touch "$RAUC_MOUNT_PREFIX/hook-slot/hook-install"
-		umount "$RAUC_MOUNT_PREFIX/hook-slot"
-		rmdir  "$RAUC_MOUNT_PREFIX/hook-slot"
+		if [ -z "$RAUC_SLOT_MOUNT_POINT" ] ; then
+		    echo "$RAUC_MOUNT_PREFIX/hook-slot"
+		    mkdir "$RAUC_MOUNT_PREFIX/hook-slot"
+		    mount "$RAUC_SLOT_DEVICE" "$RAUC_MOUNT_PREFIX/hook-slot"
+		    echo "$RAUC_MOUNT_PREFIX/hook-slot/hook-install"
+		    touch "$RAUC_MOUNT_PREFIX/hook-slot/hook-install"
+		    umount "$RAUC_MOUNT_PREFIX/hook-slot"
+		    rmdir  "$RAUC_MOUNT_PREFIX/hook-slot"
+		else
+		    touch "$RAUC_SLOT_MOUNT_POINT/hook-install-mounted"
+		fi
 		;;
 	*)
 		exit 1

--- a/test/install-fixtures.c
+++ b/test/install-fixtures.c
@@ -23,6 +23,7 @@ void fixture_helper_fixture_set_up_system_user(gchar *tmpdir,
 	g_assert(test_mkdir_relative(tmpdir, "images", 0777) == 0);
 	g_assert(test_mkdir_relative(tmpdir, "openssl-ca", 0777) == 0);
 	g_assert(test_mkdir_relative(tmpdir, "slot", 0777) == 0);
+	g_assert(test_mkdir_relative(tmpdir, "bootloader", 0777) == 0);
 
 	/* copy system config to temp dir*/
 	if (!configname)
@@ -67,10 +68,13 @@ void fixture_helper_fixture_set_up_system_user(gchar *tmpdir,
 			SLOT_SIZE, "/dev/zero") == 0);
 	g_assert(test_prepare_dummy_file(tmpdir, "images/appfs-1",
 			SLOT_SIZE, "/dev/zero") == 0);
+	g_assert(test_prepare_dummy_file(tmpdir, "images/bootloader-0",
+			SLOT_SIZE, "/dev/zero") == 0);
 	g_assert_true(test_make_filesystem(tmpdir, "images/rootfs-0"));
 	g_assert_true(test_make_filesystem(tmpdir, "images/appfs-0"));
 	g_assert_true(test_make_filesystem(tmpdir, "images/rootfs-1"));
 	g_assert_true(test_make_filesystem(tmpdir, "images/appfs-1"));
+	g_assert_true(test_make_filesystem(tmpdir, "images/bootloader-0"));
 
 	/* Set dummy bootname provider */
 	r_context_conf()->bootslot = g_strdup("system0");
@@ -98,12 +102,19 @@ void fixture_helper_set_up_system(gchar *tmpdir,
 	test_make_slot_user_writable(tmpdir, "images/appfs-0");
 	test_make_slot_user_writable(tmpdir, "images/rootfs-1");
 	test_make_slot_user_writable(tmpdir, "images/appfs-1");
+	test_make_slot_user_writable(tmpdir, "images/bootloader-0");
 
 	/* Provide active mounted slot */
 	slotfile = g_build_filename(tmpdir, "images/rootfs-0", NULL);
 	slotpath = g_build_filename(tmpdir, "slot", NULL);
 	g_assert(test_mount(slotfile, slotpath));
+	g_free(slotfile);
+	g_free(slotpath);
 
+	/* Provide already mounted slot */
+	slotfile = g_build_filename(tmpdir, "images/bootloader-0", NULL);
+	slotpath = g_build_filename(tmpdir, "bootloader", NULL);
+	g_assert(test_mount(slotfile, slotpath));
 	g_free(slotfile);
 	g_free(slotpath);
 }
@@ -134,8 +145,11 @@ void fixture_helper_set_up_bundle(gchar *tmpdir,
 			SLOT_SIZE, "/dev/zero") == 0);
 	g_assert(test_prepare_dummy_file(tmpdir, "content/appfs.ext4",
 			SLOT_SIZE, "/dev/zero") == 0);
+	g_assert(test_prepare_dummy_file(tmpdir, "content/bootloader.ext4",
+			SLOT_SIZE, "/dev/zero") == 0);
 	g_assert_true(test_make_filesystem(tmpdir, "content/rootfs.ext4"));
 	g_assert_true(test_make_filesystem(tmpdir, "content/appfs.ext4"));
+	g_assert_true(test_make_filesystem(tmpdir, "content/bootloader.ext4"));
 	if (manifest_content) {
 		g_assert_true(write_tmp_file(tmpdir, "content/manifest.raucm", manifest_content, NULL));
 	} else {
@@ -145,6 +159,7 @@ void fixture_helper_set_up_bundle(gchar *tmpdir,
 	/* Make images user-writable */
 	test_make_slot_user_writable(tmpdir, "content/rootfs.ext4");
 	test_make_slot_user_writable(tmpdir, "content/appfs.ext4");
+	test_make_slot_user_writable(tmpdir, "content/bootloader.ext4");
 
 	/* Write test file to slot */
 	g_assert(test_mkdir_relative(tmpdir, "mnt", 0777) == 0);

--- a/test/install.c
+++ b/test/install.c
@@ -205,6 +205,7 @@ static void install_fixture_tear_down(InstallFixture *fixture,
 		return;
 
 	test_umount(fixture->tmpdir, "slot");
+	test_umount(fixture->tmpdir, "bootloader");
 	test_rm_tree(fixture->tmpdir, "");
 }
 

--- a/test/install.c
+++ b/test/install.c
@@ -33,6 +33,27 @@ static void install_fixture_set_up_bundle_central_status(InstallFixture *fixture
 	fixture_helper_set_up_bundle(fixture->tmpdir, NULL, FALSE, FALSE);
 }
 
+static void install_fixture_set_up_bundle_already_mounted(InstallFixture *fixture,
+		gconstpointer user_data)
+{
+	const gchar *manifest_file = "\
+[update]\n\
+compatible=Test Config\n\
+\n\
+[hooks]\n\
+filename=hook.sh\n\
+\n\
+[image.bootloader]\n\
+filename=bootloader.ext4\n\
+hooks=install\n\
+";
+
+	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+
+	fixture_helper_set_up_system(fixture->tmpdir, NULL);
+	fixture_helper_set_up_bundle(fixture->tmpdir, manifest_file, TRUE, TRUE);
+}
+
 static void install_fixture_set_up_bundle_custom_handler(InstallFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1130,6 +1151,47 @@ static void install_test_bundle_hook_post_install(InstallFixture *fixture,
 	g_free(bundlepath);
 }
 
+/* Test with already mounted slot */
+static void install_test_already_mounted(InstallFixture *fixture,
+		gconstpointer user_data)
+{
+	gchar *bundlepath, *mountprefix, *hookfilepath;
+	RaucInstallArgs *args;
+	GError *ierror = NULL;
+	gboolean res;
+
+	/* needs to run as root */
+	if (!test_running_as_root())
+		return;
+
+	/* Set mount path to current temp dir */
+	mountprefix = g_build_filename(fixture->tmpdir, "mount", NULL);
+	g_assert_nonnull(mountprefix);
+	r_context_conf()->mountprefix = mountprefix;
+	r_context();
+
+	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
+	g_assert_nonnull(bundlepath);
+
+	hookfilepath = g_build_filename(fixture->tmpdir, "bootloader", "hook-install-mounted", NULL);
+	g_assert_nonnull(hookfilepath);
+	g_assert_false(g_file_test(hookfilepath, G_FILE_TEST_EXISTS));
+
+	args = install_args_new();
+	args->name = g_strdup(bundlepath);
+	args->notify = install_notify;
+	args->cleanup = install_cleanup;
+	res = do_install_bundle(args, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+
+	g_assert_true(g_file_test(hookfilepath, G_FILE_TEST_IS_REGULAR));
+
+	args->status_result = 0;
+
+	g_free(bundlepath);
+}
+
 static void install_fixture_set_up_system_user(InstallFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1201,6 +1263,10 @@ int main(int argc, char *argv[])
 
 	g_test_add("/install/bundle-hook/slot-post-install", InstallFixture, NULL,
 			install_fixture_set_up_bundle_post_hook, install_test_bundle_hook_post_install,
+			install_fixture_tear_down);
+
+	g_test_add("/install/already-mounted", InstallFixture, NULL,
+			install_fixture_set_up_bundle_already_mounted, install_test_already_mounted,
 			install_fixture_tear_down);
 
 	return g_test_run();

--- a/test/service.c
+++ b/test/service.c
@@ -280,7 +280,7 @@ static void service_test_slot_status(ServiceFixture *fixture, gconstpointer user
 			&error);
 	g_assert_no_error(error);
 	g_assert_nonnull(slot_status_array);
-	g_assert_cmpint(g_variant_n_children(slot_status_array), ==, 5);
+	g_assert_cmpint(g_variant_n_children(slot_status_array), ==, 6);
 
 out:
 	g_clear_pointer(&installer, g_object_unref);

--- a/test/test.conf
+++ b/test/test.conf
@@ -41,3 +41,7 @@ device=images/appfs-1
 type=ext4
 parent=rootfs.1
 
+[slot.bootloader.0]
+device=images/bootloader-0
+type=ext4
+allow-mounted=true


### PR DESCRIPTION
This is an alternative and somewhat less intrusive approach to solving the problem that #186 is also trying to solve. Instead of having RAUC unmount and mount, this simply allows the update to proceed, provided the user takes full responsibility by providing his own install hook. 

For our use case, that actually turns out to be even more convenient, since we can then more easily preserve some of the U-boot environment that would otherwise be lost when one wipes the boot partition completely.

It still requires opt-in per slot in system.conf, since we don't want to effectively disable the mounted-sanity check for those existing users that just happen to provide their own install hook.
