### PR TITLE
src/service: rauc status from install hook fails

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -318,18 +318,7 @@ static GVariant* create_slotstatus_array(void)
 static gboolean r_on_handle_get_slot_status(RInstaller *interface,
 		GDBusMethodInvocation  *invocation)
 {
-	gboolean res;
-
-	res = !r_context_get_busy();
-
-	if (res) {
-		r_installer_complete_get_slot_status(interface, invocation, create_slotstatus_array());
-	} else {
-		g_dbus_method_invocation_return_error(invocation,
-				G_IO_ERROR,
-				G_IO_ERROR_FAILED_HANDLED,
-				"already processing a different method");
-	}
+	r_installer_complete_get_slot_status(interface, invocation, create_slotstatus_array());
 
 	return TRUE;
 }


### PR DESCRIPTION
calling `rauc status --output-format=json` from within
an install hook fails with:
`GDBus.Error:org.gtk.GDBus.UnmappedGError.Quark._g_2dio_2derror_2dquark.Code30: already processing a different method`