### PR TITLE
Preparations for multi-file-checksums

### DIFF
--- a/include/checksum.h
+++ b/include/checksum.h
@@ -27,7 +27,7 @@ typedef struct {
  * @param error return location for a GError, or NULL
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean update_checksum(RaucChecksum *checksum, const gchar *filename, GError **error);
+gboolean compute_checksum(RaucChecksum *checksum, const gchar *filename, GError **error);
 
 /**
  * Verifies provided file checksum.

--- a/include/utils.h
+++ b/include/utils.h
@@ -2,6 +2,18 @@
 
 #include <glib.h>
 
+/* Use
+ *
+ *   g_auto(filedesc) fd = -1
+ *
+ * to declare a file descriptor that will be automatically closed when
+ * fd goes out of scope. The desctructor is guaranteed to preserve
+ * errno.
+ */
+typedef int filedesc;
+void close_preserve_errno(filedesc fd);
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(filedesc, close_preserve_errno, -1)
+
 #define R_LOG_DOMAIN_SUBPROCESS "rauc-subprocess"
 static inline void r_debug_subprocess(GPtrArray *args)
 {

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -4,7 +4,7 @@
 
 G_DEFINE_QUARK(r-checksum-error-quark, r_checksum_error)
 
-gboolean update_checksum(RaucChecksum *checksum, const gchar *filename, GError **error)
+gboolean compute_checksum(RaucChecksum *checksum, const gchar *filename, GError **error)
 {
 	GError *ierror = NULL;
 	g_autoptr(GMappedFile) file = NULL;

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -1,6 +1,13 @@
 #include "checksum.h"
 
 #define RAUC_DEFAULT_CHECKSUM G_CHECKSUM_SHA256
+/*
+ * G_CHECKSUM_MD5 is 0. We will never allow use of such a weak hash
+ * for anything. Hence checking for !checksum->type below to mean "use
+ * the default" is ok.
+ */
+G_STATIC_ASSERT(G_CHECKSUM_MD5 == 0);
+G_STATIC_ASSERT(RAUC_DEFAULT_CHECKSUM != 0);
 
 G_DEFINE_QUARK(r-checksum-error-quark, r_checksum_error)
 
@@ -20,7 +27,7 @@ gboolean compute_checksum(RaucChecksum *checksum, const gchar *filename, GError 
 	}
 	content = g_mapped_file_get_bytes(file);
 
-	if (checksum->digest == NULL)
+	if (!checksum->type)
 		checksum->type = RAUC_DEFAULT_CHECKSUM;
 	g_clear_pointer(&checksum->digest, g_free);
 	checksum->digest = g_compute_checksum_for_bytes(checksum->type, content);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -463,7 +463,7 @@ static gboolean update_manifest_checksums(RaucManifest *manifest, const gchar *d
 	for (GList *elem = manifest->images; elem != NULL; elem = elem->next) {
 		RaucImage *image = elem->data;
 		g_autofree gchar *filename = g_build_filename(dir, image->filename, NULL);
-		res = update_checksum(&image->checksum, filename, &ierror);
+		res = compute_checksum(&image->checksum, filename, &ierror);
 		if (!res) {
 			g_warning("Failed updating checksum: %s", ierror->message);
 			g_clear_error(&ierror);
@@ -475,7 +475,7 @@ static gboolean update_manifest_checksums(RaucManifest *manifest, const gchar *d
 	for (GList *elem = manifest->files; elem != NULL; elem = elem->next) {
 		RaucFile *file = elem->data;
 		g_autofree gchar *filename = g_build_filename(dir, file->filename, NULL);
-		res = update_checksum(&file->checksum, filename, &ierror);
+		res = compute_checksum(&file->checksum, filename, &ierror);
 		if (!res) {
 			g_warning("Failed updating checksum: %s", ierror->message);
 			g_clear_error(&ierror);

--- a/src/utils.c
+++ b/src/utils.c
@@ -4,8 +4,19 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <string.h>
+#include <unistd.h>
+#include <errno.h>
 
 #include "utils.h"
+
+void close_preserve_errno(int fd)
+{
+	int err;
+
+	err = errno;
+	(void) close(fd);
+	errno = err;
+}
 
 GBytes *read_file(const gchar *filename, GError **error)
 {

--- a/test/checksum.c
+++ b/test/checksum.c
@@ -48,14 +48,14 @@ static void checksum_test1(void)
 
 	g_clear_pointer(&checksum.digest, g_free);
 	checksum.size = 0;
-	g_assert_true(update_checksum(&checksum, "test/install-content/appfs.img", &error));
+	g_assert_true(compute_checksum(&checksum, "test/install-content/appfs.img", &error));
 	g_assert_no_error(error);
 	g_assert_cmpstr(checksum.digest, ==, TEST_DIGEST_GOOD);
 	g_assert(checksum.size == 32768);
 
 	g_clear_pointer(&checksum.digest, g_free);
 	checksum.size = 0;
-	g_assert_false(update_checksum(&checksum, "tesinstall-content/rootfs.img", &error));
+	g_assert_false(compute_checksum(&checksum, "tesinstall-content/rootfs.img", &error));
 	g_assert_error(error, G_FILE_ERROR, G_FILE_ERROR_NOENT);
 	g_clear_error(&error);
 	g_assert_null(checksum.digest);


### PR DESCRIPTION
This is preparation for allowing multiple files to go into computing the sha256, cf. #325 . From this, it would mostly be a matter of figuring out how one would pass a list of file names and perhaps provide convenience functions for passing a single file. It also tries to fix something I've noticed a couple of times: That memory use of the RAUC process temporarily goes through the roof during an update.

For now only compile-tested, as I don't have any boards handy, and it is anyway mostly a POC.