### PR TITLE
service: add annotations for qdbusxml2cpp

### DIFF
--- a/src/rauc-installer.xml
+++ b/src/rauc-installer.xml
@@ -50,6 +50,7 @@
     -->
     <method name="GetSlotStatus">
       <arg name="slot_status_array" type="a(sa{sv})" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="RaucSlotStatusArray"/>
     </method>
 
     <!-- Operation: Represents the current (global) operation rauc performs -->
@@ -58,7 +59,9 @@
     <property name="LastError" type="s" access="read"/>
     <!-- Progress: Provides installation progress informations in the form
          (percentage, message, nesting depth) -->
-    <property name="Progress" type="(isi)" access="read"/>
+    <property name="Progress" type="(isi)" access="read">
+      <annotation name="org.qtproject.QtDBus.QtTypeName" value="RaucProgress"/>
+    </property>
     <!-- Compatible: Represents the system's compatible -->
     <property name="Compatible" type="s" access="read"/>
     <!-- Variant: Represents the system's variant -->


### PR DESCRIPTION
When generating interface classes for Qt projects using qdbusxml2cpp
custom types must be annotated.

To use the generated interface class the RaucSlotStatusArray and
RaucProgress types have to be defined and registered as Qt meta types.
Additionally QDBusArgument proper streaming operators have to be
supplied.

Signed-off-by: Tobias Junghans <tobydox@veyon.io>