### PR TITLE
Introduce efi-use-bootnext option to change primary-marking behavior

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -68,6 +68,12 @@ Example configuration:
   Only valid when ``bootloader`` is set to ``grub``.
   Specifies the path under which the GRUB environment can be accessed.
 
+``barebox-statename``
+  Only valid when ``bootloader`` is set to ``barebox``.
+  Overwrites the default state ``state`` to a user-defined state name. If this
+  key not exists, the bootchooser framework searches per default for ``/state``
+  or ``/aliases/state``.
+
 .. _activate-installed:
 
 ``activate-installed``
@@ -84,12 +90,6 @@ Example configuration:
   be stored (e.g. slot specific metadata, see :ref:`slot-status`).
   This file should be located on a filesystem which is not overwritten during
   updates.
-
-``barebox-statename``
-  Only valid when ``bootloader`` is set to ``barebox``.
-  Overwrites the default state ``state`` to a user-defined state name. If this
-  key not exists, the bootchooser framework searches per default for ``/state``
-  or ``/aliases/state``.
 
 ``max-bundle-download-size``
   Defines the maximum downloadable bundle size in bytes, and thus must be

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -74,6 +74,14 @@ Example configuration:
   key not exists, the bootchooser framework searches per default for ``/state``
   or ``/aliases/state``.
 
+``efi-use-bootnext``
+  Only valid when ``bootloader`` is set to ``efi``.
+  If set to ``false``, this disables using efi variable ``BootNext`` for
+  marking a slot primary.
+  This is useful for setups where the BIOS already handles the slot switching
+  on watchdog resets.
+  Behavior defaults to ``true`` if option is not set.
+
 .. _activate-installed:
 
 ``activate-installed``
@@ -855,8 +863,12 @@ EFI
   Setting state good is then used to persist this.
 
 :primary:
-  Sets the slot as `BootNext`.
+  Sets the slot as `BootNext` by default.
   This will make the slot being booted upon next reboot only!
+
+  The behavior is different when ``efi-use-bootnext`` is set to ``false``.
+  Then this prepends the slot to the `BootOrder` list as described for 'state
+  good'.
 
 .. note:: EFI implementations differ in how they handle new or unbootable
   targets etc. It may also depend on the actual implementation if EFI variable

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -32,12 +32,12 @@ typedef struct {
 	gchar *system_variant;
 	gchar *system_bootloader;
 	gchar *system_bb_statename;
+	gchar *grubenv_path;
 	/* maximum filesize to download in bytes */
 	guint64 max_bundle_download_size;
 	/* path prefix where rauc may create mount directories */
 	gchar *mount_prefix;
 	gchar *store_path;
-	gchar *grubenv_path;
 	gboolean activate_installed;
 	gchar *statusfile_path;
 	gchar *keyring_path;

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -33,6 +33,7 @@ typedef struct {
 	gchar *system_bootloader;
 	gchar *system_bb_statename;
 	gchar *grubenv_path;
+	gboolean efi_use_bootnext;
 	/* maximum filesize to download in bytes */
 	guint64 max_bundle_download_size;
 	/* path prefix where rauc may create mount directories */

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1130,7 +1130,16 @@ static gboolean efi_set_primary(RaucSlot *slot, GError **error)
 	g_return_val_if_fail(slot, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (!efi_set_temp_primary(slot, &ierror)) {
+	if (r_context()->config->efi_use_bootnext) {
+		if (!efi_set_temp_primary(slot, &ierror)) {
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
+
+		return TRUE;
+	}
+
+	if (!efi_modify_persistent_bootorder(slot, TRUE, &ierror)) {
 		g_propagate_error(error, ierror);
 		return FALSE;
 	}

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -129,6 +129,13 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 
 	if (g_strcmp0(c->system_bootloader, "barebox") == 0) {
 		c->system_bb_statename = key_file_consume_string(key_file, "system", "barebox-statename", NULL);
+	} else if (g_strcmp0(c->system_bootloader, "grub") == 0) {
+		c->grubenv_path = resolve_path(filename,
+				key_file_consume_string(key_file, "system", "grubenv", NULL));
+		if (!c->grubenv_path) {
+			g_debug("No grubenv path provided, using /boot/grub/grubenv as default");
+			c->grubenv_path = g_strdup("/boot/grub/grubenv");
+		}
 	}
 
 	c->max_bundle_download_size = g_key_file_get_uint64(key_file, "system", "max-bundle-download-size", &ierror);
@@ -157,15 +164,6 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	if (!c->mount_prefix) {
 		g_debug("No mount prefix provided, using /mnt/rauc/ as default");
 		c->mount_prefix = g_strdup("/mnt/rauc/");
-	}
-
-	if (g_strcmp0(c->system_bootloader, "grub") == 0) {
-		c->grubenv_path = resolve_path(filename,
-				key_file_consume_string(key_file, "system", "grubenv", NULL));
-		if (!c->grubenv_path) {
-			g_debug("No grubenv path provided, using /boot/grub/grubenv as default");
-			c->grubenv_path = g_strdup("/boot/grub/grubenv");
-		}
 	}
 
 	c->activate_installed = g_key_file_get_boolean(key_file, "system", "activate-installed", &ierror);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -136,6 +136,17 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 			g_debug("No grubenv path provided, using /boot/grub/grubenv as default");
 			c->grubenv_path = g_strdup("/boot/grub/grubenv");
 		}
+	} else if (g_strcmp0(c->system_bootloader, "efi") == 0) {
+		c->efi_use_bootnext = g_key_file_get_boolean(key_file, "system", "efi-use-bootnext", &ierror);
+		if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+			c->efi_use_bootnext = TRUE;
+			g_clear_error(&ierror);
+		} else if (ierror) {
+			g_propagate_error(error, ierror);
+			res = FALSE;
+			goto free;
+		}
+		g_key_file_remove_key(key_file, "system", "efi-use-bootnext", NULL);
 	}
 
 	c->max_bundle_download_size = g_key_file_get_uint64(key_file, "system", "max-bundle-download-size", &ierror);


### PR DESCRIPTION
This adds the efi-use-bootnext option that allows disabling the default
BootNext setting for marking a slot primary as this may be inappropriate
for use cases where the BIOS already handles the slot switching
properly.

For these cases, simply sorting the slot as the first element in the
bootloader is more appropriate.
