### PR TITLE
src/signature: pass only non-empty PINs on to PKCS#11 engine

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -107,7 +107,7 @@ static ENGINE *get_pkcs11_engine(GError **error)
 	}
 
 	env = g_getenv("RAUC_PKCS11_PIN");
-	if (env != NULL) {
+	if (env != NULL && env[0] != '\0') {
 		if (!ENGINE_ctrl_cmd_string(e, "PIN", env, 0)) {
 			err = ERR_get_error_line_data(NULL, NULL, &data, &flags);
 			g_set_error(


### PR DESCRIPTION
It is convenient to pass the PIN via the environment variable. In some
production signing cases the PIN should rather be entered interactively
than being passed to RAUC via the environment variable. The environment
is built nonetheless, but with an empty RAUC_PKCS11_PIN variable. This
leads to a failing login attempt with an empty string as the PIN.

Due to the fact that the PIN is never an empty string anyway do not pass
such a PIN on and thus enable being prompted interactively for a PIN in
that case.

Signed-off-by: Bastian Krause <bst@pengutronix.de>