### PR TITLE
Issue 357: Improve version mangling

### DIFF
--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -183,9 +183,14 @@ then
             ;;
     esac
 
-    # Change the first '-' to a '.', so version-comparing tools work properly.
-    # Remove the "g" in git describe's output string, to save a byte.
-    v=`echo "$v" | sed 's/-/./;s/\(.*\)-g/\1-/'`;
+    case "$v" in
+        *-[0-9]*-g*)
+	    # Change the '-' before the number of commits since the last tag to a '.',
+	    # so version-comparing tools work properly.
+	    # Remove the "g" in git describe's output string, to save a byte.
+	    v=`echo "$v" | sed 's/-\([0-9]*-g[0-9a-f]*\)/.\1/;s/\(.*\)-g/\1-/'`;
+	    ;;
+    esac
     v_from_git=1
 elif test "x$fallback" = x || git --version >/dev/null 2>&1; then
     v=UNKNOWN

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -167,10 +167,8 @@ then
     #   Newer: v6.10-77-g0f8faeb
     #   Older: v6.10-g0f8faeb
     case $v in
-        *-rc*-*) : we have a rc release ;;
-        *-*-*) : git describe is okay three part flavor ;;
-        *-rc*) : we have a rc release ;;
-        *-*)
+        *-[0-9]*-g[0-9a-f]*) : git describe is okay three part flavor ;;
+        *-g[0-9a-f]*)
             : git describe is older two part flavor
             # Recreate the number of commits and rewrite such that the
             # result is the same as if we were using the newer version


### PR DESCRIPTION
by making the globs for detecting an old git stricter the check actually works also for rc releases. Together with the second change a release candidate doesn't use a . in the version string which fixes issue 357.