### PR TITLE
docs: Fix typos found by codespell

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -220,7 +220,7 @@ For example, a bundle can be signed with a certificate and key available as
 .. note::
   Most PKCS#11 implementations require a PIN for signing operations.
   You can either enter the PIN interactively as requested by RAUC or use the
-  ``RAUC_PKCS11_PIN`` environment variable to specifiy the PIN to use.
+  ``RAUC_PKCS11_PIN`` environment variable to specify the PIN to use.
 
 When working with PKCS#11, some tools are useful to configure and show your tokens:
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -256,7 +256,7 @@ memory specific storage strategies in all common storage medias,
 such as block devices, mtd (NAND/NOR), EEPROM, and UEFI variables.
 
 The Bootchooser framework maintains information about priority and remaining
-boot attemps while being configurable on how to deal with them for different
+boot attempts while being configurable on how to deal with them for different
 strategies.
 
 
@@ -528,7 +528,7 @@ U-Boot
 
 To enable handling of redundant booting in U-Boot, manual scripting is
 required.
-U-Boot allows storing and modifying variables in its *Envionment*.
+U-Boot allows storing and modifying variables in its *Environment*.
 Properly configured it can be accessed both from U-Boot itself as
 well as from Linux userspace.
 
@@ -722,7 +722,7 @@ Depending on your configuration ``make install`` will place this file in one of
 your system's service file folders.
 
 It is a good idea to wait for the system to be fully started before marking it
-as succesfully booted.
+as successfully booted.
 In order to achieve this, a smart solution is to create a systemd service that calls
 ``rauc status mark-good`` and use systemd's dependency handling to assure this
 service will not be executed before all relevant other services came up
@@ -890,7 +890,7 @@ meta-rauc will look as follows::
 
 
 To be able to build a signed image of this, you also need to configure
-``RAUC_KEY_FILE`` and ``RAUC_CERT_FILE`` to point to your key and certifcate
+``RAUC_KEY_FILE`` and ``RAUC_CERT_FILE`` to point to your key and certificate
 files you intend to use for signing. You may set them either from your bundle
 recipe or any global configuration (layer, site.conf, etc.), e.g.::
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -536,7 +536,7 @@ The Mark() Method
   Mark (IN  s state, IN  s slot_identifier, s slot_name, s message);
 
 Keeps a slot bootable (state == "good"), makes it unbootable (state == "bad")
-or explicitely activates it for the next boot (state == "active").
+or explicitly activates it for the next boot (state == "active").
 
 IN s *state*:
     Operation to perform (one out of "good", "bad" or "active")
@@ -611,7 +611,7 @@ The "LastError" Property
   de.pengutronix.rauc.Installer:LastError
   LastError  readable   s
 
-Holds the last message of the last error that occured.
+Holds the last message of the last error that occurred.
 
 .. _gdbus-property-de-pengutronix-rauc-Installer.Progress:
 
@@ -623,7 +623,7 @@ The "Progress" Property
   de.pengutronix.rauc.Installer:Progress
   Progress  readable   (isi)
 
-Provides installation progress informations in the form
+Provides installation progress information in the form
 
 (percentage, message, nesting depth)
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -125,7 +125,7 @@ that to the underlying bootloader implementation. In most cases this will
 disable the currently booted slot or at least switch to a different one.
 
 Although not very useful in the field, both commands recognize an optional
-argument to explicitely identify the slot to act on:
+argument to explicitly identify the slot to act on:
 
 .. code-block:: sh
 
@@ -146,7 +146,7 @@ boot by hand, for example:
 * Recurrently test the installation of a bundle in development starting from a
   known state.
 * Activate a slot that has been installed sometime before and whose activation
-  has explicitely been prevented at that time using the system configuration
+  has explicitly been prevented at that time using the system configuration
   file's parameter :ref:`activate-installed <activate-installed>`.
 * Switch back to the previous slot because one really knows |better (TM)|.
 
@@ -163,7 +163,7 @@ To do so, RAUC offers the subcommand
 where the optional argument decides which slot to (re-)activate at the expense
 of the remaining slots. Choosing ``other`` switches to the next bootable slot
 that is not the one that is currently booted. In a two-slot-setup this is
-just... the other one. If one wants to explicitely address a known slot, one can
+just... the other one. If one wants to explicitly address a known slot, one can
 do so by using its slot name which has the form ``<slot-class>.<idx>`` (e.g.
 ``rootfs.1``), see :ref:`this <slot.slot-class.idx-section>` part of section
 :ref:`System Configuration File <sec_ref_slot_config>`. Last but not least,


### PR DESCRIPTION
Called like that:

    codespell -i 3 -w docs/**/*.rst

Signed-off-by: Alexander Dahl <ada@thorsis.com>