### PR TITLE
Two useful improvements for 'rauc status'

### DIFF
--- a/include/config_file.h
+++ b/include/config_file.h
@@ -149,6 +149,26 @@ gboolean default_config(RaucConfig **config);
 RaucSlot *find_config_slot_by_device(RaucConfig *config, const gchar *device);
 
 /**
+ * Finds a slot given its device path.
+ *
+ * @param slots a GHashTable containing (gchar, RaucSlot) entries
+ * @param device the device path to search for
+ *
+ * @return a RaucSlot pointer or NULL
+ */
+RaucSlot *find_slot_by_device(GHashTable *slots, const gchar *device);
+
+/**
+ * Finds a slot given its bootname
+ *
+ * @param slots a GHashTable containing (gchar, RaucSlot) entries
+ * @param botname the bootname to search for
+ *
+ * @return a RaucSlot pointer or NULL
+ */
+RaucSlot *find_slot_by_bootname(GHashTable *slots, const gchar *bootname);
+
+/**
  * Frees the memory allocated by the RaucConfig.
  *
  * @param config a RaucConfig

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -494,12 +494,43 @@ free:
 
 RaucSlot *find_config_slot_by_device(RaucConfig *config, const gchar *device)
 {
+	g_return_val_if_fail(config, NULL);
+
+	return find_slot_by_device(config->slots, device);
+}
+
+RaucSlot *find_slot_by_device(GHashTable *slots, const gchar *device)
+{
 	GHashTableIter iter;
 	RaucSlot *slot;
 
-	g_hash_table_iter_init(&iter, config->slots);
+	g_return_val_if_fail(slots, NULL);
+	g_return_val_if_fail(device, NULL);
+
+	g_hash_table_iter_init(&iter, slots);
 	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
 		if (g_strcmp0(slot->device, device) == 0) {
+			goto out;
+		}
+	}
+
+	slot = NULL;
+
+out:
+	return slot;
+}
+
+RaucSlot *find_slot_by_bootname(GHashTable *slots, const gchar *bootname)
+{
+	GHashTableIter iter;
+	RaucSlot *slot;
+
+	g_return_val_if_fail(slots, NULL);
+	g_return_val_if_fail(bootname, NULL);
+
+	g_hash_table_iter_init(&iter, slots);
+	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
+		if (g_strcmp0(slot->bootname, bootname) == 0) {
 			goto out;
 		}
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -946,13 +946,18 @@ static gchar* r_status_formatter_readable(RaucStatusPrint *status)
 	gint slotcnt = 0;
 	GString *text = g_string_new(NULL);
 	RaucSlot *slot = NULL;
+	RaucSlot *bootedfrom = NULL;
 	gchar *name;
 
 	g_return_val_if_fail(status, NULL);
 
+	bootedfrom = find_slot_by_device(status->slots, status->bootslot);
+	if (!bootedfrom)
+		bootedfrom = find_slot_by_bootname(status->slots, status->bootslot);
+
 	g_string_append_printf(text, "Compatible:  %s\n", status->compatible);
 	g_string_append_printf(text, "Variant:     %s\n", status->variant);
-	g_string_append_printf(text, "Booted from: %s\n", status->bootslot);
+	g_string_append_printf(text, "Booted from: %s (%s)\n", bootedfrom ? bootedfrom->name : NULL, status->bootslot);
 	g_string_append_printf(text, "Activated:   %s (%s)\n", status->primary ? status->primary->name : NULL, status->primary ? status->primary->bootname : NULL);
 
 	g_string_append(text, "slot states:\n");

--- a/src/main.c
+++ b/src/main.c
@@ -1510,12 +1510,10 @@ static gboolean status_start(int argc, char **argv)
 		}
 	}
 
-	if (!print_status(status_print)) {
-		r_exit_status = 1;
-		goto out;
-	}
-
 	if (argc < 3) {
+		if (!print_status(status_print)) {
+			r_exit_status = 1;
+		}
 		goto out;
 	} else if (argc == 3) {
 		slot_identifier = "booted";


### PR DESCRIPTION
* Show slot name in 'Booted from' line
* Do not dump misleading status output on mark-* commands