### PR TITLE
Add casync tmpdir option to system.conf

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -145,6 +145,14 @@ For more information about using casync support of RAUC, refer to
   By default, the chunk store path is derived from the location of the RAUC
   bundle you install.
 
+``tmppath``
+  Allows to set the path to use as temporary directory for casync.
+  The temporary directory used by casync can be specified using the TMPDIR
+  environment variable. It falls back to /var/tmp if unset.
+  If ``tmppath`` is set then RAUC runs casync with TMPDIR sets to that path.
+  By default, the temporary directory is left unset by RAUC and casync uses its
+  internal default value ``/var/tmp``.
+
 **[autoinstall] section**
 
 The auto-install feature allows to configure a path that will be checked upon

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -39,6 +39,7 @@ typedef struct {
 	/* path prefix where rauc may create mount directories */
 	gchar *mount_prefix;
 	gchar *store_path;
+	gchar *tmp_path;
 	gboolean activate_installed;
 	gchar *statusfile_path;
 	gchar *keyring_path;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -290,6 +290,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 
 	/* parse [casync] section */
 	c->store_path = key_file_consume_string(key_file, "casync", "storepath", NULL);
+	c->tmp_path = key_file_consume_string(key_file, "casync", "tmppath", NULL);
 	if (!check_remaining_keys(key_file, "casync", &ierror)) {
 		g_propagate_error(error, ierror);
 		res = FALSE;
@@ -579,6 +580,7 @@ void free_config(RaucConfig *config)
 	g_free(config->system_bootloader);
 	g_free(config->mount_prefix);
 	g_free(config->store_path);
+	g_free(config->tmp_path);
 	g_free(config->grubenv_path);
 	g_free(config->statusfile_path);
 	g_free(config->keyring_path);

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -160,8 +160,9 @@ static gboolean copy_raw_image(RaucImage *image, GUnixOutputStream *outstream, G
 	return TRUE;
 }
 
-static gboolean casync_extract(RaucImage *image, gchar *dest, const gchar *seed, const gchar *store, GError **error)
+static gboolean casync_extract(RaucImage *image, gchar *dest, const gchar *seed, const gchar *store, const gchar *tmpdir, GError **error)
 {
+	g_autoptr(GSubprocessLauncher) launcher = NULL;
 	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
@@ -182,9 +183,13 @@ static gboolean casync_extract(RaucImage *image, gchar *dest, const gchar *seed,
 	g_ptr_array_add(args, g_strdup(dest));
 	g_ptr_array_add(args, NULL);
 
+	launcher = g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_NONE);
+	if (tmpdir)
+		g_subprocess_launcher_setenv(launcher, "TMPDIR", tmpdir, TRUE);
+
 	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sproc = g_subprocess_launcher_spawnv(launcher,
+			(const gchar * const *)args->pdata, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -233,6 +238,7 @@ static gboolean casync_extract_image(RaucImage *image, gchar *dest, GError **err
 	RaucSlot *seedslot = NULL;
 	g_autofree gchar *seed = NULL;
 	gchar *store = NULL;
+	gchar *tmpdir = NULL;
 	gboolean seed_mounted = FALSE;
 
 	/* Prepare Seed */
@@ -270,8 +276,13 @@ extract:
 	store = r_context()->install_info->mounted_bundle->storepath;
 	g_debug("Using store path: '%s'", store);
 
+	/* Set temporary directory */
+	tmpdir = r_context()->config->tmp_path;
+	if (tmpdir)
+		g_debug("Using tmp path: '%s'", tmpdir);
+
 	/* Call casync to extract */
-	res = casync_extract(image, dest, seed, store, &ierror);
+	res = casync_extract(image, dest, seed, store, tmpdir, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -62,6 +62,7 @@ max-bundle-download-size=42\n\
 path=/etc/rauc/keyring/\n\
 \n\
 [casync]\n\
+storepath=/var/lib/default.castr/\n\
 tmppath=/tmp/\n\
 \n\
 [slot.rescue.0]\n\

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -61,6 +61,9 @@ max-bundle-download-size=42\n\
 [keyring]\n\
 path=/etc/rauc/keyring/\n\
 \n\
+[casync]\n\
+tmppath=/tmp/\n\
+\n\
 [slot.rescue.0]\n\
 description=Rescue partition\n\
 device=/dev/rescue-0\n\


### PR DESCRIPTION
This commit allows setting a different temporary directory for `casync` at extraction.

`casync` caches things in the temporary directory. The default location `/var/tmp` may be limited in some use-cases. Thus, the choice of a temporary directory is very important, and the user/maintainer must have control of it.

For example, if the things that are being updated is very big (lets says 10GB), the seeding requires lots of inodes and `casync` may run out of inodes if the filesystem is already full of files.

The example below sets the temporary directory to `/tmp`:

```
$ cat /etc/rauc/system.conf
(...)
[casync]
tmppath=/tmp
(...)
```