### PR TITLE
 Add disable_counting logic

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -436,6 +436,30 @@ boot target is required::
           };
   };
 
+If an extra variable "disable_counting" is provided, then RAUC can communicate to
+the bootloader, if a firmware update has been marked as good and doesn't need to
+be tracked anymore. In this case, the bootloader can stop decrementing the remaining_attempts::
+
+  bootstate {
+
+          [...]
+
+          disable_counting@14 {
+                  reg = <0x14 0x4>;
+                  type = "uint32";
+                  default = <1>;
+          };
+  };
+
+..
+To make this work, the bootloader has to evaluate "disable_counting" explicitly, e.g. with a script::
+
+  #!/bin/sh
+  if [ "${state.bootstate.disable_counting}" = "1" ]; then
+    bootchooser -s
+  fi
+  boot bootchooser
+
 .. warning::
   This example shows only a highly condensed excerpt of setting up Barebox
   state for bootchooser.

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -290,7 +290,7 @@ static gboolean barebox_set_state(RaucSlot *slot, gboolean good, GError **error)
 
 	if (good) {
 		int disable_counting = -1;
-		if (barebox_state_get_int("disable_counting", &disable_counting, ierror)) {
+		if (barebox_state_get_int("disable_counting", &disable_counting, &ierror)) {
 			if (disable_counting)
 			{
 				// If attempts countdown is disabled, then this boot slot is already verified and marked as good.
@@ -427,7 +427,7 @@ static gboolean barebox_set_primary(RaucSlot *slot, GError **error)
 	g_ptr_array_add(pairs, g_strdup_printf(BOOTSTATE_PREFIX ".%s.remaining_attempts=%i",
 					slot->bootname, BAREBOX_STATE_ATTEMPTS_PRIMARY));
 
-	if (barebox_state_get_int("disable_counting", &disable_counting, ierror)) {
+	if (barebox_state_get_int("disable_counting", &disable_counting, &ierror)) {
 		if (disable_counting) {
 			// Set disable_counting to zero, to enable remaining_attempts countdown
 			g_message("enabling countdown of remaining_attempts");
@@ -1410,4 +1410,3 @@ gboolean r_boot_set_primary(RaucSlot *slot, GError **error)
 
 	return res;
 }
-


### PR DESCRIPTION
When the boot process is interrupted for any reason (power issues, brown-out resets, users unplugging the gadget while it boots, etc.) more than three times in a row, then bootchooser will happily switch to the fall-back target, even though there's nothing wrong with the actual target at all.

This patch limits the scope of remaining_attempts countdown to the phase between flash update and verification after reboot (if the variable "disable_counting" is present in the bootstate node).

Additionally, it limits the number of flash writes to the barebox-state partition. (there used to be two flash writes for each and every boot cycle, but with this patch no more flash writes take place after the verification of the last update).

[Barebox mailing list thread with background
](http://lists.infradead.org/pipermail/barebox/2018-October/034961.html)