### PR TITLE
src/signature.c: make a-month-from-now computation more robust

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -409,17 +409,9 @@ GBytes *cms_sign(GBytes *content, const gchar *certfile, const gchar *keyfile, g
 
 		for (int i = 0; i < sk_X509_num(verified_chain); i++) {
 			const ASN1_TIME *expiry_time;
-			struct tm *next_month;
-			time_t now;
 			time_t comp;
-			time(&now);
 
-			next_month = gmtime(&now);
-			next_month->tm_mon += 1;
-			if (next_month->tm_mon == 12)
-				next_month->tm_mon = 0;
-			comp = timegm(next_month);
-
+			comp = time(NULL) + 30*24*60*60;
 			expiry_time = X509_get0_notAfter(sk_X509_value(verified_chain, i));
 
 			/* Check if expiry time is within last month */


### PR DESCRIPTION
The current code tries to handle tm_mon wrapping, but fails to
increment tm_year - also, there's no handling of, say, March 31 ->
April 31, making the resulting broken-down time invalid, in which case
timegm() need not produce a sensible result.

Instead of doing these fragile computations on a struct tm, just add
30 days to now.

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>