### PR TITLE
minor fixes and annotation for compilation with clang

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -87,7 +87,8 @@ void r_context_begin_step(const gchar *name, const gchar *description,
  * @param description that is emitted via DBus on begin/end.
  *   A printf-like format string.
  */
-void r_context_begin_step_formatted(const gchar *name, gint substeps, const gchar *description, ...);
+void r_context_begin_step_formatted(const gchar *name, gint substeps, const gchar *description, ...)
+__attribute__((__format__(__printf__, 3, 4)));
 
 /**
  * Call at the end of a relevant code block. Percentage calculation is done

--- a/src/install.c
+++ b/src/install.c
@@ -410,7 +410,7 @@ GList* get_install_images(const RaucManifest *manifest, GHashTable *target_group
 			RaucSlot *target_slot = NULL;
 
 			/* Not interested in slots of other classes */
-			if (!g_strcmp0(lookup_image->slotclass, *cls) == 0)
+			if (g_strcmp0(lookup_image->slotclass, *cls) != 0)
 				continue;
 
 			/* Check if target_group contains an appropriate slot for this image */

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -591,9 +591,7 @@ gboolean verify_manifest(const gchar *dir, RaucManifest **output, GError **error
 {
 	GError *ierror = NULL;
 	g_autofree gchar* manifestpath = g_build_filename(dir, "manifest.raucm", NULL);
-	g_autofree gchar* signaturepath = g_build_filename(dir, "manifest.raucm.sig", NULL);
 	g_autoptr(RaucManifest) manifest = NULL;
-	g_autoptr(GBytes) sig = NULL;
 	gboolean res = FALSE;
 
 	r_context_begin_step("verify_manifest", "Verifying manifest", 2);

--- a/src/utils.c
+++ b/src/utils.c
@@ -108,7 +108,6 @@ gchar *resolve_path(const gchar *basefile, gchar *path)
 {
 	g_autofree gchar *cwd = NULL;
 	g_autofree gchar *dir = NULL;
-	g_autofree gchar *res = NULL;
 
 	if (path == NULL)
 		return NULL;


### PR DESCRIPTION
Clang has stricter warnings for some cases, so we should fix these.