### PR TITLE
src/main: free_status_print(): free slots hash table only if existing

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -930,7 +930,8 @@ static void free_status_print(RaucStatusPrint *status)
 	g_free(status->compatible);
 	g_free(status->variant);
 	g_free(status->bootslot);
-	g_hash_table_destroy(status->slots);
+	if (status->slots)
+		g_hash_table_destroy(status->slots);
 
 	g_free(status);
 	return;


### PR DESCRIPTION
Otherwise this leads to an assertion error in g_hash_table_destroy()
when `RaucStatusPrint` population was aborted early, e.g. due to missing
access to D-Bus.