### PR TITLE
test/install: deactivate check that depends on GHashTable implementation

### DIFF
--- a/test/install.c
+++ b/test/install.c
@@ -370,7 +370,8 @@ filename=bootloader.img";
 	g_assert_true(g_hash_table_contains(tgrp, "demofs"));
 	g_assert_true(g_hash_table_contains(tgrp, "bootloader"));
 	g_assert_true(g_hash_table_contains(tgrp, "prebootloader"));
-	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rescue"))->name, ==, "rescue.0");
+	//Deactivated check as the actual behavior is GHashTable-implementation-defined
+	//g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rescue"))->name, ==, "rescue.0");
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rootfs"))->name, ==, "rootfs.1");
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "appfs"))->name, ==, "appfs.1");
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "demofs"))->name, ==, "demofs.1");


### PR DESCRIPTION
The test '/install/target/' verifies that the target install groups
determined by RAUC match the expectation based on system.conf and
manifest file.

Beside all other slots the system.conf also defines two slots 'rescue.0'
and 'rescue.1' that are in no relation to any of the slots we can detect
as booted / non-booted. Thus, both are candidates for selecting them as
target group candidates.

Now, the actual selection only depends on the order they appear when
iterating over the slot GHashTable. If the implementation of GHashTable
changes, this will also affect the slot that appears in the target
group.
With the current implementation we cannot reliably determine if this
would be rescue.0 or rescue.1 and thus we have to deactivate the check
to prevent it from failing on systems with a different/modified GHashTable
implementation.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>