### PR TITLE
contrib: grub: export additional variables to environment

### DIFF
--- a/contrib/grub.conf
+++ b/contrib/grub.conf
@@ -38,7 +38,7 @@ if [ "$default" -eq 0 ]; then
     fi
 fi
 
-save_env A_TRY B_TRY
+save_env A_TRY A_OK B_TRY B_OK ORDER
 
 CMDLINE="console=ttyS0,115200 net.ifnames=0 panic=60 quiet"
 


### PR DESCRIPTION
With recent changes to the grub integration (#384) the variables exported by grub.cfg in contrib should also include A_OK, B_OK and ORDER.