### PR TITLE
Fix service error return handling

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1787,14 +1787,14 @@ static void cmdline_handler(int argc, char **argv)
 		if (confpath != NULL ||
 		    certpath != NULL ||
 		    keypath != NULL) {
-			g_error("rauc busy, cannot reconfigure");
+			g_printerr("rauc busy, cannot reconfigure\n");
 			r_exit_status = 1;
 			return;
 		}
 	}
 
 	if (r_context_get_busy() && !rcommand->while_busy) {
-		g_error("rauc busy: cannot run %s", rcommand->name);
+		g_printerr("rauc busy: cannot run %s\n", rcommand->name);
 		r_exit_status = 1;
 		return;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -1555,7 +1555,9 @@ static gboolean service_start(int argc, char **argv)
 {
 	g_debug("service start");
 
-	return r_service_run();
+	r_exit_status = r_service_run() ? 0 : 1;
+
+	return TRUE;
 }
 #endif
 

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -254,6 +254,14 @@ test_expect_success PKCS11 "rauc bundle with PKCS11 (key mismatch)" "
     bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb
 "
 
+test_expect_success SERVICE "rauc service double-init failure" "
+  start_rauc_dbus_service \
+    --conf=${SHARNESS_TEST_DIRECTORY}/test.conf \
+    --override-boot-slot=system0 &&
+  test_when_finished stop_rauc_dbus_service &&
+  test_must_fail rauc service
+"
+
 test_expect_success !SERVICE "rauc --override-boot-slot=system0 status: internally" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test.conf --override-boot-slot=system0 status
 "


### PR DESCRIPTION
So far, even if a call of 'rauc service' failed with

    Failed to obtain name de.pengutronix.rauc

the service returned exit code 0, indicating everything is fine.

This will be fixed now.