### PR TITLE
src/install.c: Add network mode deprecation warning

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -1347,6 +1347,8 @@ gboolean do_install_network(const gchar *url, GError **error)
 
 	g_assert_nonnull(url);
 
+	g_warning("Network mode is marked as deprecated!\nPlease contact RAUC maintainers if you see this message and intend to use the network mode in future RAUC versions!");
+
 	r_context_begin_step("determine_slot_states", "Determining slot states", 0);
 	res = determine_slot_states(&ierror);
 	r_context_end_step("determine_slot_states", res);

--- a/test/install.c
+++ b/test/install.c
@@ -1058,16 +1058,19 @@ static void install_test_network(InstallFixture *fixture,
 	r_context_conf()->mountprefix = mountdir;
 	r_context();
 
+	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "Network mode is marked as deprecated!\nPlease contact RAUC maintainers if you see this message and intend to use the network mode in future RAUC versions!");
 	manifesturl = g_strconcat("file://", fixture->tmpdir,
 			"/content/manifest-1.raucm", NULL);
 	g_assert_true(do_install_network(manifesturl, NULL));
 	g_free(manifesturl);
 
+	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "Network mode is marked as deprecated!\nPlease contact RAUC maintainers if you see this message and intend to use the network mode in future RAUC versions!");
 	manifesturl = g_strconcat("file://", fixture->tmpdir,
 			"/content/manifest-2.raucm", NULL);
 	g_assert_true(do_install_network(manifesturl, NULL));
 	g_free(manifesturl);
 
+	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "Network mode is marked as deprecated!\nPlease contact RAUC maintainers if you see this message and intend to use the network mode in future RAUC versions!");
 	manifesturl = g_strconcat("file://", fixture->tmpdir,
 			"/content/manifest-3.raucm", NULL);
 	g_assert_true(do_install_network(manifesturl, NULL));
@@ -1128,11 +1131,13 @@ static void install_test_network_thread(InstallFixture *fixture,
 
 	manifesturl = g_strconcat("file://", fixture->tmpdir,
 			"/content/manifest-1.raucm", NULL);
+	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "Network mode is marked as deprecated!\nPlease contact RAUC maintainers if you see this message and intend to use the network mode in future RAUC versions!");
 	g_assert_true(do_install_network(manifesturl, NULL));
 	args->name = g_strdup(manifesturl);
 	args->notify = install_notify;
 	args->cleanup = install_cleanup;
 
+	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "Network mode is marked as deprecated!\nPlease contact RAUC maintainers if you see this message and intend to use the network mode in future RAUC versions!");
 	r_loop = g_main_loop_new(NULL, FALSE);
 	g_assert_true(install_run(args));
 	g_main_loop_run(r_loop);


### PR DESCRIPTION
This is the initial step of deprecating the unused and
slightly outdated RAUC network (non-bundle) mode.

If someone actively uses this mode (Note: Affects only 'real' network mode, without bundles, not the remote functionality of RAUC)