### PR TITLE
Some extensions and fixes for rauc.t argument handling testing

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -543,8 +543,14 @@ static gboolean checksum_start(int argc, char **argv)
 		goto out;
 	}
 
-	if (argc != 3) {
+	if (argc < 3) {
 		g_printerr("A directory name must be provided\n");
+		r_exit_status = 1;
+		goto out;
+	}
+
+	if (argc > 3) {
+		g_printerr("Excess argument: %s\n", argv[3]);
 		r_exit_status = 1;
 		goto out;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -160,6 +160,7 @@ static gboolean install_start(int argc, char **argv)
 
 	if (argc > 3) {
 		g_printerr("Excess argument: %s\n", argv[3]);
+		r_exit_status = 1;
 		goto out;
 	}
 
@@ -263,6 +264,7 @@ static gboolean bundle_start(int argc, char **argv)
 
 	if (argc > 4) {
 		g_printerr("Excess argument: %s\n", argv[4]);
+		r_exit_status = 1;
 		goto out;
 	}
 
@@ -313,6 +315,7 @@ static gboolean write_slot_start(int argc, char **argv)
 
 	if (argc > 4) {
 		g_printerr("Excess argument: %s\n", argv[4]);
+		r_exit_status = 1;
 		goto out;
 	}
 
@@ -402,6 +405,7 @@ static gboolean resign_start(int argc, char **argv)
 
 	if (argc > 4) {
 		g_printerr("Excess argument: %s\n", argv[4]);
+		r_exit_status = 1;
 		goto out;
 	}
 
@@ -443,6 +447,7 @@ static gboolean extract_start(int argc, char **argv)
 
 	if (argc > 4) {
 		g_printerr("Excess argument: %s\n", argv[4]);
+		r_exit_status = 1;
 		goto out;
 	}
 
@@ -494,6 +499,7 @@ static gboolean convert_start(int argc, char **argv)
 
 	if (argc > 4) {
 		g_printerr("Excess argument: %s\n", argv[4]);
+		r_exit_status = 1;
 		goto out;
 	}
 
@@ -821,6 +827,7 @@ static gboolean info_start(int argc, char **argv)
 
 	if (argc > 3) {
 		g_printerr("Excess argument: %s\n", argv[3]);
+		r_exit_status = 1;
 		goto out;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -243,13 +243,6 @@ static gboolean bundle_start(int argc, char **argv)
 	GError *ierror = NULL;
 	g_debug("bundle start");
 
-	if (r_context()->certpath == NULL ||
-	    r_context()->keypath == NULL) {
-		g_printerr("Cert and key files must be provided\n");
-		r_exit_status = 1;
-		goto out;
-	}
-
 	if (argc < 3) {
 		g_printerr("An input directory name must be provided\n");
 		r_exit_status = 1;
@@ -264,6 +257,13 @@ static gboolean bundle_start(int argc, char **argv)
 
 	if (argc > 4) {
 		g_printerr("Excess argument: %s\n", argv[4]);
+		r_exit_status = 1;
+		goto out;
+	}
+
+	if (r_context()->certpath == NULL ||
+	    r_context()->keypath == NULL) {
+		g_printerr("Cert and key files must be provided\n");
 		r_exit_status = 1;
 		goto out;
 	}
@@ -383,14 +383,6 @@ static gboolean resign_start(int argc, char **argv)
 	GError *ierror = NULL;
 	g_debug("resign start");
 
-	if (r_context()->certpath == NULL ||
-	    r_context()->keypath == NULL ||
-	    r_context()->keyringpath == NULL) {
-		g_printerr("Cert, key and keyring files must be provided\n");
-		r_exit_status = 1;
-		goto out;
-	}
-
 	if (argc < 3) {
 		g_printerr("An input bundle must be provided\n");
 		r_exit_status = 1;
@@ -405,6 +397,14 @@ static gboolean resign_start(int argc, char **argv)
 
 	if (argc > 4) {
 		g_printerr("Excess argument: %s\n", argv[4]);
+		r_exit_status = 1;
+		goto out;
+	}
+
+	if (r_context()->certpath == NULL ||
+	    r_context()->keypath == NULL ||
+	    r_context()->keyringpath == NULL) {
+		g_printerr("Cert, key and keyring files must be provided\n");
 		r_exit_status = 1;
 		goto out;
 	}

--- a/test/get-coverity.sh
+++ b/test/get-coverity.sh
@@ -14,7 +14,7 @@ if [[ "${TRAVIS_BRANCH^^}" =~ "${COVERITY_SCAN_BRANCH_PATTERN^^}" ]]; then
   echo -e "\033[33;1mCoverity Scan configured to run on branch ${TRAVIS_BRANCH}\033[0m"
 else
   echo -e "\033[33;1mCoverity Scan NOT configured to run on branch ${TRAVIS_BRANCH}\033[0m"
-  exit 1
+  exit 0
 fi
 
 # Environment check, note that secure tokens are not available for PR's not coming form the main repo

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -146,7 +146,6 @@ test_expect_success "rauc missing arg" "
   test_must_fail rauc bundle &&
   test_must_fail rauc checksum &&
   test_must_fail rauc resign &&
-  test_must_fail rauc install &&
   test_must_fail rauc info
 "
 

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -142,10 +142,12 @@ test_expect_success "rauc invalid cmd" "
 test_expect_success "rauc missing arg" "
   test_expect_code 1 rauc install &&
   test_expect_code 1 rauc write-slot &&
+  test_expect_code 1 rauc write-slot slot &&
   test_expect_code 1 rauc info &&
   test_expect_code 1 rauc bundle &&
+  test_expect_code 1 rauc bundle input &&
   test_expect_code 1 rauc checksum &&
-  test_expect_code 1 rauc resign &&
+  test_expect_code 1 rauc resign input &&
   test_expect_code 1 rauc info
 "
 

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -151,6 +151,16 @@ test_expect_success "rauc missing arg" "
   test_expect_code 1 rauc info
 "
 
+test_expect_success "rauc excess args" "
+  test_expect_code 1 rauc install bundle excess &&
+  test_expect_code 1 rauc write-slot source target excess &&
+  test_expect_code 1 rauc info bundle excess &&
+  test_expect_code 1 rauc bundle indir outbundle excess &&
+  test_expect_code 1 rauc checksum indir excess &&
+  test_expect_code 1 rauc resign inbundle outbundle excess &&
+  test_expect_code 1 rauc info bundle excess
+"
+
 test_expect_success "rauc version" "
   rauc --version
 "

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -140,13 +140,13 @@ test_expect_success "rauc invalid cmd" "
 "
 
 test_expect_success "rauc missing arg" "
-  test_must_fail rauc install &&
-  test_must_fail rauc write-slot &&
-  test_must_fail rauc info &&
-  test_must_fail rauc bundle &&
-  test_must_fail rauc checksum &&
-  test_must_fail rauc resign &&
-  test_must_fail rauc info
+  test_expect_code 1 rauc install &&
+  test_expect_code 1 rauc write-slot &&
+  test_expect_code 1 rauc info &&
+  test_expect_code 1 rauc bundle &&
+  test_expect_code 1 rauc checksum &&
+  test_expect_code 1 rauc resign &&
+  test_expect_code 1 rauc info
 "
 
 test_expect_success "rauc version" "
@@ -162,10 +162,6 @@ test_expect_success "rauc help" "
   rauc checksum --help &&
   rauc resign --help &&
   rauc info --help
-"
-
-test_expect_success "rauc checksum without argument" "
-  test_expect_code 1 rauc checksum
 "
 
 test_expect_success "rauc checksum with signing" "

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -154,7 +154,14 @@ test_expect_success "rauc version" "
 "
 
 test_expect_success "rauc help" "
-  rauc --help
+  rauc --help &&
+  rauc install --help &&
+  rauc write-slot --help &&
+  rauc info --help &&
+  rauc bundle --help &&
+  rauc checksum --help &&
+  rauc resign --help &&
+  rauc info --help
 "
 
 test_expect_success "rauc checksum without argument" "

--- a/test/run-coverity.sh
+++ b/test/run-coverity.sh
@@ -37,7 +37,7 @@ if [[ "${TRAVIS_BRANCH^^}" =~ "${COVERITY_SCAN_BRANCH_PATTERN^^}" ]]; then
   echo -e "\033[33;1mCoverity Scan configured to run on branch ${TRAVIS_BRANCH}\033[0m"
 else
   echo -e "\033[33;1mCoverity Scan NOT configured to run on branch ${TRAVIS_BRANCH}\033[0m"
-  exit 1
+  exit 0
 fi
 
 # Verify upload is permitted


### PR DESCRIPTION
* Remove redundant tests
* Add more testing
* Revealed that excess args do not result in exit code != 0
