### PR TITLE
Fix boot selection handling for asymmetric update scenarios.

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -34,13 +34,13 @@ static GString *bootchooser_order_primay(RaucSlot *slot)
 
 	order = g_string_new(slot->bootname);
 
-	/* Iterate over class members */
+	/* Iterate over boot selection-handled slots (bootname set) */
 	slots = g_hash_table_get_values(r_context()->config->slots);
 	for (GList *l = slots; l != NULL; l = l->next) {
 		RaucSlot *s = l->data;
 		if (s == slot)
 			continue;
-		if (s->sclass != slot->sclass)
+		if (!s->bootname)
 			continue;
 
 		g_string_append_c(order, ' ');

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -304,9 +304,8 @@ static gboolean barebox_set_primary(RaucSlot *slot, GError **error)
 		int prio;
 		BareboxSlotState bb_state;
 
-		if (s->sclass != slot->sclass)
+		if (!s->bootname)
 			continue;
-
 
 		if (!barebox_state_get(s->bootname, &bb_state, &ierror)) {
 			g_propagate_error(error, ierror);

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -278,7 +278,6 @@ path=/etc/rauc/keyring/\n\
 [slot.rescue.0]\n\
 device=/dev/rescue-0\n\
 type=raw\n\
-bootname=R\n\
 readonly=true\n\
 \n\
 [slot.rootfs.0]\n\

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -263,6 +263,8 @@ bootstate.system0.priority=20\n\
 static void bootchooser_grub(BootchooserFixture *fixture,
 		gconstpointer user_data)
 {
+	GError *ierror = NULL;
+	gboolean res = FALSE;
 	RaucSlot *slot;
 
 	const gchar *cfg_file = "\
@@ -300,13 +302,19 @@ bootname=B\n";
 	slot = find_config_slot_by_device(r_context()->config, "/dev/rootfs-0");
 	g_assert_nonnull(slot);
 
-	g_assert_true(r_boot_set_state(slot, TRUE, NULL));
-	g_assert_true(r_boot_set_state(slot, FALSE, NULL));
+	res = r_boot_set_state(slot, TRUE, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	res = r_boot_set_state(slot, FALSE, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 
 	slot = find_config_slot_by_device(r_context()->config, "/dev/rootfs-1");
 	g_assert_nonnull(slot);
 
-	g_assert_true(r_boot_set_primary(slot, NULL));
+	res = r_boot_set_primary(slot, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 }
 
 /* Write content to state storage for uboot fw_setenv / fw_printenv RAUC mock


### PR DESCRIPTION
This mainly fixes the barebox boot selection handling for cases where we update a slot class from another as this is usual the case in asymmetric scenarios.

To prevent from breaking this, some test were added.