### PR TITLE
Atomic MBR boot partition update

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,7 @@ librauc_la_SOURCES = \
 	src/install.c \
 	src/manifest.c \
 	src/mark.c \
+	src/mbr.c \
 	src/mount.c \
 	src/service.c \
 	src/signature.c \
@@ -56,6 +57,7 @@ librauc_la_SOURCES = \
 	include/install.h \
 	include/manifest.h \
 	include/mark.h \
+	include/mbr.h \
 	include/mount.h \
 	include/service.h \
 	include/signature.h \

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ Features
   * UBIFS
   * raw NAND (using nandwrite)
   * squashfs
+  * MBR partition table
 * Independent from updates source
 
   * **USB Stick**

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -105,6 +105,10 @@ typedef struct _RaucSlot {
 	gchar *extra_mount_opts;
 	/** flag indicating to resize after writing (only for ext4) */
 	gboolean resize;
+	/** start address of first boot-partition (only for boot-mbr-switch) */
+	guint64 region_start;
+	/** size of both partitions(only for boot-mbr-switch) */
+	guint64 region_size;
 
 	/** current state of the slot (runtime) */
 	SlotState state;

--- a/include/mbr.h
+++ b/include/mbr.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <glib.h>
+
+struct mbr_switch_partition {
+	guint64 start;          /* address in bytes */
+	guint64 size;           /* size in bytes */
+};
+
+/**
+ * Get the address and size of the inactive boot partition
+ * if a partition exists in the defined region.
+ *
+ * @param device dev path (/dev/mmcblkX)
+ * @param partition will contain the inactive boot partition (start & size)
+ * @param region_start start address of the region, where bootpartitions are
+ * are inside
+ * @param region_size size of the region, where bootpartitions are are inside
+ * @param error return location for a GError, or NULL
+ *
+ * @return True if succeeded, False if failed
+ */
+gboolean r_mbr_switch_get_inactive_partition(const gchar *device,
+		struct mbr_switch_partition *partition,
+		guint64 region_start, guint64 region_size,
+		GError **error);
+
+/**
+ * Clear the the memory area defined in dest_partition.
+ *
+ * @param device dev path (/dev/mmcblkX)
+ * @param dest_partition partition to be cleared (start & size) *
+ * @param error return location for a GError, or NULL
+ *
+ * @return True if succeeded, False if failed
+ */
+gboolean r_mbr_switch_clear_partition(const gchar *device,
+		const struct mbr_switch_partition *dest_partition,
+		GError **error);
+
+/**
+ * Set the boot partition in master boot record to point to the
+ * partion at address and size in partition.
+ *
+ * @param device dev path (/dev/mmcblkX)
+ * @param partition updated boot partition (start & size)
+ * @param error return location for a GError, or NULL
+ *
+ * @return True if succeeded, False if failed
+ */
+gboolean r_mbr_switch_set_boot_partition(const gchar *device,
+		const struct mbr_switch_partition *partition,
+		GError **error);

--- a/include/utils.h
+++ b/include/utils.h
@@ -113,3 +113,8 @@ gchar * key_file_consume_string(
 		const gchar *group_name,
 		const gchar *key,
 		GError **error);
+
+guint64 key_file_consume_binary_suffixed_string(GKeyFile *key_file,
+		const gchar *group_name,
+		const gchar *key,
+		GError **error);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -431,6 +431,25 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 				goto free;
 			}
 			g_key_file_remove_key(key_file, groups[i], "resize", NULL);
+
+			if (g_strcmp0(slot->type, "boot-mbr-switch") == 0) {
+				slot->region_start = key_file_consume_binary_suffixed_string(key_file, groups[i],
+						"region-start", &ierror);
+				if (ierror) {
+					g_propagate_prefixed_error(error, ierror, "mandatory for boot-mbr-switch: ");
+					res = FALSE;
+					goto free;
+				}
+
+				slot->region_size = key_file_consume_binary_suffixed_string(key_file, groups[i],
+						"region-size", &ierror);
+				if (ierror) {
+					g_propagate_prefixed_error(error, ierror, "mandatory for boot-mbr-switch: ");
+					res = FALSE;
+					goto free;
+				}
+			}
+
 			g_hash_table_insert(slots, (gchar*)slot->name, slot);
 		}
 		g_strfreev(groupsplit);

--- a/src/mbr.c
+++ b/src/mbr.c
@@ -1,0 +1,444 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <glib/gstdio.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/mount.h>
+#include <linux/hdreg.h>
+
+#include "mbr.h"
+#include "update_handler.h"
+
+/* partition entry in MBR partition table, the system boots from */
+#define BOOT_PARTITION_ENTRY		0
+#define MBR_NUMBER_OF_PARTITIONS	4
+#define MBR_MAGIC_NUMBER_L		0x55
+#define MBR_MAGIC_NUMBER_H		0xAA
+
+struct chs_entry {
+	guint8 head;
+	guint8 sector;
+	guint8 cylinder;
+};
+
+struct mbr {
+	guint8 bootstrap_code[440];
+	guint32 disk_signature;
+	guint16 unused;
+	struct partition_tbl_entry {
+		guint8 boot_indicator;
+		struct chs_entry chs_start;
+		guint8 type;
+		struct chs_entry chs_end;
+		guint32 partition_start;
+		guint32 partition_size;
+	} partition_table[MBR_NUMBER_OF_PARTITIONS];
+	guint8 magic_number[2];
+} __attribute__((packed));
+
+G_STATIC_ASSERT(sizeof(struct mbr) == 512);
+
+static guint get_sectorsize(gint fd)
+{
+	guint sector_size;
+
+	if (ioctl(fd, BLKSSZGET, &sector_size) != 0)
+		return 512;
+
+	return sector_size;
+}
+
+static gboolean get_number_of_sectors(gint fd, guint *sectors,
+		GError **error)
+{
+	g_return_val_if_fail(sectors, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (ioctl(fd, BLKGETSIZE, sectors) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"ioctl command 0x%04x failed: %s",
+				BLKGETSIZE, g_strerror(errno));
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean get_hd_geometry(gint fd, struct hd_geometry *geometry,
+		GError **error)
+{
+	g_return_val_if_fail(geometry, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (ioctl(fd, HDIO_GETGEO, geometry) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"ioctl command 0x%04x failed: %s",
+				HDIO_GETGEO, g_strerror(errno));
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean validate_region(gint fd, guint64 start, guint64 size,
+		guint sector_size, GError **error)
+{
+	gboolean res = FALSE;
+	guint number_of_sectors;
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (start < sizeof(struct mbr) || size == 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"no valid configuration for region");
+		goto out;
+	}
+
+	if ((start % (2 * sector_size)) != 0 || (size % (2 * sector_size)) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Region configuration is not aligned to the double"
+				"sector-size %d", 2 * sector_size);
+		goto out;
+	}
+
+	res = get_number_of_sectors(fd, &number_of_sectors, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
+	if ((start + size) >= (guint64)number_of_sectors * sector_size) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Region configuration is bigger than device");
+		res = FALSE;
+		goto out;
+	}
+
+out:
+	return res;
+}
+
+static gboolean read_mbr(gint fd, struct mbr *mbr, GError **error)
+{
+	g_return_val_if_fail(mbr, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (read(fd, mbr, sizeof(*mbr)) != sizeof(*mbr)) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Read: %s", g_strerror(errno));
+		return FALSE;
+	}
+
+	if (mbr->magic_number[0] != MBR_MAGIC_NUMBER_L ||
+	    mbr->magic_number[1] != MBR_MAGIC_NUMBER_H) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"No valid master boot record found");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean is_region_free(guint64 region_start, guint64 region_size,
+		const struct partition_tbl_entry *partition_tbl, guint sector_size,
+		GError **error)
+{
+	guint64 p_start, p_end;
+	guint i;
+
+	g_return_val_if_fail(partition_tbl, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	for (i = 0; i < MBR_NUMBER_OF_PARTITIONS; i++) {
+		if (i == BOOT_PARTITION_ENTRY)
+			continue;
+
+		p_start = (guint64)partition_tbl[i].partition_start * sector_size;
+		p_end = (guint64)partition_tbl[i].partition_size * sector_size +
+		        p_start - 1;
+
+		if (region_start >= p_start && region_start <= p_end)
+		{
+			g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+					"Region start address 0x%lx is in area of "
+					"partition %d (0x%lx - 0x%lx)",
+					region_start, i, p_start, p_end);
+			break;
+		}
+
+		if (p_start >= region_start &&
+		    p_start <= region_start + region_size - 1)
+		{
+			g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+					"Region end address 0x%lx is in area of "
+					"partition %d (0x%lx - 0x%lx)",
+					region_start + region_size - 1, i, p_start,
+					p_end);
+			break;
+		}
+	}
+
+	if (i < MBR_NUMBER_OF_PARTITIONS)
+		return FALSE;
+
+	return TRUE;
+}
+
+/**
+ * Calculation of the CHS value from an LBA value
+ *
+ * The 3 CHS bytes in Partition are stored with following layout:
+ *   - 8 bits for HEAD
+ *   - upper 2 bits for CYLINDER
+ *   - 6 bits for SECTOR
+ *   - lower 8 bits for CYLINDER
+ */
+static void get_chs(struct chs_entry *chs, guint32 lba,
+		const struct hd_geometry *geometry)
+{
+	g_return_if_fail(chs);
+	g_return_if_fail(geometry);
+
+	chs->sector = lba % geometry->sectors + 1;
+
+	lba /= geometry->sectors;
+	chs->head = lba % geometry->heads;
+
+	lba /= geometry->heads;
+	chs->cylinder = lba & 0xFF;
+
+	/* Move bit 8 & 9 of cylinder to bit 6 & 7 of sector */
+	chs->sector |= (lba >> 2) & 0xC0;
+}
+
+static gboolean get_raw_partition_entry(gint fd,
+		struct partition_tbl_entry *raw_entry,
+		const struct mbr_switch_partition *partition, GError **error)
+{
+	gboolean res = FALSE;
+	guint sector_size;
+	struct hd_geometry geometry;
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(raw_entry, FALSE);
+	g_return_val_if_fail(partition, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	sector_size = get_sectorsize(fd);
+
+	if (partition->start % sector_size || partition->size % sector_size) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Partition start address or size is not a multipe"
+				" of sector size %d", sector_size);
+		goto out;
+	}
+
+	res = get_hd_geometry(fd, &geometry, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
+	raw_entry->partition_start = partition->start / sector_size;
+	raw_entry->partition_size = partition->size / sector_size;
+
+	get_chs(&raw_entry->chs_start, raw_entry->partition_start, &geometry);
+
+	get_chs(&raw_entry->chs_end,
+			raw_entry->partition_start + raw_entry->partition_size - 1,
+			&geometry);
+out:
+	return res;
+}
+
+gboolean r_mbr_switch_get_inactive_partition(const gchar *device,
+		struct mbr_switch_partition *partition,
+		guint64 region_start, guint64 region_size,
+		GError **error)
+{
+	gboolean res = FALSE;
+	struct mbr mbr;
+	GError *ierror = NULL;
+	struct partition_tbl_entry *boot_part;
+	guint sector_size;
+	gint fd;
+
+	g_return_val_if_fail(device, FALSE);
+	g_return_val_if_fail(partition, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	fd = g_open(device, O_RDONLY);
+
+	sector_size = get_sectorsize(fd);
+
+	res = validate_region(fd, region_start, region_size, sector_size, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
+	res = read_mbr(fd, &mbr, &ierror);
+	if (!res) {
+		g_propagate_prefixed_error(error, ierror,
+				"Failed to read MBR:");
+		goto out;
+	}
+
+	/* check if region overlaps with any partition */
+	res = is_region_free(region_start, region_size, mbr.partition_table,
+			sector_size, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+	res = FALSE;
+
+	boot_part = &mbr.partition_table[BOOT_PARTITION_ENTRY];
+
+	if (boot_part->partition_start == 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"No boot partition found in entry %d",
+				BOOT_PARTITION_ENTRY);
+		goto out;
+	}
+
+	if ((region_start / sector_size) ==
+	    (guint64)boot_part->partition_start) {
+		partition->start = region_start + region_size / 2;
+	}
+	else if (((region_start + region_size / 2) / sector_size) ==
+	         (guint64)boot_part->partition_start) {
+		partition->start = region_start;
+	}
+	else {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Boot partition's start address does not match "
+				"region configuration");
+		goto out;
+	}
+	partition->size = region_size / 2;
+
+	res = TRUE;
+out:
+	if (fd >= 0)
+		g_close(fd, NULL);
+
+	return res;
+}
+
+gboolean r_mbr_switch_clear_partition(const gchar *device,
+		const struct mbr_switch_partition *dest_partition,
+		GError **error)
+{
+	gboolean res = FALSE;
+	static gchar zerobuf[512] = {};
+	gint clear_size = sizeof(zerobuf);
+	guint clear_count = 0;
+	gint tmp_count = 0;
+	gint fd;
+
+	g_return_val_if_fail(device, FALSE);
+	g_return_val_if_fail(dest_partition, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	fd = g_open(device, O_RDWR);
+	if (fd == -1) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Opening device failed: %s",
+				g_strerror(errno));
+		goto out;
+	}
+
+	if (lseek(fd, dest_partition->start, SEEK_SET) !=
+	    (off_t)dest_partition->start) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Failed to set file to position %lu: %s",
+				dest_partition->start, g_strerror(errno));
+		goto out;
+	}
+
+	while (clear_count < dest_partition->size) {
+		if ((dest_partition->size - clear_count) < sizeof(zerobuf))
+			clear_size = dest_partition->size - clear_count;
+
+		tmp_count = write(fd, zerobuf, clear_size);
+
+		if (tmp_count < 0)
+			break;
+
+		clear_count += tmp_count;
+	}
+
+	if (clear_count != dest_partition->size) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Failed to clear partition: %s",
+				g_strerror(errno));
+		goto out;
+	}
+	res = TRUE;
+out:
+	if (fd >= 0)
+		g_close(fd, NULL);
+
+	return res;
+}
+
+gboolean r_mbr_switch_set_boot_partition(const gchar *device,
+		const struct mbr_switch_partition *partition,
+		GError **error)
+{
+	gboolean res = FALSE;
+	struct mbr mbr;
+	struct partition_tbl_entry *boot_part;
+	GError *ierror = NULL;
+	gint fd;
+
+	g_return_val_if_fail(device, FALSE);
+	g_return_val_if_fail(partition, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	fd = g_open(device, O_RDWR);
+	if (fd == -1) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Opening device failed: %s",
+				g_strerror(errno));
+		goto out;
+	}
+
+	res = read_mbr(fd, &mbr, &ierror);
+	if (!res) {
+		g_propagate_prefixed_error(error, ierror,
+				"Failed to read MBR:");
+		goto out;
+	}
+
+	boot_part = &mbr.partition_table[BOOT_PARTITION_ENTRY];
+
+	res = get_raw_partition_entry(fd, boot_part, partition, &ierror);
+	if (!res) {
+		g_propagate_prefixed_error(error, ierror,
+				"Failed to create new partition entry:");
+		goto out;
+	}
+
+	if (lseek(fd, 0, SEEK_SET) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Failed to seek to position 0");
+		goto out;
+	}
+
+	if (write(fd, &mbr, sizeof(mbr)) != sizeof(mbr)) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Could not write new MBR: %s",
+				g_strerror(errno));
+		goto out;
+	}
+
+	res = TRUE;
+out:
+	if (fd >= 0)
+		g_close(fd, NULL);
+
+	return res;
+}


### PR DESCRIPTION
This introduces a possibility to update a bootloader on a FAT partition, for SoCs with a ROM code which boots from the first partition in the MBR partition table, by changing the partition table.