### PR TITLE
configure.ac: add a fallback version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([rauc], m4_esyscmd([./build-aux/git-version-gen .tarball-version]), [rauc@pengutronix.de])
+AC_INIT([rauc], m4_esyscmd([./build-aux/git-version-gen --fallback 1.0-rc1 .tarball-version]), [rauc@pengutronix.de])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
not sure this is welcome, but given it is so easy: This uses a feature of the version generation script to provide a fallback version that is used in the absence of a .tarball-version file and git metadata.