### PR TITLE
src: add missing subprocess call debug logs for g_subprocess_new()

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -36,6 +36,8 @@ static inline GSubprocess * r_subprocess_launcher_spawnv(GSubprocessLauncher *la
 			(const gchar * const *)args->pdata, error);
 }
 
+GSubprocess *r_subprocess_new(GSubprocessFlags flags, GError **error, const gchar *argv0, ...);
+
 #define R_LOG_LEVEL_TRACE 1 << G_LOG_LEVEL_USER_SHIFT
 #define r_trace(...)   g_log(G_LOG_DOMAIN,         \
 		R_LOG_LEVEL_TRACE,    \

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <gio/gio.h>
 #include <glib.h>
 
 /* Use
@@ -15,11 +16,24 @@ void close_preserve_errno(filedesc fd);
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(filedesc, close_preserve_errno, -1)
 
 #define R_LOG_DOMAIN_SUBPROCESS "rauc-subprocess"
-static inline void r_debug_subprocess(GPtrArray *args)
+
+static inline GSubprocess* r_subprocess_newv(GPtrArray *args, GSubprocessFlags flags, GError **error)
 {
 	gchar *call = g_strjoinv(" ", (gchar**) args->pdata);
 	g_log(R_LOG_DOMAIN_SUBPROCESS, G_LOG_LEVEL_DEBUG, "launching subprocess: %s", call);
 	g_free(call);
+
+	return g_subprocess_newv((const gchar * const *) args->pdata, flags, error);
+}
+
+static inline GSubprocess * r_subprocess_launcher_spawnv(GSubprocessLauncher *launcher, GPtrArray *args, GError **error)
+{
+	gchar *call = g_strjoinv(" ", (gchar**) args->pdata);
+	g_log(R_LOG_DOMAIN_SUBPROCESS, G_LOG_LEVEL_DEBUG, "launching subprocess: %s", call);
+	g_free(call);
+
+	return g_subprocess_launcher_spawnv(launcher,
+			(const gchar * const *)args->pdata, error);
 }
 
 #define R_LOG_LEVEL_TRACE 1 << G_LOG_LEVEL_USER_SHIFT

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -82,9 +82,7 @@ static gboolean barebox_state_get(const gchar* bootname, BareboxSlotState *bb_st
 	g_ptr_array_add(args, g_strdup_printf(BOOTSTATE_PREFIX ".%s.remaining_attempts", bootname));
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sub = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_STDOUT_PIPE, &ierror);
+	sub = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_STDOUT_PIPE, &ierror);
 	if (!sub) {
 		g_propagate_prefixed_error(
 				error,
@@ -172,9 +170,7 @@ static gboolean barebox_state_set(GPtrArray *pairs, GError **error)
 	}
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sub = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sub = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (!sub) {
 		g_propagate_prefixed_error(
 				error,
@@ -358,9 +354,7 @@ static gboolean grub_env_get(const gchar *key, GString **value, GError **error)
 	g_ptr_array_add(sub_args, g_strdup("list"));
 	g_ptr_array_add(sub_args, NULL);
 
-	r_debug_subprocess(sub_args);
-	sub = g_subprocess_newv((const gchar * const *)sub_args->pdata,
-			G_SUBPROCESS_FLAGS_STDOUT_PIPE | G_SUBPROCESS_FLAGS_STDERR_MERGE, &ierror);
+	sub = r_subprocess_newv(sub_args, G_SUBPROCESS_FLAGS_STDOUT_PIPE | G_SUBPROCESS_FLAGS_STDERR_MERGE, &ierror);
 	if (!sub) {
 		g_propagate_prefixed_error(
 				error,
@@ -440,9 +434,7 @@ static gboolean grub_env_set(GPtrArray *pairs, GError **error)
 	g_ptr_array_insert(pairs, 2, g_strdup("set"));
 	g_ptr_array_add(pairs, NULL);
 
-	r_debug_subprocess(pairs);
-	sub = g_subprocess_newv((const gchar * const *)pairs->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sub = r_subprocess_newv(pairs, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (!sub) {
 		g_propagate_prefixed_error(
 				error,

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -641,7 +641,7 @@ static gboolean uboot_env_get(const gchar *key, GString **value, GError **error)
 	g_return_val_if_fail(value && *value == NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	sub = g_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE, &ierror,
+	sub = r_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE, &ierror,
 			UBOOT_FWPRINTENV_NAME, key, NULL);
 	if (!sub) {
 		g_propagate_prefixed_error(
@@ -696,7 +696,7 @@ static gboolean uboot_env_set(const gchar *key, const gchar *value, GError **err
 	g_return_val_if_fail(value, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	sub = g_subprocess_new(G_SUBPROCESS_FLAGS_NONE, &ierror, UBOOT_FWSETENV_NAME,
+	sub = r_subprocess_new(G_SUBPROCESS_FLAGS_NONE, &ierror, UBOOT_FWSETENV_NAME,
 			key, value, NULL);
 	if (!sub) {
 		g_propagate_prefixed_error(
@@ -940,8 +940,7 @@ static gboolean efi_bootorder_set(gchar *order, GError **error)
 	g_return_val_if_fail(order, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-
-	sub = g_subprocess_new(G_SUBPROCESS_FLAGS_NONE, &ierror, EFIBOOTMGR_NAME,
+	sub = r_subprocess_new(G_SUBPROCESS_FLAGS_NONE, &ierror, EFIBOOTMGR_NAME,
 			"--bootorder", order, NULL);
 
 	if (!sub) {
@@ -972,7 +971,7 @@ static gboolean efi_set_bootnext(gchar *bootnumber, GError **error)
 	g_return_val_if_fail(bootnumber, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	sub = g_subprocess_new(G_SUBPROCESS_FLAGS_NONE, &ierror, EFIBOOTMGR_NAME,
+	sub = r_subprocess_new(G_SUBPROCESS_FLAGS_NONE, &ierror, EFIBOOTMGR_NAME,
 			"--bootnext", bootnumber, NULL);
 
 	if (!sub) {
@@ -1041,7 +1040,7 @@ static gboolean efi_bootorder_get(GList **bootorder_entries, GList **all_entries
 	g_return_val_if_fail(bootnext == NULL || *bootnext == NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	sub = g_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE, &ierror,
+	sub = r_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE, &ierror,
 			EFIBOOTMGR_NAME, NULL);
 	if (!sub) {
 		g_propagate_prefixed_error(

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -29,7 +29,7 @@ static gboolean mksquashfs(const gchar *bundlename, const gchar *contentdir, GEr
 		goto out;
 	}
 
-	sproc = g_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_SILENCE,
+	sproc = r_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_SILENCE,
 			&ierror, "mksquashfs",
 			contentdir,
 			bundlename,

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -82,9 +82,7 @@ static gboolean unsquashfs(const gchar *bundlename, const gchar *contentdir, con
 
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -150,9 +148,7 @@ static gboolean casync_make_arch(const gchar *idxpath, const gchar *contentpath,
 	g_ptr_array_add(args, g_strjoinv(" ", (gchar**) g_ptr_array_free(iargs, FALSE)));
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -192,9 +188,7 @@ static gboolean casync_make_blob(const gchar *idxpath, const gchar *contentpath,
 	}
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,

--- a/src/mount.c
+++ b/src/mount.c
@@ -34,9 +34,7 @@ gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar*
 	g_ptr_array_add(args, g_strdup(mountpoint));
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -80,9 +78,7 @@ gboolean r_umount(const gchar *filename, GError **error)
 	g_ptr_array_add(args, g_strdup(filename));
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -187,9 +187,7 @@ static gboolean casync_extract(RaucImage *image, gchar *dest, const gchar *seed,
 	if (tmpdir)
 		g_subprocess_launcher_setenv(launcher, "TMPDIR", tmpdir, TRUE);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_launcher_spawnv(launcher,
-			(const gchar * const *)args->pdata, &ierror);
+	sproc = r_subprocess_launcher_spawnv(launcher, args, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -369,9 +367,7 @@ static gboolean ubifs_format_slot(RaucSlot *dest_slot, GError **error)
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -404,9 +400,7 @@ static gboolean ext4_resize_slot(RaucSlot *dest_slot, GError **error)
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -444,9 +438,7 @@ static gboolean ext4_format_slot(RaucSlot *dest_slot, GError **error)
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -483,9 +475,7 @@ static gboolean vfat_format_slot(RaucSlot *dest_slot, GError **error)
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -521,9 +511,7 @@ static gboolean nand_format_slot(const gchar *device, GError **error)
 	g_ptr_array_add(args, g_strdup("0"));
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -559,9 +547,7 @@ static gboolean nand_write_slot(const gchar *image, const gchar *device, GError 
 	g_ptr_array_add(args, g_strdup(image));
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -598,9 +584,7 @@ static gboolean untar_image(RaucImage *image, gchar *dest, GError **error)
 	g_ptr_array_add(args, g_strdup("--numeric-owner"));
 	g_ptr_array_add(args, NULL);
 
-	r_debug_subprocess(args);
-	sproc = g_subprocess_newv((const gchar * const *)args->pdata,
-			G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,

--- a/src/utils.c
+++ b/src/utils.c
@@ -9,6 +9,30 @@
 
 #include "utils.h"
 
+GSubprocess *r_subprocess_new(GSubprocessFlags flags, GError **error, const gchar *argv0, ...)
+{
+	GSubprocess *result;
+	g_autoptr(GPtrArray) args = NULL;
+	const gchar *arg;
+	va_list ap;
+
+	g_return_val_if_fail(argv0 != NULL && argv0[0] != '\0', NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	args = g_ptr_array_new();
+
+	va_start(ap, argv0);
+	g_ptr_array_add(args, (gchar *) argv0);
+	while ((arg = va_arg(ap, const gchar *)))
+		g_ptr_array_add(args, (gchar *) arg);
+	g_ptr_array_add(args, NULL);
+	va_end(ap);
+
+	result = r_subprocess_newv(args, flags, error);
+
+	return result;
+}
+
 void close_preserve_errno(int fd)
 {
 	int err;


### PR DESCRIPTION
We have the utility function r_debug_subprocess() which precedes each
call of g_subprocess_newv() and prints the command and args used.
But, for subprocess calls being invoked with g_subprocess_new()
(non-argv-variant), this is not possible and there currently simply is
no output of the invoked call.
This is quite unexpected in debugging scenarios (to see some subprocess
calls and others not).

This patch fixes this by adding manual g_log() calls for each
subprocess.

Note this is a duplication of the argument list, but still much shorter
than using invocations of g_subprocess_newv().

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>