### PR TITLE
Fix uninitialized locals

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -904,7 +904,7 @@ static gboolean save_slot_status_globally(GError **error)
 	/* Save all slot status information */
 	g_hash_table_iter_init(&iter, r_context()->config->slots);
 	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
-		g_autofree gchar *group;
+		g_autofree gchar *group = NULL;
 
 		if (!slot->status) {
 			continue;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1151,7 +1151,7 @@ out:
 static gboolean img_to_boot_mbr_switch_handler(RaucImage *image, RaucSlot *dest_slot, const gchar *hook_name, GError **error)
 {
 	gboolean res = FALSE;
-	int out_fd, inactive_part;
+	int out_fd = -1, inactive_part;
 	g_autoptr(GUnixOutputStream) outstream = NULL;
 	GError *ierror = NULL;
 	struct mbr_switch_partition dest_partition;


### PR DESCRIPTION
The compiler has found those two errors below:

```
            In file included from /usr/include/glib-2.0/glib.h:114,
                             from src/config_file.c:1:
            src/config_file.c: In function ‘save_slot_status’:
            /usr/include/glib-2.0/glib/glib-autocleanups.h:28:3: error: ‘group’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
               28 |   g_free (*pp);
                  |   ^~~~~~~~~~~~
            src/config_file.c:905:21: note: ‘group’ was declared here
              905 |   g_autofree gchar *group;
                  |                     ^~~~~
            (...)
            src/update_handler.c: In function ‘img_to_boot_mbr_switch_handler’:
            src/update_handler.c:1249:3: error: ‘out_fd’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
             1249 |   close(out_fd);
                  |   ^~~~~~~~~~~~~
            cc1: all warnings being treated as errors
```