### PR TITLE
Add extra-mount-opts slot config key

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -210,6 +210,10 @@ hierarchical separator.
   matches hash of installed one.
   This replaces the deprecated entry ``ignore-checksum``.
 
+``extra-mount-opts``
+  Allows to specify custom mount options that will be passed to the slots
+  ``mount`` call as ``-o`` argument value.
+
 .. _sec_ref_manifest:
 
 Manifest

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -99,6 +99,8 @@ typedef struct _RaucSlot {
 	gboolean readonly;
 	/** flag indicating if the slot update may be forced */
 	gboolean force_install_same;
+	/** extra mount options for this slot */
+	gchar *extra_mount_opts;
 
 	/** current state of the slot (runtime) */
 	SlotState state;

--- a/include/mount.h
+++ b/include/mount.h
@@ -13,11 +13,13 @@
  * @param mountpoint destination path for mount
  * @param type type of image to mount (results in -t option)
  * @param size maximum size of image to mount (for loop mounts)
+ * @param extra_options additional mount options that will be passed to mount
+ *        via `-o` argument
  * @param error return location for a GError, or NULL
  *
  * @return True if succeeded, False if failed
  */
-gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar* type, gsize size, GError **error);
+gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar* type, gsize size, const gchar *extra_options, GError **error);
 
 /**
  * Loopback mount a file.

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -407,6 +407,8 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 			g_key_file_remove_key(key_file, groups[i], "force-install-same", NULL);
 			g_key_file_remove_key(key_file, groups[i], "ignore-checksum", NULL);
 
+			slot->extra_mount_opts = key_file_consume_string(key_file, groups[i], "extra-mount-opts", NULL);
+
 			g_hash_table_insert(slots, (gchar*)slot->name, slot);
 		}
 		g_strfreev(groupsplit);

--- a/src/mount.c
+++ b/src/mount.c
@@ -6,7 +6,7 @@
 #include "mount.h"
 #include "utils.h"
 
-gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar* type, gsize size, GError **error)
+gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar* type, gsize size, const gchar* extra_options, GError **error)
 {
 	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
@@ -25,6 +25,10 @@ gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar*
 	if (size != 0) {
 		g_ptr_array_add(args, g_strdup("-o"));
 		g_ptr_array_add(args, g_strdup_printf("ro,loop,sizelimit=%"G_GSIZE_FORMAT, size));
+	}
+	if (extra_options) {
+		g_ptr_array_add(args, g_strdup("-o"));
+		g_ptr_array_add(args, g_strdup(extra_options));
 	}
 	g_ptr_array_add(args, g_strdup(source));
 	g_ptr_array_add(args, g_strdup(mountpoint));
@@ -57,7 +61,7 @@ out:
 
 gboolean r_mount_loop(const gchar *filename, const gchar *mountpoint, gsize size, GError **error)
 {
-	return r_mount_full(filename, mountpoint, "squashfs", size, error);
+	return r_mount_full(filename, mountpoint, "squashfs", size, NULL, error);
 }
 
 gboolean r_umount(const gchar *filename, GError **error)
@@ -159,7 +163,7 @@ gboolean r_mount_slot(RaucSlot *slot, GError **error)
 		goto out;
 	}
 
-	res = r_mount_full(slot->device, mount_point, slot->type, 0, &ierror);
+	res = r_mount_full(slot->device, mount_point, slot->type, 0, NULL, &ierror);
 	if (!res) {
 		res = FALSE;
 		g_propagate_prefixed_error(

--- a/src/mount.c
+++ b/src/mount.c
@@ -163,7 +163,7 @@ gboolean r_mount_slot(RaucSlot *slot, GError **error)
 		goto out;
 	}
 
-	res = r_mount_full(slot->device, mount_point, slot->type, 0, NULL, &ierror);
+	res = r_mount_full(slot->device, mount_point, slot->type, 0, slot->extra_mount_opts, &ierror);
 	if (!res) {
 		res = FALSE;
 		g_propagate_prefixed_error(

--- a/test/common.c
+++ b/test/common.c
@@ -237,7 +237,7 @@ gboolean test_make_filesystem(const gchar *dirname, const gchar *filename)
 
 gboolean test_mount(const gchar *src, const gchar *dest)
 {
-	return r_mount_full(src, dest, NULL, 0, NULL);
+	return r_mount_full(src, dest, NULL, 0, NULL, NULL);
 }
 
 


### PR DESCRIPTION
Allow passing custom slot config options to RAUC's slot mount calls.

This fixes #281.