### PR TITLE
src/install: Add --force-install-same option

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -44,6 +44,8 @@ typedef struct {
 	gchar *handlerextra;
 	/* ignore compatible check */
 	gboolean ignore_compatible;
+	/* force install same option */
+	gboolean force_install_same;
 
 	/* for storing installation runtime informations */
 	RContextInstallationInfo *install_info;

--- a/src/install.c
+++ b/src/install.c
@@ -924,7 +924,8 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 		}
 
 		/* skip if slot is up-to-date */
-		if (!dest_slot->force_install_same && g_strcmp0(mfimage->checksum.digest, slot_state->checksum.digest) == 0) {
+		if (!dest_slot->force_install_same && !r_context()->force_install_same &&
+		    g_strcmp0(mfimage->checksum.digest, slot_state->checksum.digest) == 0) {
 			install_args_update(args, g_strdup_printf("Skipping update for correct image %s", mfimage->filename));
 			g_message("Skipping update for correct image %s", mfimage->filename);
 			r_context_end_step("check_slot", TRUE);

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,7 @@ GMainLoop *r_loop = NULL;
 int r_exit_status = 0;
 
 gboolean install_ignore_compatible = FALSE;
+gboolean install_force_install_same = FALSE;
 gboolean info_noverify, info_dumpcert = FALSE;
 gboolean status_detailed = FALSE;
 gchar *output_format = NULL;
@@ -176,6 +177,7 @@ static gboolean install_start(int argc, char **argv)
 	args->status_result = 2;
 
 	r_context_conf()->ignore_compatible = install_ignore_compatible;
+	r_context_conf()->force_install_same = install_force_install_same;
 
 	r_loop = g_main_loop_new(NULL, FALSE);
 	if (ENABLE_SERVICE) {
@@ -1612,6 +1614,7 @@ typedef struct {
 
 GOptionEntry entries_install[] = {
 	{"ignore-compatible", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_compatible, "disable compatible check", NULL},
+	{"force-install-same", '\0', 0, G_OPTION_ARG_NONE, &install_force_install_same, "unconditionally update slot", NULL},
 	{0}
 };
 


### PR DESCRIPTION
Make 'rauc install --force-install-same' behave as though the
'force-install-same' slot configuration option is set to 'true'.  This
can be useful if you only want to reload a slot with the same contents
occasionally.

Signed-off-by: Ian Abbott <abbotti@mev.co.uk>