### PR TITLE
Fix memleaks in resolve_bundle_path (refs #426)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -104,9 +104,10 @@ static gchar *resolve_bundle_path(char *path)
 
 	bundlescheme = g_uri_parse_scheme(path);
 	if (bundlescheme == NULL && !g_path_is_absolute(path)) {
-		bundlelocation = g_build_filename(g_get_current_dir(), path, NULL);
+		g_autofree gchar *cwd = g_get_current_dir();
+		bundlelocation = g_build_filename(cwd, path, NULL);
 	} else {
-		gchar *hostname = NULL;
+		g_autofree gchar *hostname = NULL;
 
 		if (g_strcmp0(bundlescheme, "file") == 0) {
 			bundlelocation = g_filename_from_uri(path, &hostname, &error);


### PR DESCRIPTION
1)
According to documentation g_get_current_dir() returned string should
be freed when no longer needed. So use a g_autofree decorated variable
to buffer the returned pointer.

2)
g_filename_from_uri() allocs memory for the hostname component if found.
But in this case (hostname != NULL) we leave the funtion with return
which does not free (the now assigned) hostname.
We can use g_autofree decoration to fix this without the need to care
about explicitely.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>