### PR TITLE
Check that we do not generate a bundle inside a source dir

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -100,6 +100,7 @@ gboolean rm_tree(const gchar *path, GError **error);
  * @param path The path to resolve an absolute path for
  *
  * @return An absolute path name, determined as described above, NULL if undeterminable
+ *         [transfer full]
  */
 gchar *resolve_path(const gchar *basefile, gchar *path);
 

--- a/src/main.c
+++ b/src/main.c
@@ -241,6 +241,8 @@ out:
 static gboolean bundle_start(int argc, char **argv)
 {
 	GError *ierror = NULL;
+	g_autofree gchar *inpath = NULL;
+	g_autofree gchar *outpath = NULL;
 	g_debug("bundle start");
 
 	if (argc < 3) {
@@ -268,8 +270,17 @@ static gboolean bundle_start(int argc, char **argv)
 		goto out;
 	}
 
-	g_debug("input directory: %s", argv[2]);
-	g_debug("output bundle: %s", argv[3]);
+	inpath = resolve_path(NULL, argv[2]);
+	outpath = resolve_path(NULL, argv[3]);
+
+	if (g_str_has_prefix(outpath, inpath)) {
+		g_printerr("Bundle path must be located outside input directory!\n");
+		r_exit_status = 1;
+		goto out;
+	}
+
+	g_debug("input directory: %s", inpath);
+	g_debug("output bundle: %s", outpath);
 
 	if (!update_manifest(argv[2], FALSE, &ierror)) {
 		g_printerr("Failed to update manifest: %s\n", ierror->message);

--- a/src/utils.c
+++ b/src/utils.c
@@ -114,7 +114,7 @@ gchar *resolve_path(const gchar *basefile, gchar *path)
 		return NULL;
 
 	if (g_path_is_absolute(path))
-		return path;
+		return g_strdup(path);
 
 	dir = g_path_get_dirname(basefile);
 	if (g_path_is_absolute(dir))

--- a/src/utils.c
+++ b/src/utils.c
@@ -116,11 +116,15 @@ gchar *resolve_path(const gchar *basefile, gchar *path)
 	if (g_path_is_absolute(path))
 		return g_strdup(path);
 
+	cwd = g_get_current_dir();
+
+	if (!basefile)
+		return g_build_filename(cwd, path, NULL);
+
 	dir = g_path_get_dirname(basefile);
 	if (g_path_is_absolute(dir))
 		return g_build_filename(dir, path, NULL);
 
-	cwd = g_get_current_dir();
 	return g_build_filename(cwd, dir, path, NULL);
 }
 


### PR DESCRIPTION
This will lead to undesired behavior such as endless loops or having
bundle artifacts inside the bundle.

Fixes #21