### PR TITLE
configure: refine D-Bus install directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ jobs:
       before_script:
         - docker exec -it cross uname -a
         - docker exec -it cross apt-get update
-        - docker exec -it cross apt-get install -y build-essential automake libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev
+        - docker exec -it cross apt-get install -y build-essential automake libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev
       script:
         - docker exec -it cross ./autogen.sh
         - docker exec -it cross ./configure

--- a/Makefile.am
+++ b/Makefile.am
@@ -90,8 +90,8 @@ systemdunitdir=$(SYSTEMD_UNITDIR)
 nodist_systemdunit_DATA = data/rauc.service
 endif
 
-dbussystemdir = $(DBUS_SYSTEMSERVICEDIR)
-nodist_dbussystem_DATA = data/de.pengutronix.rauc.service
+dbussystemservicedir = $(DBUS_SYSTEMSERVICEDIR)
+nodist_dbussystemservice_DATA = data/de.pengutronix.rauc.service
 
 dbuspolicydir = $(DBUS_POLICYDIR)
 dist_dbuspolicy_DATA = data/de.pengutronix.rauc.conf
@@ -238,11 +238,11 @@ EXTRA_DIST += $(wildcard docs/*.rst)
 AM_DISTCHECK_CONFIGURE_FLAGS = \
     --without-systemdunitdir \
     --with-dbuspolicydir=$$dc_install_base/$(dbuspolicydir) \
-    --with-dbussystemservicedir=$$dc_install_base/$(dbussystemdir)
+    --with-dbussystemservicedir=$$dc_install_base/$(dbussystemservicedir)
 
 CLEANFILES = $(gdbus_installer_generated) \
 	     $(nodist_systemdunit_DATA) \
-	     $(nodist_dbussystem_DATA) \
+	     $(nodist_dbussystemservice_DATA) \
 	     $(nodist_dbuswrapper_SCRIPTS) \
 	     data/rauc.service \
 	     test/empty.dat \

--- a/Makefile.am
+++ b/Makefile.am
@@ -235,7 +235,10 @@ EXTRA_DIST += docs/extensions
 EXTRA_DIST += docs/release-checklist.txt
 EXTRA_DIST += $(wildcard docs/*.rst)
 
-AM_DISTCHECK_CONFIGURE_FLAGS = "--without-systemdunitdir"
+AM_DISTCHECK_CONFIGURE_FLAGS = \
+    --without-systemdunitdir \
+    --with-dbuspolicydir=$$dc_install_base/$(dbuspolicydir) \
+    --with-dbussystemservicedir=$$dc_install_base/$(dbussystemdir)
 
 CLEANFILES = $(gdbus_installer_generated) \
 	     $(nodist_systemdunit_DATA) \

--- a/Makefile.am
+++ b/Makefile.am
@@ -236,7 +236,7 @@ EXTRA_DIST += docs/release-checklist.txt
 EXTRA_DIST += $(wildcard docs/*.rst)
 
 AM_DISTCHECK_CONFIGURE_FLAGS = \
-    --without-systemdunitdir \
+    --with-systemdunitdir=$$dc_install_base/$(systemdunitdir) \
     --with-dbuspolicydir=$$dc_install_base/$(dbuspolicydir) \
     --with-dbussystemservicedir=$$dc_install_base/$(dbussystemservicedir)
 

--- a/README.rst
+++ b/README.rst
@@ -121,13 +121,14 @@ Host (Build) Prerequisites
 
 -  automake
 -  libtool
+-  libdbus-1-dev
 -  libglib2.0-dev
 -  libcurl3-dev
 -  libssl-dev
 
 ::
 
-   sudo apt-get install automake libtool libglib2.0-dev libcurl3-dev libssl-dev
+   sudo apt-get install automake libtool libdbus-1-dev libglib2.0-dev libcurl3-dev libssl-dev
 
 If you intend to use json-support you also need
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,7 @@ AS_IF([test "x$enable_service" != "xno"], [
 
 # Checks for libraries.
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.45.8 gio-2.0 gio-unix-2.0])
+PKG_CHECK_MODULES([DBUS1], [dbus-1])
 
 AC_ARG_ENABLE([network],
        AS_HELP_STRING([--disable-network], [Disable network update mode])
@@ -89,14 +90,14 @@ AM_CONDITIONAL(SYSTEMD, test -n "${with_systemdunitdir}")
 AC_ARG_WITH([dbuspolicydir],
         AS_HELP_STRING([--with-dbuspolicydir=DIR], [D-Bus policy directory]),
         [],
-        [with_dbuspolicydir=${datadir}/dbus-1/system.d])
+        [with_dbuspolicydir="$($PKG_CONFIG --variable=datadir dbus-1)/dbus-1/system.d"])
 DBUS_POLICYDIR="${with_dbuspolicydir}"
 AC_SUBST(DBUS_POLICYDIR)
 
 AC_ARG_WITH([dbussystemservicedir],
         AS_HELP_STRING([--with-dbussystemservicedir=DIR], [D-Bus system service directory]),
         [],
-        [with_dbussystemservicedir=${datadir}/dbus-1/system-services])
+        [with_dbussystemservicedir="$($PKG_CONFIG --variable=system_bus_services_dir dbus-1)"])
 DBUS_SYSTEMSERVICEDIR="${with_dbussystemservicedir}"
 AC_SUBST(DBUS_SYSTEMSERVICEDIR)
 

--- a/configure.ac
+++ b/configure.ac
@@ -78,9 +78,10 @@ AS_IF([test "x$enable_json" != "xno"], [
 
 AX_CHECK_OPENSSL([],[AC_MSG_ERROR([OpenSSL not found])])
 
-AC_ARG_WITH([systemdunitdir], AC_HELP_STRING([--with-systemdunitdir=DIR],
-	[path to systemd service directory]), [with_systemdunitdir=${withval}],
-		[with_systemdunitdir="`$PKG_CONFIG --variable=systemdsystemunitdir systemd`"])
+AC_ARG_WITH([systemdunitdir],
+        AC_HELP_STRING([--with-systemdunitdir=DIR], [path to systemd service directory]),
+        [],
+        [with_systemdunitdir="$($PKG_CONFIG --variable=systemdsystemunitdir systemd)"])
 if (test -n "${with_systemdunitdir}"); then
 	SYSTEMD_UNITDIR="${with_systemdunitdir}"
 	AC_SUBST(SYSTEMD_UNITDIR)

--- a/data/de.pengutronix.rauc.conf
+++ b/data/de.pengutronix.rauc.conf
@@ -3,7 +3,7 @@
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
   <!-- This config allows anyone to control rauc -->
-  <!-- It is usually installed to /etc/dbus-1/system.d -->
+  <!-- It is usually installed to /usr/share/dbus-1/system.d -->
 
   <policy context="default">
     <allow send_destination="de.pengutronix.rauc"/>


### PR DESCRIPTION
For the D-Bus system service directory, we can rely on pkg-config
to query the target directory, instead of constructing our own
assumption.

For D-Bus policy directory, there is no such pkg-config variable.
However, D-Bus's $datadir might be different from ours, so use
D-Bus's ones.

This allows to compile/install rauc to /usr/local but place the
D-Bus config files in the directories which are considered by
distribution's D-Bus.

While at, adjust the syntax for systemd service directory part
a little bit to match the D-Bus stuff.

We also rename some internal autoconf variables to match the
configure parameter names.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>