### PR TITLE
test/install: fix test for undefined behavior in slot selection handling

### DIFF
--- a/test/install.c
+++ b/test/install.c
@@ -257,6 +257,8 @@ filename=bootloader.img";
 
 	g_assert_true(load_manifest_file(pathname, &rm, NULL));
 
+	r_context_conf()->bootslot = g_strdup("system0");
+
 	g_assert_true(determine_slot_states(NULL));
 
 	g_assert_nonnull(r_context()->config);

--- a/test/install.c
+++ b/test/install.c
@@ -281,9 +281,19 @@ filename=bootloader.img";
 	g_assert_true(g_hash_table_contains(tgrp, "prebootloader"));
 	//Deactivated check as the actual behavior is GHashTable-implementation-defined
 	//g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rescue"))->name, ==, "rescue.0");
-	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rootfs"))->name, ==, "rootfs.1");
-	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "appfs"))->name, ==, "appfs.1");
-	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "demofs"))->name, ==, "demofs.1");
+	/* We need to assure that the algorithm did not select the active group '0' */
+	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rootfs"))->name, !=, "rootfs.0");
+	/* The algorithm could select either group '1' or group '2'. The actual
+	 * selection is still GHashTable-implementation-defined.*/
+	if (g_strcmp0(((RaucSlot*)g_hash_table_lookup(tgrp, "rootfs"))->name, "rootfs.1") == 0) {
+		g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rootfs"))->name, ==, "rootfs.1");
+		g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "appfs"))->name, ==, "appfs.1");
+		g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "demofs"))->name, ==, "demofs.1");
+	} else {
+		g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rootfs"))->name, ==, "rootfs.2");
+		g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "appfs"))->name, ==, "appfs.2");
+		g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "demofs"))->name, ==, "demofs.2");
+	}
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "bootloader"))->name, ==, "bootloader.0");
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "prebootloader"))->name, ==, "prebootloader.0");
 	g_assert_cmpint(g_hash_table_size(tgrp), ==, 6);


### PR DESCRIPTION
For the triple-redundancy rootfs.0, rootfs.1, rootfs.2 (including their
childs), we have rootfs.0 set to 'active' so far and thus both rootfs.2
and rootfs.2 being detected as 'inactive'.

For this case, there is still no real definition of when or whether to select
rootfs.1 or rootfs.2.

Prior to this, the test checked for the selected slot being rootfs.1
which was valid for the concrete implementation, but mainly depending on
the order that was given by the GHashTable (iterator) implementation.

In recent glib version this changed resulting in rootfs.2 being selected
instead.

We adapt the test for checking correctly for both cases.

Supersedes #475