### PR TITLE
Equalize contents of release tar ball to git tree and a typo fix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,7 +105,9 @@ EXTRA_DIST += data/rauc.service.in \
 	      contrib \
 	      build-uncrustify.sh \
 	      .uncrustify.cfg \
-	      uncrustify.sh
+	      uncrustify.sh \
+	      rauc_logo.png \
+	      rauc_logo_small.png
 
 dist_man_MANS = rauc.1
 
@@ -142,15 +144,22 @@ check_LTLIBRARIES = librauctest.la
 
 EXTRA_DIST += tap-t \
 	      tap-test \
+	      uml-test uml-test-init \
+	      test/Dockerfile \
 	      test/bin \
 	      test/install-content \
 	      test/openssl-ca \
-	      test/manifest.raucm \
+	      $(wildcard test/*.raucb) \
+	      $(wildcard test/*.raucm) \
 	      test/rauc.t \
 	      test/rootfs.raucs \
 	      test/sharness.sh \
+	      test/system.conf \
 	      test/test.conf \
-	      test/test-global.conf
+	      test/test-global.conf \
+	      test/get-coverity.sh \
+	      test/openssl-ca.sh \
+	      test/run-coverity.sh
 
 librauctest_la_SOURCES = \
 	test/common.c \
@@ -221,6 +230,7 @@ doc:
 EXTRA_DIST += docs/conf.py
 EXTRA_DIST += docs/images
 EXTRA_DIST += docs/extensions
+EXTRA_DIST += docs/release-checklist.txt
 EXTRA_DIST += $(wildcard docs/*.rst)
 
 AM_DISTCHECK_CONFIGURE_FLAGS = "--without-systemdunitdir"

--- a/rauc.1
+++ b/rauc.1
@@ -40,7 +40,7 @@ This manual page documents briefly the
 .BR rauc
 command line utility.
 
-It was written for the Debian GNU/Linux distribution to satify the
+It was written for the Debian GNU/Linux distribution to satisfy the
 packaging requirements. Thus it should only serve as a summary,
 reading the comprehensive online manual (\fBhttps://rauc.readthedocs.io/\fR)
 is recommended.


### PR DESCRIPTION
These patch opportunities were noticed while creating a Debian package for rauc. Most changes are harmless, but for example `test/invalid-sig-bundle.raucb` was missing which (silently) invalidated the respective test.

The release archive contains `rauc-installer-generated.h` which I'm not sure about if that is right. Other than that the remaining differences between the files in git and the archive are auto* related files (`aclocal.m4`, `autogen.sh`, `build-aux/*`, `configure`, `config.h.in`, `m4/*`, `Makefile.in`, `contrib/cgi/autogen.sh`), `.gitignore` files, `.lgtm.yml`, `travis.yml`, and versioning stuff (`.version`, `.tarball-version`).