### PR TITLE
tail-call real rauc process

### DIFF
--- a/data/rauc-service.sh.in
+++ b/data/rauc-service.sh.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-@bindir@/rauc service
+exec @bindir@/rauc service


### PR DESCRIPTION
Apart from avoiding the small memory overhead of a pointless persistent process, this also ensures signals, etc are sent to the rauc process and not the shell wrapper.