### PR TITLE
src/install: fix building with --disable-network

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -1230,6 +1230,7 @@ out:
 }
 #endif
 
+#if ENABLE_NETWORK
 static void print_slot_hash_table(GHashTable *hash_table)
 {
 	GHashTableIter iter;
@@ -1241,6 +1242,7 @@ static void print_slot_hash_table(GHashTable *hash_table)
 		g_print("  %s -> %s\n", key, slot->name);
 	}
 }
+#endif
 
 gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 {


### PR DESCRIPTION
print_slot_hash_table() is only used within the network handling code,
thus when having this disabled this static function is unused and will
produce a warning that is fatal when compiling with -Werror.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>