### PR TITLE
.uncrustify.cfg: enforce space between if and '('

### DIFF
--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -12,5 +12,6 @@ indent_func_param_double        = true
 indent_switch_case              = 8
 nl_fdef_brace                   = add
 align_keep_tabs                 = true
+sp_before_sparen                = true
 # option(s) with 'not default' value: 13
 #

--- a/src/context.c
+++ b/src/context.c
@@ -570,7 +570,7 @@ void r_context_clean(void)
 		context->keyringpath = NULL;
 		context->keyringdirectory = NULL;
 
-		if(context->config) {
+		if (context->config) {
 			context->config->keyring_path = NULL;
 		}
 	}

--- a/src/network.c
+++ b/src/network.c
@@ -104,7 +104,7 @@ static gboolean transfer(RaucTransfer *xfer, GError **error)
 		goto out;
 	} else if (r != CURLE_OK) {
 		size_t len = strlen(errbuf);
-		if(len)
+		if (len)
 			g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Transfer failed: %s%s", errbuf, ((errbuf[len - 1] != '\n') ? "\n" : ""));
 		else
 			g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Transfer failed: %s", curl_easy_strerror(res));

--- a/src/signature.c
+++ b/src/signature.c
@@ -654,7 +654,7 @@ gboolean cms_get_cert_chain(CMS_ContentInfo *cms, X509_STORE *store, STACK_OF(X5
 		goto out;
 	}
 
-	if(X509_verify_cert(cert_ctx) != 1) {
+	if (X509_verify_cert(cert_ctx) != 1) {
 		g_set_error(
 				error,
 				R_SIGNATURE_ERROR,

--- a/src/utils.c
+++ b/src/utils.c
@@ -75,7 +75,7 @@ gboolean copy_file(const gchar *srcprefix, const gchar *srcfile,
 static int rm_tree_cb(const char *fpath, const struct stat *sb,
 		int typeflag, struct FTW *ftwbuf)
 {
-	switch(typeflag) {
+	switch (typeflag) {
 		case FTW_F:
 		case FTW_SL:
 			return g_unlink(fpath);


### PR DESCRIPTION
This is the de-facto default we use in the entire code except for a very
few cases where not yet. We fix them now.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>