### PR TITLE
src/install: notify about post-install operation

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -10,6 +10,7 @@
 
 typedef void (*progress_callback) (gint percentage, const gchar *message,
 		gint nesting_depth);
+typedef void (*operation_callback) (const gchar *message);
 
 typedef struct {
 	/* The bundle currently mounted by RAUC */
@@ -47,6 +48,8 @@ typedef struct {
 
 	/* for storing installation runtime informations */
 	RContextInstallationInfo *install_info;
+
+	operation_callback operation_callback;
 } RaucContext;
 
 typedef struct {
@@ -119,6 +122,7 @@ void r_context_free_progress_step(RaucProgressStep *step);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucProgressStep, r_context_free_progress_step);
 
 void r_context_register_progress_callback(progress_callback progress_cb);
+void r_context_register_operation_callback(operation_callback operation_cb);
 
 RaucContext *r_context_conf(void);
 const RaucContext *r_context(void);

--- a/src/context.c
+++ b/src/context.c
@@ -519,6 +519,15 @@ void r_context_register_progress_callback(progress_callback progress_cb)
 	context->progress_callback = progress_cb;
 }
 
+void r_context_register_operation_callback(operation_callback operation_cb)
+{
+	g_return_if_fail(operation_cb);
+
+	g_assert_null(context->operation_callback);
+
+	context->operation_callback = operation_cb;
+}
+
 RaucContext *r_context_conf(void)
 {
 	if (context == NULL) {

--- a/src/install.c
+++ b/src/install.c
@@ -1344,6 +1344,8 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 
 	if (r_context()->config->postinstall_handler) {
 		g_message("Starting post install handler: %s", r_context()->config->postinstall_handler);
+		if (r_context()->operation_callback)
+			r_context()->operation_callback("post-install");
 		res = launch_and_wait_handler(bundle->mount_point, r_context()->config->postinstall_handler, manifest, target_group, &ierror);
 		if (!res) {
 			g_propagate_prefixed_error(error, ierror, "Post-install handler error: ");

--- a/src/service.c
+++ b/src/service.c
@@ -418,6 +418,12 @@ static void send_progress_callback(gint percentage,
 	g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_installer));
 }
 
+static void send_operation_callback(const gchar *message)
+{
+	if (r_installer)
+		r_installer_set_operation(r_installer, message);
+}
+
 static void r_on_bus_acquired(GDBusConnection *connection,
 		const gchar     *name,
 		gpointer user_data)
@@ -447,6 +453,7 @@ static void r_on_bus_acquired(GDBusConnection *connection,
 			NULL);
 
 	r_context_register_progress_callback(send_progress_callback);
+	r_context_register_operation_callback(send_operation_callback);
 
 	// Set initial Operation status to "idle"
 	r_installer_set_operation(r_installer, "idle");


### PR DESCRIPTION
This change adds an operation callback to the context, thus providing
a possibility to notify DBus listeners when post-install handler is executed

Signed-off-by: Vyacheslav Yurkov <Vyacheslav.Yurkov@bruker.com>