### PR TITLE
Add new InstallBundle Method to D-Bus API

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -654,7 +654,9 @@ de.pengutronix.rauc.Installer
 
 Methods
 ~~~~~~~
-:ref:`Install <gdbus-method-de-pengutronix-rauc-Installer.Install>` (IN  s source);
+:ref:`InstallBundle <gdbus-method-de-pengutronix-rauc-Installer.InstallBundle>` (IN  s source, IN a{sv} args);
+
+:ref:`Install <gdbus-method-de-pengutronix-rauc-Installer.Install>` (IN  s source); (deprecated)
 
 :ref:`Info <gdbus-method-de-pengutronix-rauc-Installer.Info>` (IN  s bundle, s compatible, s version);
 
@@ -688,10 +690,38 @@ Description
 Method Details
 ~~~~~~~~~~~~~~
 
+.. _gdbus-method-de-pengutronix-rauc-Installer.InstallBundle:
+
+The InstallBundle() Method
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+  de.pengutronix.rauc.Installer.InstallBundle()
+  Install (IN  s source, IN a{sv} args);
+
+Triggers the installation of a bundle.
+This method call is non-blocking.
+After completion, the :ref:`"Completed" <gdbus-signal-de-pengutronix-rauc-Installer.Completed>` signal will be emitted.
+
+IN s *source*:
+    Path to bundle to be installed
+
+IN a{sv} *args*:
+    Arguments to pass to installation
+
+    Currently supported:
+
+    :STRING 'ignore-compatible', VARIANT 'b' <true/false>: Ignore the default compatible check for forcing
+        installation of bundles on platforms that a compatible not matching the one
+        of the bundle to be installed
+
 .. _gdbus-method-de-pengutronix-rauc-Installer.Install:
 
 The Install() Method
 ^^^^^^^^^^^^^^^^^^^^
+
+.. note:: This method is deprecated.
 
 .. code::
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -476,12 +476,12 @@ Installing a Bundle
 The D-Bus API's main purpose is to trigger and monitor the installation
 process via its ``Installer`` interface.
 
-The ``Install`` method call triggers the installation of a given bundle in the
+The ``InstallBundle`` method call triggers the installation of a given bundle in the
 background and returns immediately.
 Upon completion of the installation RAUC emits the ``Completed`` signal,
 indicating either successful or failed installation.
 For details on triggering the installation process, see the
-:ref:`gdbus-method-de-pengutronix-rauc-Installer.Install` chapter in the
+:ref:`gdbus-method-de-pengutronix-rauc-Installer.InstallBundle` chapter in the
 reference documentation.
 
 While the installation is in progress, constant progress information will be
@@ -533,7 +533,7 @@ Triggering an installation:
 
 .. code-block:: sh
 
-  busctl call de.pengutronix.rauc / de.pengutronix.rauc.Installer Install s "/path/to/bundle"
+  busctl call de.pengutronix.rauc / de.pengutronix.rauc.Installer InstallBundle sa{sv} "/path/to/bundle" 0
 
 Mark a slot as good:
 

--- a/include/context.h
+++ b/include/context.h
@@ -45,8 +45,6 @@ typedef struct {
 
 	/* optional custom handler extra arguments */
 	gchar *handlerextra;
-	/* ignore compatible check */
-	gboolean ignore_compatible;
 
 	/* for storing installation runtime informations */
 	RContextInstallationInfo *install_info;

--- a/include/install.h
+++ b/include/install.h
@@ -29,6 +29,8 @@ typedef struct {
 	GMutex status_mutex;
 	GQueue status_messages;
 	gint status_result;
+	/* install options */
+	gboolean ignore_compatible;
 } RaucInstallArgs;
 
 /**

--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -10,6 +10,18 @@
       <arg name="source" type="s"/>
     </method>
 
+    <!--
+         InstallBundle:
+         @source: Path to bundle to be installed
+         @args: Additional arguments to pass
+
+         Triggers an installation.
+    -->
+    <method name="InstallBundle">
+      <arg name="source" type="s"/>
+      <arg name="args" type="a{sv}" direction="in"/>
+    </method>
+
    <!--
     Info: D-Bus variant of rauc info <bundle>
     @bundle: full path to the queried bundle.

--- a/src/install.c
+++ b/src/install.c
@@ -446,9 +446,9 @@ static void parse_handler_output(gchar* line)
 	}
 }
 
-static gboolean verify_compatible(RaucManifest *manifest)
+static gboolean verify_compatible(RaucInstallArgs *args, RaucManifest *manifest)
 {
-	if (r_context()->ignore_compatible) {
+	if (args->ignore_compatible) {
 		return TRUE;
 	} else if (g_strcmp0(r_context()->config->system_compatible,
 			manifest->update_compatible) == 0) {
@@ -691,7 +691,7 @@ static gboolean launch_and_wait_custom_handler(RaucInstallArgs *args, gchar* bun
 			res = FALSE;
 			goto out;
 		}
-	} else if (!verify_compatible(manifest)) {
+	} else if (!verify_compatible(args, manifest)) {
 		g_set_error_literal(error, R_INSTALL_ERROR, R_INSTALL_ERROR_COMPAT_MISMATCH,
 				"Compatible mismatch");
 		res = FALSE;
@@ -793,7 +793,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 			res = FALSE;
 			goto early_out;
 		}
-	} else if (!verify_compatible(manifest)) {
+	} else if (!verify_compatible(args, manifest)) {
 		res = FALSE;
 		g_set_error_literal(error, R_INSTALL_ERROR, R_INSTALL_ERROR_COMPAT_MISMATCH,
 				"Compatible mismatch");

--- a/src/main.c
+++ b/src/main.c
@@ -225,11 +225,13 @@ static gboolean install_start(int argc, char **argv)
 	args->cleanup = install_cleanup;
 	args->status_result = 2;
 
-	r_context_conf()->ignore_compatible = install_ignore_compatible;
+	args->ignore_compatible = install_ignore_compatible;
 
 	r_loop = g_main_loop_new(NULL, FALSE);
 	if (ENABLE_SERVICE) {
 		g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
+
+		g_variant_dict_insert(&dict, "ignore-compatible", "b", args->ignore_compatible);
 
 		installer = r_installer_proxy_new_for_bus_sync(bus_type,
 				G_DBUS_PROXY_FLAGS_GET_INVALIDATED_PROPERTIES,

--- a/src/main.c
+++ b/src/main.c
@@ -229,6 +229,8 @@ static gboolean install_start(int argc, char **argv)
 
 	r_loop = g_main_loop_new(NULL, FALSE);
 	if (ENABLE_SERVICE) {
+		g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
+
 		installer = r_installer_proxy_new_for_bus_sync(bus_type,
 				G_DBUS_PROXY_FLAGS_GET_INVALIDATED_PROPERTIES,
 				"de.pengutronix.rauc", "/", NULL, &error);
@@ -248,7 +250,11 @@ static gboolean install_start(int argc, char **argv)
 			goto out_loop;
 		}
 		g_debug("Trying to contact rauc service");
-		if (!r_installer_call_install_sync(installer, args->name, NULL,
+		if (!r_installer_call_install_bundle_sync(
+				installer,
+				args->name,
+				g_variant_dict_end(&dict), /* floating, no unref needed */
+				NULL,
 				&error)) {
 			g_printerr("Failed %s\n", error->message);
 			g_error_free(error);

--- a/src/service.c
+++ b/src/service.c
@@ -58,6 +58,7 @@ static gboolean r_on_handle_install_bundle(
 		GVariant *arg_args)
 {
 	RaucInstallArgs *args = install_args_new();
+	g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(arg_args);
 	gboolean res;
 
 	g_print("input bundle: %s\n", source);
@@ -69,6 +70,8 @@ static gboolean r_on_handle_install_bundle(
 	args->name = g_strdup(source);
 	args->notify = service_install_notify;
 	args->cleanup = service_install_cleanup;
+
+	g_variant_dict_lookup(&dict, "ignore-compatible", "b", &args->ignore_compatible);
 
 	r_installer_set_operation(r_installer, "installing");
 	g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_installer));

--- a/src/service.c
+++ b/src/service.c
@@ -51,9 +51,11 @@ static gboolean service_install_cleanup(gpointer data)
 	return G_SOURCE_REMOVE;
 }
 
-static gboolean r_on_handle_install(RInstaller *interface,
-		GDBusMethodInvocation  *invocation,
-		const gchar *source)
+static gboolean r_on_handle_install_bundle(
+		RInstaller *interface,
+		GDBusMethodInvocation *invocation,
+		const gchar *source,
+		GVariant *arg_args)
 {
 	RaucInstallArgs *args = install_args_new();
 	gboolean res;
@@ -91,6 +93,13 @@ out:
 	return TRUE;
 }
 
+static gboolean r_on_handle_install(RInstaller *interface,
+		GDBusMethodInvocation  *invocation,
+		const gchar *arg_source)
+{
+	g_message("Using deprecated 'Install' D-Bus Method (replaced by 'InstallBundle')");
+	return r_on_handle_install_bundle(interface, invocation, arg_source, NULL);
+}
 
 static gboolean r_on_handle_info(RInstaller *interface,
 		GDBusMethodInvocation  *invocation,
@@ -427,6 +436,10 @@ static void r_on_bus_acquired(GDBusConnection *connection,
 
 	g_signal_connect(r_installer, "handle-install",
 			G_CALLBACK(r_on_handle_install),
+			NULL);
+
+	g_signal_connect(r_installer, "handle-install-bundle",
+			G_CALLBACK(r_on_handle_install_bundle),
 			NULL);
 
 	g_signal_connect(r_installer, "handle-info",

--- a/src/service.c
+++ b/src/service.c
@@ -64,8 +64,10 @@ static gboolean r_on_handle_install_bundle(
 	g_print("input bundle: %s\n", source);
 
 	res = !r_context_get_busy();
-	if (!res)
+	if (!res) {
+		args->status_result = 1;
 		goto out;
+	}
 
 	args->name = g_strdup(source);
 	args->notify = service_install_notify;
@@ -77,12 +79,13 @@ static gboolean r_on_handle_install_bundle(
 	g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_installer));
 	res = install_run(args);
 	if (!res) {
+		args->status_result = 1;
 		goto out;
 	}
 	args = NULL;
 
 out:
-	g_clear_pointer(&args, g_free);
+	g_clear_pointer(&args, install_args_free);
 	if (res) {
 		r_installer_complete_install(interface, invocation);
 	} else {

--- a/test/service.c
+++ b/test/service.c
@@ -201,7 +201,7 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 	g_assert_cmpint(g_signal_connect(installer, "g-properties-changed",
 			G_CALLBACK(on_installer_changed), args), !=, 0);
 	g_assert_cmpint(g_signal_connect(installer, "completed",
-			G_CALLBACK(on_installer_completed), args), !=, 0);
+			G_CALLBACK(on_installer_completed), NULL), !=, 0);
 
 	/* initial operation must be 'idle', initial last_error must be empty */
 	operation = r_installer_get_operation(installer);

--- a/test/service.c
+++ b/test/service.c
@@ -111,6 +111,16 @@ static void on_installer_completed(GDBusProxy *proxy, gint result,
 	g_main_loop_quit(testloop);
 }
 
+static void on_installer_completed_failed(GDBusProxy *proxy, gint result,
+		gpointer data)
+{
+	const gchar *last_error = NULL;
+	last_error = r_installer_get_last_error(installer);
+	g_assert_cmpstr(last_error, !=, "");
+	g_assert_cmpint(result, !=, 0);
+	g_main_loop_quit(testloop);
+}
+
 static void assert_progress(GVariant *progress, gint32 percentage, const gchar *message, gint32 depth)
 {
 	gint32 comp_percentage, comp_depth;
@@ -243,6 +253,69 @@ static void service_test_install_bundle(ServiceFixture *fixture, gconstpointer u
 	service_test_install(fixture, user_data, FALSE);
 }
 
+static void service_test_install_api(ServiceFixture *fixture, gconstpointer user_data)
+{
+	GError *error = NULL;
+	gboolean ret = FALSE;
+	g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
+
+	testloop = g_main_loop_new(NULL, FALSE);
+
+	installer = r_installer_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
+			G_DBUS_PROXY_FLAGS_GET_INVALIDATED_PROPERTIES,
+			"de.pengutronix.rauc", "/", NULL, NULL);
+
+	g_assert_cmpint(g_signal_connect(installer, "completed",
+			G_CALLBACK(on_installer_completed_failed), NULL), !=, 0);
+
+	/* Test with invalid key */
+	g_variant_dict_insert(&dict, "invalid-key", "b", TRUE);
+
+	ret = r_installer_call_install_bundle_sync(
+			installer,
+			g_strdup("dummy path"),
+			g_variant_dict_end(&dict), /* floating, no unref needed */
+			NULL,
+			&error);
+
+	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_FAILED_HANDLED);
+	g_assert_false(ret);
+	g_clear_error(&error);
+
+	/* Test with valid key but invalid type */
+	g_variant_dict_init(&dict, NULL);
+	g_variant_dict_insert(&dict, "ignore-compatible", "s", "buhlean");
+
+	ret = r_installer_call_install_bundle_sync(
+			installer,
+			g_strdup("dummy path"),
+			g_variant_dict_end(&dict), /* floating, no unref needed */
+			NULL,
+			&error);
+
+	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_FAILED_HANDLED);
+	g_assert_false(ret);
+	g_clear_error(&error);
+
+	/* Test with valid key and valid type */
+	g_variant_dict_init(&dict, NULL);
+	g_variant_dict_insert(&dict, "ignore-compatible", "b", TRUE);
+
+	ret = r_installer_call_install_bundle_sync(
+			installer,
+			g_strdup("dummy path"),
+			g_variant_dict_end(&dict), /* floating, no unref needed */
+			NULL,
+			&error);
+	/* (actual installation will fail as 'dummy path' does not exist) */
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	g_main_loop_run(testloop);
+
+	g_clear_pointer(&installer, g_object_unref);
+}
+
 static void service_test_install_deprecated(ServiceFixture *fixture, gconstpointer user_data)
 {
 	service_test_install(fixture, user_data, TRUE);
@@ -334,6 +407,10 @@ int main(int argc, char *argv[])
 
 	g_test_add("/service/install-deprecated", ServiceFixture, NULL,
 			service_install_fixture_set_up, service_test_install_deprecated,
+			service_fixture_tear_down);
+
+	g_test_add("/service/install-api", ServiceFixture, NULL,
+			service_install_fixture_set_up, service_test_install_api,
 			service_fixture_tear_down);
 
 	g_test_add("/service/info", ServiceFixture, NULL,

--- a/test/service.c
+++ b/test/service.c
@@ -9,6 +9,7 @@
 #include <install.h>
 #include <manifest.h>
 #include <mount.h>
+#include <utils.h>
 
 #include "../rauc-installer-generated.h"
 
@@ -57,8 +58,19 @@ Exec="TEST_SERVICES "/rauc -c test/test.conf service\n", NULL);
 
 static void service_fixture_tear_down(ServiceFixture *fixture, gconstpointer user_data)
 {
+	GError *error = NULL;
+	gboolean ret = FALSE;
+
 	g_test_dbus_down(fixture->dbus);
 	g_object_unref(fixture->dbus);
+
+	test_umount(fixture->tmpdir, "slot");
+	test_umount(fixture->tmpdir, "bootloader");
+
+	ret = rm_tree(fixture->tmpdir, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_free(fixture->tmpdir);
 }
 
 static void on_installer_changed(GDBusProxy *proxy, GVariant *changed,


### PR DESCRIPTION
In the past, there were a lot of cases where we ran into the limitation of the `Install` method of the D-Bus `Installer` interface. These were all caused by the missing ability to pass additional arguments to the install call.

As we cannot break existing setups, we cannot simply change the method signature. Instead, we need to introduce an alternative method.

Here it is: ``InstallBundle sa{sv}``

Where the new generic dict of string-variant (``a{sv}``) allows passing and handling all kind of current and future parameters without changing the interface again.

This initial series includes support for one argument that was already implemented for the non-D-Bus case: ``--ignore-compatible``. It allows forcing the installation of a bundle on a per-installation-call base

Reference: #248