### PR TITLE
Add option for automatically resizing written ext4 images

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -220,6 +220,11 @@ hierarchical separator.
   matches hash of installed one.
   This replaces the deprecated entry ``ignore-checksum``.
 
+``resize=<true/false>``
+  If set to ``true`` this will tell RAUC to resize the filesystem after having
+  written the image to this slot. This only has an effect when writing an ext4
+  file system to an ext4 slot, i.e. if the slot has``type=ext4`` set.
+
 ``extra-mount-opts=<options>``
   Allows to specify custom mount options that will be passed to the slots
   ``mount`` call as ``-o`` argument value.

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -101,6 +101,8 @@ typedef struct _RaucSlot {
 	gboolean force_install_same;
 	/** extra mount options for this slot */
 	gchar *extra_mount_opts;
+	/** flag indicating to resize after writing (only for ext4) */
+	gboolean resize;
 
 	/** current state of the slot (runtime) */
 	SlotState state;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -409,6 +409,17 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 
 			slot->extra_mount_opts = key_file_consume_string(key_file, groups[i], "extra-mount-opts", NULL);
 
+			slot->resize = g_key_file_get_boolean(key_file, groups[i], "resize", &ierror);
+			if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+				slot->resize = FALSE;
+				g_clear_error(&ierror);
+			}
+			else if (ierror) {
+				g_propagate_error(error, ierror);
+				res = FALSE;
+				goto free;
+			}
+			g_key_file_remove_key(key_file, groups[i], "resize", NULL);
 			g_hash_table_insert(slots, (gchar*)slot->name, slot);
 		}
 		g_strfreev(groupsplit);

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -367,6 +367,34 @@ ignore-checksum=typo\n";
 	g_clear_error(&ierror);
 }
 
+static void config_file_typo_in_boolean_resize_key(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	RaucConfig *config;
+	GError *ierror = NULL;
+	gchar* pathname;
+
+	const gchar *cfg_file = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+\n\
+[slot.rescue.0]\n\
+description=Rescue partition\n\
+device=/dev/null\n\
+type=ext4\n\
+resize=typo\n";
+
+
+	pathname = write_tmp_file(fixture->tmpdir, "invalid_config.conf", cfg_file, NULL);
+	g_assert_nonnull(pathname);
+
+	g_assert_false(load_config(pathname, &config, &ierror));
+	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE);
+	g_clear_error(&ierror);
+}
+
 static void config_file_typo_in_boolean_activate_installed_key(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
@@ -824,6 +852,9 @@ int main(int argc, char *argv[])
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/typo-in-boolean-ignore-checksum-key", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_typo_in_boolean_ignore_checksum_key,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/typo-in-boolean-resize-key", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_typo_in_boolean_resize_key,
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/typo-in-boolean-activate-installed-key", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_typo_in_boolean_activate_installed_key,


### PR DESCRIPTION
This adds a `resize` slot option that will trigger a call of `resize2fs` after having written an ext4 image.

The use case for this is having an image smaller than the actual partition size where the file system should span the entire partition afterwards.