### PR TITLE
Fix Issues with Slot Status Over D-Bus

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1311,7 +1311,7 @@ static gboolean retrieve_slot_states_via_dbus(GHashTable **slots, GError **error
 		}
 		g_variant_dict_lookup(&dict, "mountpoint", "s", &slot->mount_point);
 		g_variant_dict_lookup(&dict, "boot-status", "s", &boot_good);
-		if (g_strcmp0(boot_good, "good")) {
+		if (g_strcmp0(boot_good, "good") == 0) {
 			slot->boot_good = TRUE;
 		} else {
 			slot->boot_good = FALSE;

--- a/src/main.c
+++ b/src/main.c
@@ -902,6 +902,7 @@ out:
 }
 
 typedef struct {
+	/* Reference to primary slot (must not be freed) */
 	RaucSlot *primary;
 	gchar *compatible;
 	gchar *variant;
@@ -913,7 +914,6 @@ static void free_status_print(RaucStatusPrint *status)
 {
 	g_return_if_fail(status);
 
-	r_free_slot(status->primary);
 	g_free(status->compatible);
 	g_free(status->variant);
 	g_free(status->bootslot);
@@ -1387,10 +1387,17 @@ static gboolean retrieve_status_via_dbus(RaucStatusPrint **status_print, GError 
 	istatus->variant = r_installer_dup_variant(proxy);
 	istatus->compatible = r_installer_dup_compatible(proxy);
 	istatus->bootslot = r_installer_dup_boot_slot(proxy);
-	istatus->slots = NULL;
-	/* Add an empty dummy slot only containing name of primary */
-	istatus->primary = g_new0(RaucSlot, 1);
-	istatus->primary->name = primary;
+
+	/* Obtain configured slots and their state */
+	if (!retrieve_slot_states_via_dbus(&istatus->slots, &ierror)) {
+		g_propagate_prefixed_error(error, ierror, "rauc status: error retrieving slot status via D-Bus: ");
+		g_error_free(ierror);
+		return FALSE;
+	}
+
+	/* Finally, we get the right primary slot reference from the list */
+	if (primary)
+		istatus->primary = g_hash_table_lookup(istatus->slots, primary);
 
 	*status_print = g_steal_pointer(&istatus);
 
@@ -1476,14 +1483,6 @@ static gboolean status_start(int argc, char **argv)
 		if (!retrieve_status_via_dbus(&status_print, &ierror)) {
 			message = g_strdup_printf(
 					"rauc status: error retrieving slot status via D-Bus: %s",
-					ierror->message);
-			g_error_free(ierror);
-			r_exit_status = 1;
-			goto out;
-		}
-
-		if (!retrieve_slot_states_via_dbus(&status_print->slots, &ierror)) {
-			message = g_strdup_printf("rauc status: error retrieving slot status via D-Bus: %s",
 					ierror->message);
 			g_error_free(ierror);
 			r_exit_status = 1;


### PR DESCRIPTION
Fixes 2 issues on the client side:

* boot status is displayed inverted
* bootname for primary slot is unavailable