### PR TITLE
test/install: deactivate more tests that depend on GHashTable impleme…

### DIFF
--- a/test/install.c
+++ b/test/install.c
@@ -277,11 +277,11 @@ filename=bootloader.img";
 	g_assert_true(g_hash_table_contains(tgrp, "demofs"));
 	g_assert_true(g_hash_table_contains(tgrp, "bootloader"));
 	g_assert_true(g_hash_table_contains(tgrp, "prebootloader"));
-	//Deactivated check as the actual behavior is GHashTable-implementation-defined
+	//Deactivated checks as the actual behavior is GHashTable-implementation-defined
 	//g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rescue"))->name, ==, "rescue.0");
-	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rootfs"))->name, ==, "rootfs.1");
-	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "appfs"))->name, ==, "appfs.1");
-	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "demofs"))->name, ==, "demofs.1");
+	//g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rootfs"))->name, ==, "rootfs.1");
+	//g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "appfs"))->name, ==, "appfs.1");
+	//g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "demofs"))->name, ==, "demofs.1");
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "bootloader"))->name, ==, "bootloader.0");
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "prebootloader"))->name, ==, "prebootloader.0");
 	g_assert_cmpint(g_hash_table_size(tgrp), ==, 6);


### PR DESCRIPTION
…ntation

In the same spirit as 35c98ab18f90 ("test/install: deactivate check that
depends on GHashTable implementation") also deactivate three further
tests that depend on the interna of GHashTable. 

With this change on top of a cherry-pick of 35c98ab18f and bc25067177 this fixes building the rauc 1.1 Debian package on s390x.