### PR TITLE
bootchooser: a failure in calling barebox_state should be propagated

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -241,9 +241,8 @@ static RaucSlot* barebox_get_primary(GError **error)
 			continue;
 
 		if (!barebox_state_get(slot->bootname, &state, &ierror)) {
-			g_debug("%s", ierror->message);
-			g_clear_error(&ierror);
-			continue;
+			g_propagate_error(error, ierror);
+			return NULL;
 		}
 
 		if (state.attempts == 0)


### PR DESCRIPTION
When getting an error while calling barebox state on a slot that has a
bootname set, this should always fail.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>