### PR TITLE
service: add InfoVerify to D-Bus allowing to optionally skip bundle verification

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -512,7 +512,9 @@ Methods
 ~~~~~~~
 :ref:`Install <gdbus-method-de-pengutronix-rauc-Installer.Install>` (IN  s source);
 
-:ref:`Info <gdbus-method-de-pengutronix-rauc-Installer.Info>` (IN  s bundle, s compatible, s version);
+:ref:`Info <gdbus-method-de-pengutronix-rauc-Installer.Info>` (IN  s bundle, s compatible, s version); (deprecated)
+
+:ref:`InfoVerify <gdbus-method-de-pengutronix-rauc-Installer.InfoVerify>` (IN  s bundle, IN b verify, s compatible, s version);
 
 :ref:`Mark <gdbus-method-de-pengutronix-rauc-Installer.Mark>` (IN  s state, IN  s slot_identifier, s slot_name, s message);
 
@@ -566,6 +568,8 @@ IN s *source*:
 The Info() Method
 ^^^^^^^^^^^^^^^^^
 
+.. note:: This method is deprecated (see :ref:`InfoVerify <gdbus-method-de-pengutronix-rauc-Installer.InfoVerify>`)
+
 .. code::
 
   de.pengutronix.rauc.Installer.Info()
@@ -575,6 +579,30 @@ Provides bundle info.
 
 IN s *bundle*:
     Path to bundle information should be shown
+
+s *compatible*:
+    Compatible of bundle
+
+s *version*:
+    Version string of bundle
+
+.. _gdbus-method-de-pengutronix-rauc-Installer.InfoVerify:
+
+The InfoVerify() Method
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+  de.pengutronix.rauc.Installer.InfoVerify()
+  Info (IN  s bundle, IN b verify, s compatible, s version);
+
+Provides bundle info.
+
+IN s *bundle*:
+    Path to bundle information should be shown
+
+IN b *verify*:
+    True to verify the bundle, false to disable bundle verification
 
 s *compatible*:
     Compatible of bundle

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -634,6 +634,12 @@ Monitor the D-Bus interface
 
   busctl monitor de.pengutronix.rauc
 
+Read bundle information (optionally skipping verification)
+
+.. code-block:: sh
+
+  busctl call de.pengutronix.rauc / de.pengutronix.rauc.Installer InfoVerify sb "/path/to/bundle" 1
+
 .. _debugging:
 
 Debugging RAUC

--- a/src/rauc-installer.xml
+++ b/src/rauc-installer.xml
@@ -16,8 +16,22 @@
     @compatile: the compatible string from the bundle
     @version: the version string from the bundle
    -->
-   <method name="Info">
+    <method name="Info">
       <arg name="bundle" type="s" direction="in" />
+      <arg name="compatible" type="s" direction="out" />
+      <arg name="version" type="s" direction="out" />
+    </method>
+
+   <!--
+    Info: D-Bus variant of rauc info <bundle>
+    @bundle: full path to the queried bundle.
+    @verify: true to enable bundle verification, false otherwise
+    @compatile: the compatible string from the bundle
+    @version: the version string from the bundle
+   -->
+    <method name="InfoVerify">
+      <arg name="bundle" type="s" direction="in" />
+      <arg name="verify" type="b" direction="in" />
       <arg name="compatible" type="s" direction="out" />
       <arg name="version" type="s" direction="out" />
     </method>

--- a/src/service.c
+++ b/src/service.c
@@ -94,8 +94,8 @@ out:
 static gboolean r_on_handle_info_verify(RInstaller *interface,
 		GDBusMethodInvocation  *invocation,
 		const gchar *arg_bundle,
-        const gboolean arg_verify
-        )
+		const gboolean arg_verify
+		)
 {
 	g_autofree gchar* tmpdir = NULL;
 	g_autofree gchar* bundledir = NULL;
@@ -167,8 +167,8 @@ static gboolean r_on_handle_info(RInstaller *interface,
 		GDBusMethodInvocation  *invocation,
 		const gchar *arg_bundle)
 {
-    g_message("Using deprecated 'Info' D-Bus Method (replaced by 'InfoVerify')");
-    return r_on_handle_info_verify(interface, invocation, arg_bundle, TRUE);
+	g_message("Using deprecated 'Info' D-Bus Method (replaced by 'InfoVerify')");
+	return r_on_handle_info_verify(interface, invocation, arg_bundle, TRUE);
 }
 
 static gboolean r_on_handle_mark(RInstaller *interface,
@@ -443,9 +443,9 @@ static void r_on_bus_acquired(GDBusConnection *connection,
 			G_CALLBACK(r_on_handle_info),
 			NULL);
 
-    g_signal_connect(r_installer, "handle-info-verify",
-            G_CALLBACK(r_on_handle_info_verify),
-            NULL);
+	g_signal_connect(r_installer, "handle-info-verify",
+			G_CALLBACK(r_on_handle_info_verify),
+			NULL);
 
 	g_signal_connect(r_installer, "handle-mark",
 			G_CALLBACK(r_on_handle_mark),


### PR DESCRIPTION
As already mentioned in #248 (more specific this https://github.com/rauc/rauc/issues/248#issuecomment-429223150 one), using the Info method via D-Bus is useful to obtain bundle information prior to installing a bundle.

I had the same use-case: I have a (rather large) bundle on a (slow) USB removable storage and verification is just taking too much time. I rather skip verification at that stage.

This pull request adds a new D-Bus method and deprecates the old one.