### PR TITLE
Fix bundle detection on big endian

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -248,7 +248,7 @@ static gboolean input_stream_read_uint64_all(GInputStream *stream,
 	return res;
 }
 
-#define SQUASHFS_MAGIC			0x73717368
+#define SQUASHFS_MAGIC			GUINT32_TO_LE(0x73717368)
 
 /* Attempts to read and verify the squashfs magic to verify having a valid bundle */
 static gboolean input_stream_check_bundle_identifier(GInputStream *stream, GError **error)


### PR DESCRIPTION
The squashfs magic is contained in little endian order in the image. To
be able to detect it correctly on big endian the magic value needs its
endianess switched to properly compare with the respective value found
using read(2) from the image.

With this the test suite runs successfully on a sparc64 box apart from a single test that fails because mksquashfs dies with a bus error, which I reported on https://bugs.debian.org/932787 .