### PR TITLE
Invert Slot Skipping Logic

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -234,12 +234,17 @@ hierarchical separator.
   Marks the slot as existing but not updatable. May be used for sanity checking
   or informative purpose. A ``readonly`` slot cannot be a target slot.
 
-``force-install-same=<true/false>``
-  If set to ``true`` this will bypass the default hash comparison for this slot
-  and force RAUC to unconditionally update it. The default value is ``false``,
-  which means that updating this slot will be skipped if new image's hash
-  matches hash of installed one.
-  This replaces the deprecated entry ``ignore-checksum``.
+``install-same=<true/false>``
+  If set to ``false``, this will tell RAUC to skip writing slots that already
+  have the same content as the one that should be installed.
+  Having the 'same' content means that the hash value stored for the target
+  slot and the hash value of the update image are equal.
+  The default value is ``true`` here, meaning that no optimization will be done
+  as this can be unexpected if RAUC is not the only one that potentially alters
+  a slot's content.
+
+  This replaces the deprecated entries ``ignore-checksum`` and
+  ``force-install-same``.
 
 ``resize=<true/false>``
   If set to ``true`` this will tell RAUC to resize the filesystem after having

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -99,8 +99,8 @@ typedef struct _RaucSlot {
 	gchar *bootname;
 	/** flag indicating if the slot is updatable */
 	gboolean readonly;
-	/** flag indicating if the slot update may be forced */
-	gboolean force_install_same;
+	/** flag indicating if slot skipping optimization should be used */
+	gboolean install_same;
 	/** extra mount options for this slot */
 	gchar *extra_mount_opts;
 	/** flag indicating to resize after writing (only for ext4) */

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -405,7 +405,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 					/* try also deprecated flag ignore-checksum */
 					slot->install_same = g_key_file_get_boolean(key_file, groups[i], "ignore-checksum", &ierror);
 					if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
-						slot->install_same = FALSE;
+						slot->install_same = TRUE;
 						g_clear_error(&ierror);
 					}
 					else if (ierror) {

--- a/src/install.c
+++ b/src/install.c
@@ -925,8 +925,8 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 			goto out;
 		}
 
-		/* skip if slot is up-to-date */
-		if (!dest_slot->force_install_same && g_strcmp0(mfimage->checksum.digest, slot_state->checksum.digest) == 0) {
+		/* if explicitly enabled, skip update of up-to-date slots */
+		if (!dest_slot->install_same && g_strcmp0(mfimage->checksum.digest, slot_state->checksum.digest) == 0) {
 			install_args_update(args, g_strdup_printf("Skipping update for correct image %s", mfimage->filename));
 			g_message("Skipping update for correct image %s", mfimage->filename);
 			r_context_end_step("check_slot", TRUE);


### PR DESCRIPTION
This replaces the former `force-install-same` key by a new `install-same` one to reflect that we invert the default.

From now on, the default behavior of RAUC will be to always install an image, regardless of whether its target slot checksum is the same as the image's checksum.

This inverts the default slot skipping optimization present since the initial release of RAUC.

Explicitly enabling this handling is still possible of course, by simply specifying

``` ini
[slot.rootfs.0]
...
install-same=false
```

in your system config.

This change will not have any impact on compatibility with old setup despite that you do not gain minor speed performance in rare cases by default.