### PR TITLE
src/main: strip possible remote error information in retrieve_status_…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1412,6 +1412,8 @@ static gboolean retrieve_status_via_dbus(RaucStatusPrint **status_print, GError 
 	}
 
 	if (!r_installer_call_get_primary_sync(proxy, &primary, NULL, &ierror)) {
+		if (g_dbus_error_is_remote_error(ierror))
+			g_dbus_error_strip_remote_error(ierror);
 		g_warning("%s", ierror->message);
 		g_clear_error(&ierror);
 	}


### PR DESCRIPTION
…via_dbus()

Turns message

    (rauc:12601): rauc-WARNING **: 15:39:38.369: GDBus.Error:org.gtk.GDBus.UnmappedGError.Quark._g_2dio_2derror_2dquark.Code30: Failed getting primary slot: Obtaining primary entry from bootloader 'noop' not supported yet

into

    (rauc:12601): rauc-WARNING **: 15:39:38.369: Failed getting primary slot: Obtaining primary entry from bootloader 'noop' not supported yet

As there is currently no benefit in keeping the remote informatio or
applying remote GError mapping, this simple handling is sufficient.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>