### PR TITLE
src/main.c: A progress bar for RAUC

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -25,7 +25,7 @@
 GMainLoop *r_loop = NULL;
 int r_exit_status = 0;
 
-gboolean install_ignore_compatible = FALSE;
+gboolean install_ignore_compatible, install_progressbar = FALSE;
 gboolean info_noverify, info_dumpcert = FALSE;
 gboolean status_detailed = FALSE;
 gchar *output_format = NULL;
@@ -102,7 +102,7 @@ static void on_installer_changed(GDBusProxy *proxy, GVariant *changed,
 	if (g_variant_lookup(changed, "Operation", "&s", &message)) {
 		g_queue_push_tail(&args->status_messages, g_strdup_printf("%s\n", message));
 	} else if (g_variant_lookup(changed, "Progress", "(i&si)", &percentage, &message, &depth)) {
-		if (isatty(STDOUT_FILENO)) {
+		if (install_progressbar && isatty(STDOUT_FILENO)) {
 			g_autofree gchar *progress = make_progress_line(percentage);
 			/* This does:
 			 * - move to start of line
@@ -1668,6 +1668,7 @@ typedef struct {
 
 GOptionEntry entries_install[] = {
 	{"ignore-compatible", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_compatible, "disable compatible check", NULL},
+	{"progress", '\0', 0, G_OPTION_ARG_NONE, &install_progressbar, "show progress bar", NULL},
 	{0}
 };
 


### PR DESCRIPTION
A little gadget I always wanted to have... And did in the train locally
because of poor german LTE performance...

It gives you a two-lined progress bar while installing with RAUC. The
first line contains the message in the same style as before, the second
line contains a hash-printing progress bar in the width of the current
terminal.

Output will be similar to this:

     50% Checking Bundle done.
    [xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                             ] 50%

This is only activated if we detect a tty, otherwise we use the
old-style printing format.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>