### PR TITLE
src/bootchooser:  update grub2 to allow multiple failed attempts

### DIFF
--- a/contrib/grub.conf
+++ b/contrib/grub.conf
@@ -1,4 +1,8 @@
-default=0
+# Dual boot A/B using RAUC this will go in the order given by ORDER and select the 
+# first valid image <slot>_OK=1 and <slot>_TRY != "xxx" (3 failed attempts)
+# if both slots have reached the max failures it will boot the recovery
+# in the future
+
 timeout=3
 
 set ORDER="A B"
@@ -6,53 +10,51 @@ set A_OK=0
 set B_OK=0
 set A_TRY=0
 set B_TRY=0
+DESIRE_BOOT=RESCUE
 load_env
 
 # select bootable slot
 for SLOT in $ORDER; do
     if [ "$SLOT" == "A" ]; then
-        INDEX=1
-        OK=$A_OK
-        TRY=$A_TRY
-        A_TRY=1
+        TRY=${A_TRY}
+        if [ "${A_OK}" -eq 1 -a "${A_TRY}" != "xxx" ]; then
+            A_TRY="${A_TRY}x"
+        else
+            A_OK=0
+        fi
+        OK=${A_OK}
     fi
     if [ "$SLOT" == "B" ]; then
-        INDEX=2
-        OK=$B_OK
-        TRY=$B_TRY
-        B_TRY=1
+        TRY=${B_TRY}
+        if [ "${B_OK}" -eq 1 -a "${B_TRY}" != "xxx" ]; then
+            B_TRY="${B_TRY}x"
+        else
+            B_OK=0
+        fi
+        OK=${B_OK}
     fi
-    if [ "$OK" -eq 1 -a "$TRY" -eq 0 ]; then
-        default=$INDEX
+    if [ "${OK}" -eq 1 ]; then
+        DESIRED_BOOT=${SLOT}
         break
     fi
 done
 
-# reset booted flags
-if [ "$default" -eq 0 ]; then
-    if [ "$A_OK" -eq 1 -a "$A_TRY" -eq 1 ]; then
-        A_TRY=0
-    fi
-    if [ "$B_OK" -eq 1 -a "$B_TRY" -eq 1 ]; then
-        B_TRY=0
-    fi
-fi
-
-save_env A_TRY B_TRY
+default="RAUC_${DESIRED_BOOT}"
+save_env A_TRY B_TRY LAST_TRY A_OK B_OK
 
 CMDLINE="console=ttyS0,115200 net.ifnames=0 panic=60 quiet"
 
-menuentry "Rescue" {
+menuentry "Rescue" --id RAUC_RESCUE {
     linux (hd0,1)/kernel root=/dev/sda1 $CMDLINE rauc.slot=R
     initrd (hd0,1)/initramfs
 }
 
-menuentry "Slot A (OK=$A_OK TRY=$A_TRY)" {
+menuentry "Slot A (OK=$A_OK TRY=$A_TRY)" --id RAUC_A {
     linux (hd0,2)/kernel root=/dev/sda2 $CMDLINE rauc.slot=A
     initrd (hd0,2)/initramfs
 }
 
-menuentry "Slot B (OK=$B_OK TRY=$B_TRY)" {
+menuentry "Slot B (OK=$B_OK TRY=$B_TRY)" --id RAUC_B {
     linux (hd0,3)/kernel root=/dev/sda3 $CMDLINE rauc.slot=B
     initrd (hd0,3)/initramfs
 }

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -341,9 +341,9 @@ bootname=B\n";
 
 	/* check rootfs.0 and rootfs.1 are considered bad (as not marked good or boot attempt failed) */
 	test_grub_initialize_state("\
-A_TRY=1\n\
-B_TRY=0\n\
-A_OK=1\n\
+A_TRY=\n\
+B_TRY=\n\
+A_OK=0\n\
 B_OK=0\n\
 ORDER=A B\n\
 ");
@@ -352,10 +352,10 @@ ORDER=A B\n\
 	g_assert_true(r_boot_get_state(rootfs1, &good, &error));
 	g_assert_false(good);
 
-	/* check rootfs.0 and rootfs.1 are not considered good (A_TRY and B_OK not set) */
+	/* check rootfs.0 and rootfs.1 are not considered good (A_OK and B_OK not set) */
 	test_grub_initialize_state("\
-B_TRY=0\n\
-A_OK=1\n\
+B_TRY=\n\
+A_TRY=\n\
 ORDER=A B\n\
 ");
 	g_assert_false(r_boot_get_state(rootfs0, &good, &error));
@@ -365,10 +365,10 @@ ORDER=A B\n\
 	g_assert_error(error, R_BOOTCHOOSER_ERROR, R_BOOTCHOOSER_ERROR_PARSE_FAILED);
 	g_clear_error(&error);
 
-	/* check rootfs.1 is considered primary (as rootfs.0 has A_TRY=1) */
+	/* check rootfs.1 is considered primary (as rootfs.0 has A_OK=0) */
 	test_grub_initialize_state("\
-A_TRY=1\n\
-B_TRY=0\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=0\n\
 B_OK=1\n\
 ORDER=A B\n\
@@ -380,8 +380,8 @@ ORDER=A B\n\
 
 	/* check none is considered primary (as rootfs.0 has A_OK=0 and rootfs.1 is not in ORDER) */
 	test_grub_initialize_state("\
-A_TRY=0\n\
-B_TRY=0\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=0\n\
 B_OK=1\n\
 ORDER=A\n\
@@ -391,22 +391,10 @@ ORDER=A\n\
 	g_assert_error(error, R_BOOTCHOOSER_ERROR, R_BOOTCHOOSER_ERROR_PARSE_FAILED);
 	g_clear_error(&error);
 
-	/* check none is considered primary (B_TRY is not set, rootfs.0 is not in ORDER) */
-	test_grub_initialize_state("\
-A_TRY=0\n\
-A_OK=0\n\
-B_OK=1\n\
-ORDER=B\n\
-");
-	primary = r_boot_get_primary(&error);
-	g_assert_null(primary);
-	g_assert_error(error, R_BOOTCHOOSER_ERROR, R_BOOTCHOOSER_ERROR_PARSE_FAILED);
-	g_clear_error(&error);
-
 	/* check none is considered primary (B_OK is not set, rootfs.0 is not in ORDER) */
 	test_grub_initialize_state("\
-A_TRY=0\n\
-B_TRY=0\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=0\n\
 ORDER=B\n\
 ");
@@ -417,8 +405,8 @@ ORDER=B\n\
 
 	/* check rootfs.0 + rootfs.1 are considered good */
 	test_grub_initialize_state("\
-A_TRY=0\n\
-B_TRY=0\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=1\n\
 B_OK=1\n\
 ORDER=A B\n\
@@ -430,16 +418,16 @@ ORDER=A B\n\
 
 	/* check rootfs.0 is marked bad (A_OK set to 0) */
 	test_grub_initialize_state("\
-A_TRY=0\n\
-B_TRY=0\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=1\n\
 B_OK=1\n\
 ORDER=A B\n\
 ");
 	g_assert_true(r_boot_set_state(rootfs0, FALSE, &error));
 	g_assert_true(test_grub_post_state("\
-A_TRY=0\n\
-B_TRY=0\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=0\n\
 B_OK=1\n\
 ORDER=A B\n\
@@ -450,16 +438,16 @@ ORDER=A B\n\
 
 	/* check rootfs.0 is marked good (A_OK set to 0) */
 	test_grub_initialize_state("\
-A_TRY=1\n\
-B_TRY=0\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=0\n\
 B_OK=1\n\
 ORDER=A B\n\
 ");
 	g_assert_true(r_boot_set_state(rootfs0, TRUE, &error));
 	g_assert_true(test_grub_post_state("\
-A_TRY=0\n\
-B_TRY=0\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=1\n\
 B_OK=1\n\
 ORDER=A B\n\
@@ -468,18 +456,18 @@ ORDER=A B\n\
 	g_assert_true(r_boot_get_state(rootfs0, &good, &error));
 	g_assert_true(good);
 
-	/* check rootfs.1 is marked primary (B_TRY=0, B_OK=1, B first in ORDER) */
+	/* check rootfs.1 is marked primary (B_OK=1, B first in ORDER) */
 	test_grub_initialize_state("\
-A_TRY=0\n\
-B_TRY=1\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=1\n\
 B_OK=0\n\
 ORDER=A B\n\
 ");
 	g_assert_true(r_boot_set_primary(rootfs1, NULL));
 	g_assert_true(test_grub_post_state("\
-A_TRY=0\n\
-B_TRY=0\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=1\n\
 B_OK=1\n\
 ORDER=B A\n\
@@ -495,16 +483,16 @@ ORDER=B A\n\
 
 	/* check rootfs.1 is marked primary and rootfs.0 is disabled */
 	test_grub_initialize_state("\
-A_TRY=1\n\
-B_TRY=1\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=0\n\
 B_OK=0\n\
 ORDER=A B\n\
 ");
 	g_assert_true(r_boot_set_primary(rootfs1, NULL));
 	g_assert_true(test_grub_post_state("\
-A_TRY=1\n\
-B_TRY=0\n\
+A_TRY=\n\
+B_TRY=\n\
 A_OK=0\n\
 B_OK=1\n\
 ORDER=B A\n\


### PR DESCRIPTION
update bootchooser to allow grub to have N failed attempts before
falling back to next slot.  Only use the %_OK to determine slot
status.  Update the grub.conf example to have 3 tried before
going to next boot option and to use named menuentries for
cleaner grub conf