### PR TITLE
src/config_file: fix: always overwrite temporary system_variant

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -212,19 +212,17 @@ static void r_context_configure(void)
 		if (!compatible) {
 			g_warning("Failed to read dtb compatible: %s", error->message);
 			g_clear_error(&error);
-		} else {
-			g_free(context->config->system_variant);
-			context->config->system_variant = compatible;
 		}
+		g_free(context->config->system_variant);
+		context->config->system_variant = compatible;
 	} else if (context->config->system_variant_type == R_CONFIG_SYS_VARIANT_FILE) {
 		gchar *variant = get_variant_from_file(context->config->system_variant, &error);
 		if (!variant) {
 			g_warning("Failed to read system variant from file: %s", error->message);
 			g_clear_error(&error);
-		} else {
-			g_free(context->config->system_variant);
-			context->config->system_variant = variant;
 		}
+		g_free(context->config->system_variant);
+		context->config->system_variant = variant;
 	}
 
 	if (context->config->systeminfo_handler &&


### PR DESCRIPTION
We use the 'system_variant' key as a temporary storage for the filename
the key should be derived from.
No matter if we succeed with that or not, we must assure the key is
replaced afterwards.
With the current handling, in case for example get_variant_from_file()
failed and returned NULL, we do not overwrite 'system_variant' which
leads to having the variant set to the path to the filename we wanted to
read it from. This is clearly wrong.

We can simple fix this by setting the context 'system_variant'
unconditionally. Then it gets either the value 'NULL' (unset) or the
right value.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>