### PR TITLE
src/bundle: Correct a g_set_error() format specifier

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -267,7 +267,7 @@ static gboolean input_stream_check_bundle_identifier(GInputStream *stream, GErro
 		g_set_error(error,
 				G_IO_ERROR,
 				G_IO_ERROR_PARTIAL_INPUT,
-				"Only %lu of %lu bytes read",
+				"Only %"G_GSIZE_FORMAT " of %zu bytes read",
 				bytes_read,
 				sizeof(squashfs_id));
 		return FALSE;


### PR DESCRIPTION
'input_stream_check_bundle_identifier()' calls 'g_set_error()' when
'bytes_read != sizeof(squashfs_id)', but the format specifier is
incorrect.  It uses "%lu" for 'bytes_read' (of type 'gsize'), and for
'sizeof(squashfs_id)' (of type 'size_t').  Use "%"G_GSIZE_FORMAT for
'bytes_read' and "%zu" for 'sizeof(squashfs_id)' to avoid compiler
warnings.

Signed-off-by: Ian Abbott <abbotti@mev.co.uk>