### PR TITLE
introduce enum to tweak verification during bundle resigning

### DIFF
--- a/include/bundle.h
+++ b/include/bundle.h
@@ -42,6 +42,11 @@ typedef enum {
 	CHECK_BUNDLE_NO_VERIFY     = BIT(1),      // If not set the bundle signature
 	                                          // will be verified, if set this
 	                                          // step will be skipped.
+	CHECK_BUNDLE_NO_CHECK_TIME = BIT(2),      // If set, X509_V_FLAG_NO_CHECK_TIME
+	                                          // is passed to openssl to suppress
+	                                          // checking the validity period of
+	                                          // certificates and CRLs against
+	                                          // the current time.
 } CheckBundleParams;
 
 /**

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -5,6 +5,7 @@
 #include <gio/gio.h>
 
 #include "manifest.h"
+#include "utils.h"
 
 #define R_BUNDLE_ERROR r_bundle_error_quark()
 GQuark r_bundle_error_quark(void);
@@ -35,6 +36,14 @@ typedef struct {
 	STACK_OF(X509) *verified_chain;
 } RaucBundle;
 
+typedef enum {
+	CHECK_BUNDLE_DEFAULT       = 0,
+	/* skip BIT(0) for now to avoid interpreting a TRUE as NO_VERIFY by mistake */
+	CHECK_BUNDLE_NO_VERIFY     = BIT(1),      // If not set the bundle signature
+	                                          // will be verified, if set this
+	                                          // step will be skipped.
+} CheckBundleParams;
+
 /**
  * Create a bundle.
  *
@@ -56,13 +65,12 @@ G_GNUC_WARN_UNUSED_RESULT;
  * @param bundle return location for a RaucBundle struct.
  *               This will contain all bundle information obtained by
  *               check_bundle
- * @param verify If set to true the bundle signature will also be verified, if
- *               set to FALSE this step will be skipped
+ * @param params bit-field enum CheckBundleParams with additional flags for the check
  * @param error Return location for a GError
  *
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, gboolean verify, GError **error)
+gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleParams params, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**

--- a/include/utils.h
+++ b/include/utils.h
@@ -3,6 +3,8 @@
 #include <gio/gio.h>
 #include <glib.h>
 
+#define BIT(nr) (1UL << (nr))
+
 /* Use
  *
  *   g_auto(filedesc) fd = -1

--- a/rauc.1
+++ b/rauc.1
@@ -137,6 +137,10 @@ Resign an already signed bundle.
 disable bundle verification
 
 .TP
+\fB\-\-no\-check\-time\fR
+don't check validity period of certificates against current time
+
+.TP
 \fB\-\-signing\-keyring=\fR\fIPEMFILE\fR
 verification keyring file
 
@@ -215,6 +219,10 @@ Print bundle info.
 .TP
 \fB\-\-no\-verify\fR
 disable bundle verification
+
+.TP
+\fB\-\-no\-check\-time\fR
+don't check validity period of certificates against current time
 
 .TP
 \fB\-\-output\-format=\fR[\fBreadable\fR|\fBshell\fR|\fBjson\fR|\fBjson-pretty\fR]

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1384,10 +1384,11 @@ out:
 	return res;
 }
 
-gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, gboolean verify, GError **error)
+gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleParams params, GError **error)
 {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
+	gboolean verify = !(params & CHECK_BUNDLE_NO_VERIFY);
 	g_autoptr(RaucBundle) ibundle = g_new0(RaucBundle, 1);
 	g_autoptr(GBytes) manifest_bytes = NULL;
 	gchar *bundlescheme = NULL;
@@ -1395,6 +1396,7 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, gboolean ver
 
 	g_return_val_if_fail(bundlename, FALSE);
 	g_return_val_if_fail(bundle != NULL && *bundle == NULL, FALSE);
+	g_return_val_if_fail(!(params & TRUE), FALSE); /* protect against passing TRUE as the params enum */
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	r_context_begin_step("check_bundle", "Checking bundle", verify);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1469,13 +1469,19 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleP
 	if (verify) {
 		CMS_ContentInfo *cms = NULL;
 		X509_STORE *store = setup_x509_store(NULL, NULL, &ierror);
+		X509_VERIFY_PARAM *param = NULL;
 		if (!store) {
 			g_propagate_error(error, ierror);
 			res = FALSE;
 			goto out;
 		}
+		param = X509_STORE_get0_param(store);
 
 		g_message("Verifying bundle signature... ");
+
+		if (params & CHECK_BUNDLE_NO_CHECK_TIME)
+			X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_NO_CHECK_TIME);
+
 		if (detached) {
 			int fd = g_file_descriptor_based_get_fd(G_FILE_DESCRIPTOR_BASED(ibundle->stream));
 

--- a/src/install.c
+++ b/src/install.c
@@ -1039,7 +1039,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	// TODO: mount info in context ?
 	install_args_update(args, "Checking and mounting bundle...");
 
-	res = check_bundle(bundlefile, &bundle, TRUE, &ierror);
+	res = check_bundle(bundlefile, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;

--- a/src/main.c
+++ b/src/main.c
@@ -465,6 +465,7 @@ out:
 G_GNUC_UNUSED
 static gboolean resign_start(int argc, char **argv)
 {
+	CheckBundleParams check_bundle_params = CHECK_BUNDLE_DEFAULT;
 	g_autoptr(RaucBundle) bundle = NULL;
 	GError *ierror = NULL;
 	g_debug("resign start");
@@ -495,7 +496,10 @@ static gboolean resign_start(int argc, char **argv)
 		goto out;
 	}
 
-	if (!check_bundle(argv[2], &bundle, !verification_disabled, &ierror)) {
+	if (verification_disabled)
+		check_bundle_params |= CHECK_BUNDLE_NO_VERIFY;
+
+	if (!check_bundle(argv[2], &bundle, check_bundle_params, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -540,7 +544,7 @@ static gboolean extract_signature_start(int argc, char **argv)
 	g_debug("input bundle: %s", argv[2]);
 	g_debug("output file: %s", argv[3]);
 
-	if (!check_bundle(argv[2], &bundle, TRUE, &ierror)) {
+	if (!check_bundle(argv[2], &bundle, CHECK_BUNDLE_DEFAULT, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -585,7 +589,7 @@ static gboolean extract_start(int argc, char **argv)
 	g_debug("input bundle: %s", argv[2]);
 	g_debug("output dir: %s", argv[3]);
 
-	if (!check_bundle(argv[2], &bundle, TRUE, &ierror)) {
+	if (!check_bundle(argv[2], &bundle, CHECK_BUNDLE_DEFAULT, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -638,7 +642,7 @@ static gboolean convert_start(int argc, char **argv)
 	g_debug("input bundle: %s", argv[2]);
 	g_debug("output bundle: %s", argv[3]);
 
-	if (!check_bundle(argv[2], &bundle, TRUE, &ierror)) {
+	if (!check_bundle(argv[2], &bundle, CHECK_BUNDLE_DEFAULT, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -908,6 +912,7 @@ static gboolean info_start(int argc, char **argv)
 	gboolean res = FALSE;
 	gchar* (*formatter)(RaucManifest *manifest) = NULL;
 	gchar *text;
+	CheckBundleParams check_bundle_params = CHECK_BUNDLE_DEFAULT;
 
 	if (argc < 3) {
 		g_printerr("A file name must be provided\n");
@@ -939,7 +944,10 @@ static gboolean info_start(int argc, char **argv)
 		goto out;
 	g_debug("input bundle: %s", bundlelocation);
 
-	res = check_bundle(bundlelocation, &bundle, !verification_disabled, &error);
+	if (verification_disabled)
+		check_bundle_params |= CHECK_BUNDLE_NO_VERIFY;
+
+	res = check_bundle(bundlelocation, &bundle, check_bundle_params, &error);
 	if (!res) {
 		g_printerr("%s\n", error->message);
 		g_clear_error(&error);
@@ -1709,7 +1717,7 @@ static gboolean mount_start(int argc, char **argv)
 		goto out; /* an error message was already printed by resolve_bundle_path */
 	g_debug("input bundle: %s", bundlelocation);
 
-	res = check_bundle(bundlelocation, &bundle, TRUE, &error);
+	res = check_bundle(bundlelocation, &bundle, CHECK_BUNDLE_DEFAULT, &error);
 	if (!res) {
 		g_printerr("%s\n", error->message);
 		g_clear_error(&error);

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,7 @@ int r_exit_status = 0;
 
 gboolean install_ignore_compatible, install_progressbar = FALSE;
 gboolean verification_disabled = FALSE;
+gboolean no_check_time = FALSE;
 gboolean info_dumpcert = FALSE;
 gboolean status_detailed = FALSE;
 gchar *output_format = NULL;
@@ -498,6 +499,8 @@ static gboolean resign_start(int argc, char **argv)
 
 	if (verification_disabled)
 		check_bundle_params |= CHECK_BUNDLE_NO_VERIFY;
+	if (no_check_time)
+		check_bundle_params |= CHECK_BUNDLE_NO_CHECK_TIME;
 
 	if (!check_bundle(argv[2], &bundle, check_bundle_params, &ierror)) {
 		g_printerr("%s\n", ierror->message);
@@ -946,6 +949,8 @@ static gboolean info_start(int argc, char **argv)
 
 	if (verification_disabled)
 		check_bundle_params |= CHECK_BUNDLE_NO_VERIFY;
+	if (no_check_time)
+		check_bundle_params |= CHECK_BUNDLE_NO_CHECK_TIME;
 
 	res = check_bundle(bundlelocation, &bundle, check_bundle_params, &error);
 	if (!res) {
@@ -1799,6 +1804,7 @@ static GOptionEntry entries_bundle[] = {
 
 static GOptionEntry entries_resign[] = {
 	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
+	{"no-check-time", '\0', 0, G_OPTION_ARG_NONE, &no_check_time, "don't check validity period of certificates against current time", NULL},
 	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
 	{0}
 };
@@ -1812,6 +1818,7 @@ static GOptionEntry entries_convert[] = {
 
 static GOptionEntry entries_info[] = {
 	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
+	{"no-check-time", '\0', 0, G_OPTION_ARG_NONE, &no_check_time, "don't check validity period of certificates against current time", NULL},
 	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format", "FORMAT"},
 	{"dump-cert", '\0', 0, G_OPTION_ARG_NONE, &info_dumpcert, "dump certificate", NULL},
 	{0}

--- a/src/service.c
+++ b/src/service.c
@@ -139,7 +139,7 @@ static gboolean r_on_handle_info(RInstaller *interface,
 	if (!res)
 		goto out;
 
-	res = check_bundle(arg_bundle, &bundle, TRUE, &error);
+	res = check_bundle(arg_bundle, &bundle, CHECK_BUNDLE_DEFAULT, &error);
 	if (!res) {
 		g_warning("%s", error->message);
 		g_clear_error(&error);

--- a/src/signature.c
+++ b/src/signature.c
@@ -1133,7 +1133,7 @@ gboolean cms_verify_bytes(GBytes *content, GBytes *sig, X509_STORE *store, CMS_C
 		CMS_SignerInfo *si;
 		X509_ATTRIBUTE *xa;
 		ASN1_TYPE *so;
-		X509_VERIFY_PARAM *param = X509_VERIFY_PARAM_new();
+		X509_VERIFY_PARAM *param = X509_STORE_get0_param(store);
 		struct tm tm;
 		time_t signingtime;
 
@@ -1156,8 +1156,6 @@ gboolean cms_verify_bytes(GBytes *content, GBytes *sig, X509_STORE *store, CMS_C
 
 		/* use signing time for verification */
 		X509_VERIFY_PARAM_set_time(param, signingtime);
-		X509_STORE_set1_param(store, param);
-		X509_VERIFY_PARAM_free(param);
 	}
 
 	if (detached)

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -130,7 +130,7 @@ static void test_check_empty_bundle(BundleFixture *fixture,
 	bundlename = write_random_file(fixture->tmpdir, "bundle.raucb", 0, 1234);
 	g_assert_nonnull(bundlename);
 
-	res = check_bundle(bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_false(res);
 	g_assert_error(ierror, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT);
 	g_assert_null(bundle);
@@ -147,7 +147,7 @@ static void test_check_invalid_bundle(BundleFixture *fixture,
 	bundlename = write_random_file(fixture->tmpdir, "bundle.raucb", 1024, 1234);
 	g_assert_nonnull(bundlename);
 
-	res = check_bundle(bundlename, &bundle, FALSE, &ierror);
+	res = check_bundle(bundlename, &bundle, CHECK_BUNDLE_NO_VERIFY, &ierror);
 	g_assert_false(res);
 	g_assert_error(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_IDENTIFIER);
 	g_assert_null(bundle);
@@ -160,7 +160,7 @@ static void bundle_test_create_check_error(BundleFixture *fixture,
 	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_false(res);
 	g_assert_error(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_FORMAT);
 	g_assert_null(bundle);
@@ -178,7 +178,7 @@ static void bundle_test_create_extract(BundleFixture *fixture,
 	outputdir = g_build_filename(fixture->tmpdir, "output", NULL);
 	g_assert_nonnull(outputdir);
 
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -211,7 +211,7 @@ static void bundle_test_create_mount_extract(BundleFixture *fixture,
 	if (!test_running_as_root())
 		return;
 
-	res = check_bundle(fixture->bundlename, &bundle, FALSE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_NO_VERIFY, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -237,7 +237,7 @@ static void bundle_test_extract_manifest(BundleFixture *fixture,
 	outputdir = g_build_filename(fixture->tmpdir, "output", NULL);
 	g_assert_nonnull(outputdir);
 
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -270,7 +270,7 @@ static void bundle_test_extract_signature(BundleFixture *fixture,
 	outputsig = g_build_filename(fixture->tmpdir, "bundle.sig", NULL);
 	g_assert_nonnull(outputsig);
 
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -319,7 +319,7 @@ static void bundle_test_check_casync_old(BundleFixture *fixture, gconstpointer u
 	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
 			"Verifying bundle signature*" );
 
-	res = check_bundle(bundlepath, &bundle, TRUE, &ierror);
+	res = check_bundle(bundlepath, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -348,7 +348,7 @@ static void bundle_test_check_casync_new(BundleFixture *fixture, gconstpointer u
 	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
 			"Verifying bundle signature*" );
 
-	res = check_bundle(bundlepath, &bundle, TRUE, &ierror);
+	res = check_bundle(bundlepath, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -380,7 +380,7 @@ static void bundle_test_resign(BundleFixture *fixture,
 	 * the context's 'pending' flag which would cause a re-initialization
 	 * of context and thus overwrite content of 'config' member. */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
@@ -389,7 +389,7 @@ static void bundle_test_resign(BundleFixture *fixture,
 
 	/* Verify input bundle with 'dev' keyring */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-only-ca.pem");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
@@ -410,7 +410,7 @@ static void bundle_test_resign(BundleFixture *fixture,
 	 * installing development bundles as well as moving to production
 	 * bundles. */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-only-ca.pem");
-	res = check_bundle(resignbundle, &bundle, TRUE, &ierror);
+	res = check_bundle(resignbundle, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
@@ -419,7 +419,7 @@ static void bundle_test_resign(BundleFixture *fixture,
 
 	/* Verify resigned bundle with rel keyring */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	res = check_bundle(resignbundle, &bundle, TRUE, &ierror);
+	res = check_bundle(resignbundle, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
@@ -434,7 +434,7 @@ static void bundle_test_wrong_capath(BundleFixture *fixture,
 	g_autoptr(GError) ierror = NULL;
 	r_context()->config->keyring_path = g_strdup("does/not/exist.pem");
 
-	g_assert_false(check_bundle(fixture->bundlename, &bundle, TRUE, &ierror));
+	g_assert_false(check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror));
 	g_assert_null(bundle);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_CA_LOAD);
 
@@ -457,7 +457,7 @@ static void bundle_test_verify_no_crl_warn(BundleFixture *fixture,
 			"Reading bundle*");
 	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
 			"Detected CRL but CRL checking is disabled!");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -471,7 +471,7 @@ static void bundle_test_verify_revoked(BundleFixture *fixture,
 	g_autoptr(RaucBundle) bundle = NULL;
 	g_autoptr(GError) ierror = NULL;
 
-	g_assert_false(check_bundle(fixture->bundlename, &bundle, TRUE, &ierror));
+	g_assert_false(check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror));
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_assert_null(bundle);
 }
@@ -487,7 +487,7 @@ static void bundle_test_purpose_default(BundleFixture *fixture,
 
 	g_message("testing default purpose with default cert");
 	r_context()->config->keyring_check_purpose = NULL;
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -495,7 +495,7 @@ static void bundle_test_purpose_default(BundleFixture *fixture,
 
 	g_message("testing purpose 'smimesign' with default cert");
 	r_context()->config->keyring_check_purpose = g_strdup("smimesign");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -503,14 +503,14 @@ static void bundle_test_purpose_default(BundleFixture *fixture,
 
 	g_message("testing purpose 'codesign' with default cert");
 	r_context()->config->keyring_check_purpose = g_strdup("codesign");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
 
 	g_message("testing purpose 'any' with default cert");
 	r_context()->config->keyring_check_purpose = g_strdup("any");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -530,7 +530,7 @@ static void bundle_test_purpose_email(BundleFixture *fixture,
 
 	g_message("testing default purpose with 'smimesign' cert");
 	r_context()->config->keyring_check_purpose = NULL;
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -538,7 +538,7 @@ static void bundle_test_purpose_email(BundleFixture *fixture,
 
 	g_message("testing purpose 'smimesign' with 'smimesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("smimesign");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -546,7 +546,7 @@ static void bundle_test_purpose_email(BundleFixture *fixture,
 
 	g_message("testing purpose 'codesign' with 'smimesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("codesign");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
@@ -554,7 +554,7 @@ static void bundle_test_purpose_email(BundleFixture *fixture,
 
 	g_message("testing purpose 'any' with 'smimesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("any");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -574,7 +574,7 @@ static void bundle_test_purpose_codesign(BundleFixture *fixture,
 
 	g_message("testing default purpose with 'codesign' cert");
 	r_context()->config->keyring_check_purpose = NULL;
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
@@ -582,7 +582,7 @@ static void bundle_test_purpose_codesign(BundleFixture *fixture,
 
 	g_message("testing purpose 'smimesign' with 'codesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("smimesign");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
@@ -590,7 +590,7 @@ static void bundle_test_purpose_codesign(BundleFixture *fixture,
 
 	g_message("testing purpose 'codesign' with 'codesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("codesign");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -598,7 +598,7 @@ static void bundle_test_purpose_codesign(BundleFixture *fixture,
 
 	g_message("testing purpose 'any' with 'codesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("any");
-	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -501,6 +501,19 @@ test_expect_success FAKETIME "rauc verfiy with 'use-bundle-signing-time': invali
   test_must_fail faketime "2018-01-01" rauc --conf $SHARNESS_TEST_DIRECTORY/use-bundle-signing-time.conf info ${TEST_TMPDIR}/out.raucb
 "
 
+test_expect_success FAKETIME "rauc info --no-check-time" "
+  rm -f ${TEST_TMPDIR}/out.raucb &&
+  faketime "2018-01-01" \
+    rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
+    bundle $SHARNESS_TEST_DIRECTORY/install-content ${TEST_TMPDIR}/out.raucb &&
+  test -f ${TEST_TMPDIR}/out.raucb &&
+  faketime "2018-01-01" rauc info --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem ${TEST_TMPDIR}/out.raucb &&
+  test_must_fail faketime "2022-01-01" rauc info --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem ${TEST_TMPDIR}/out.raucb &&
+  faketime "2022-01-01" rauc info --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem --no-check-time ${TEST_TMPDIR}/out.raucb
+"
+
 test_expect_success FAKETIME "rauc sign bundle with expired certificate" "
   rm -f ${TEST_TMPDIR}/out.raucb &&
   test_must_fail faketime "2019-07-02" \

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -8,12 +8,12 @@
 #include "common.h"
 #include "context.h"
 #include "mount.h"
+#include "utils.h"
 
 typedef struct {
 	gchar *tmpdir;
 } UpdateHandlerFixture;
 
-#define BIT(nr) (1UL << (nr))
 typedef enum {
 	TEST_UPDATE_HANDLER_DEFAULT       = 0,
 	TEST_UPDATE_HANDLER_EXPECT_FAIL   = BIT(0),


### PR DESCRIPTION
This PR allows to give `--no-verify` and `--allow-expired` when resigning
to skip over expired certificates in this process.
