### PR TITLE
Rework progress step allocation and freeing

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -50,8 +50,8 @@ typedef struct {
 
 typedef struct {
 	/* name identifying progress step */
-	const gchar *name;
-	const gchar *description;
+	gchar *name;
+	gchar *description;
 
 	gint substeps_total;
 	gint substeps_done;
@@ -94,6 +94,15 @@ void r_context_end_step(const gchar *name, gboolean success);
  * @param percentage explicit step percentage
  */
 void r_context_set_step_percentage(const gchar *name, gint percentage);
+
+/**
+ * Frees the memory allocated by the RaucProgressStep.
+ *
+ * @param step a RaucProgressStep to free
+ */
+void r_context_free_progress_step(RaucProgressStep *step);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucProgressStep, r_context_free_progress_step);
 
 void r_context_register_progress_callback(progress_callback progress_cb);
 

--- a/include/context.h
+++ b/include/context.h
@@ -76,6 +76,19 @@ void r_context_begin_step(const gchar *name, const gchar *description,
 		gint sub_steps);
 
 /**
+ * Call at the beginning of a relevant code block. Provides progress
+ * information via DBus when rauc service is running.
+ *
+ * Same as r_context_begin_step() but allows printf-like format strings.
+ *
+ * @param name identifying the step
+ * @param sub_steps number of direct sub steps contained in this step
+ * @param description that is emitted via DBus on begin/end.
+ *   A printf-like format string.
+ */
+void r_context_begin_step_formatted(const gchar *name, gint substeps, const gchar *description, ...);
+
+/**
  * Call at the end of a relevant code block. Percentage calculation is done
  * automatically if not set explicitly.
  * If the step did not complete successfully the number of nested substeps

--- a/src/context.c
+++ b/src/context.c
@@ -13,6 +13,9 @@ static const gchar *regex_match(const gchar *pattern, const gchar *string)
 	g_autoptr(GRegex) regex = NULL;
 	g_autoptr(GMatchInfo) match = NULL;
 
+	g_return_val_if_fail(pattern, NULL);
+	g_return_val_if_fail(string, NULL);
+
 	regex = g_regex_new(pattern, 0, 0, NULL);
 	if (g_regex_match(regex, string, 0, &match))
 		return g_match_info_fetch(match, 1);
@@ -101,6 +104,10 @@ static gboolean launch_and_wait_variables_handler(gchar *handler_name, GHashTabl
 	GInputStream *instream;
 	gchar* outline;
 
+	g_return_val_if_fail(handler_name, FALSE);
+	g_return_val_if_fail(variables, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
 	handlelaunch = g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE | G_SUBPROCESS_FLAGS_STDERR_MERGE);
 
 	/* we copy the variables from the hashtable and add them to the
@@ -153,6 +160,8 @@ static gchar* get_system_dtb_compatible(GError **error)
 	gchar *contents = NULL;
 	GError *ierror = NULL;
 
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
 	if (!g_file_get_contents("/sys/firmware/devicetree/base/compatible", &contents, NULL, &ierror)) {
 		g_propagate_error(error, ierror);
 		return NULL;
@@ -165,6 +174,9 @@ static gchar* get_variant_from_file(const gchar* filename, GError **error)
 {
 	gchar *contents = NULL;
 	GError *ierror = NULL;
+
+	g_return_val_if_fail(filename, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	if (!g_file_get_contents(filename, &contents, NULL, &ierror)) {
 		g_propagate_error(error, ierror);
@@ -326,6 +338,9 @@ void r_context_begin_step(const gchar *name, const gchar *description,
 	RaucProgressStep *step = g_new0(RaucProgressStep, 1);
 	RaucProgressStep *parent;
 
+	g_return_if_fail(name);
+	g_return_if_fail(description);
+
 	/* set properties */
 	step->name = g_strdup(name);
 	step->description = g_strdup(description);
@@ -383,6 +398,8 @@ void r_context_end_step(const gchar *name, gboolean success)
 	RaucProgressStep *step;
 	GList *step_element;
 	RaucProgressStep *parent;
+
+	g_return_if_fail(name);
 
 	/* "stack" should never be NULL at this point */
 	g_assert_nonnull(context->progress);
@@ -442,6 +459,8 @@ void r_context_set_step_percentage(const gchar *name, gint custom_percent)
 	RaucProgressStep *parent;
 	gint percent_difference;
 
+	g_return_if_fail(name);
+
 	g_assert_nonnull(context->progress);
 
 	step = context->progress->data;
@@ -481,7 +500,8 @@ void r_context_free_progress_step(RaucProgressStep *step)
 
 void r_context_register_progress_callback(progress_callback progress_cb)
 {
-	g_assert_nonnull(progress_cb);
+	g_return_if_fail(progress_cb);
+
 	g_assert_null(context->progress_callback);
 
 	context->progress_callback = progress_cb;

--- a/src/context.c
+++ b/src/context.c
@@ -327,8 +327,8 @@ void r_context_begin_step(const gchar *name, const gchar *description,
 	RaucProgressStep *parent;
 
 	/* set properties */
-	step->name = name;
-	step->description = description;
+	step->name = g_strdup(name);
+	step->description = g_strdup(description);
 	step->substeps_total = substeps;
 	step->substeps_done = 0;
 	step->percent_done = 0;
@@ -418,7 +418,7 @@ void r_context_end_step(const gchar *name, gboolean success)
 			step_element);
 
 	g_list_free(step_element);
-	g_free(step);
+	r_context_free_progress_step(step);
 }
 
 void r_context_set_step_percentage(const gchar *name, gint custom_percent)
@@ -453,6 +453,15 @@ void r_context_set_step_percentage(const gchar *name, gint custom_percent)
 	/* r_context_step_end sends 100% progress step */
 	if (custom_percent != 100)
 		r_context_send_progress(FALSE, FALSE);
+}
+
+void r_context_free_progress_step(RaucProgressStep *step)
+{
+	g_return_if_fail(step);
+
+	g_free(step->name);
+	g_free(step->description);
+	g_free(step);
 }
 
 void r_context_register_progress_callback(progress_callback progress_cb)

--- a/src/context.c
+++ b/src/context.c
@@ -363,6 +363,21 @@ void r_context_begin_step(const gchar *name, const gchar *description,
 	r_context_send_progress(FALSE, FALSE);
 }
 
+void r_context_begin_step_formatted(const gchar *name, gint substeps, const gchar *description, ...)
+{
+	va_list args;
+	g_autofree gchar *desc_formatted = NULL;
+
+	g_return_if_fail(name);
+	g_return_if_fail(description);
+
+	va_start(args, description);
+	desc_formatted = g_strdup_vprintf(description, args);
+	va_end(args);
+
+	r_context_begin_step(name, desc_formatted, substeps);
+}
+
 void r_context_end_step(const gchar *name, gboolean success)
 {
 	RaucProgressStep *step;

--- a/src/install.c
+++ b/src/install.c
@@ -873,7 +873,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 
 		install_args_update(args, g_strdup_printf("Checking slot %s", dest_slot->name));
 
-		r_context_begin_step("check_slot", g_strdup_printf("Checking slot %s", dest_slot->name), 0);
+		r_context_begin_step_formatted("check_slot", 0, "Checking slot %s", dest_slot->name);
 
 		load_slot_status(dest_slot);
 		slot_state = dest_slot->status;


### PR DESCRIPTION
Let progress objects allocate and free their strings themselves and do not leave this to the other levels.

By also introducing a printf-style printout function this prevents producing memory leaks by allocated but non-freed strings when creating progress messages.

This addresses the issues noted in #341.