### PR TITLE
Fix leaking GDataInputStream's

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -62,7 +62,7 @@ static gboolean barebox_state_get(const gchar* bootname, BareboxSlotState *bb_st
 	g_autoptr(GSubprocess) sub = NULL;
 	GError *ierror = NULL;
 	GInputStream *instream;
-	GDataInputStream *datainstream;
+	g_autoptr(GDataInputStream) datainstream = NULL;
 	gchar* outline;
 	guint64 result[2] = {};
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(6, g_free);

--- a/src/install.c
+++ b/src/install.c
@@ -609,7 +609,7 @@ static gboolean launch_and_wait_handler(gchar *update_source, gchar *handler_nam
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	GInputStream *instream = NULL;
-	GDataInputStream *datainstream = NULL;
+	g_autoptr(GDataInputStream) datainstream = NULL;
 	gchar *outline;
 
 	handlelaunch = g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE | G_SUBPROCESS_FLAGS_STDERR_MERGE);
@@ -658,7 +658,7 @@ static gboolean run_bundle_hook(RaucManifest *manifest, gchar* bundledir, const 
 	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	GInputStream *instream = NULL;
-	GDataInputStream *datainstream = NULL;
+	g_autoptr(GDataInputStream) datainstream = NULL;
 	gboolean res = FALSE;
 	gchar *outline, *hookreturnmsg = NULL;
 


### PR DESCRIPTION
The GDataInputStream 'datainstream' is created from 'instream' with
g_data_input_stream_new() but never freed.

Luckily we have g_autoptr() mechanism, so that we just need to declare
'datainstream' as an auto pointer variable here to have it freed
correctly as soon as it leaves the context.

Note that the bug described above also leads to an open file descriptor
remaining.
The more often on calls, for example, 'rauc status' the more open file
descriptors will be collected until they suddenly hit the maximum number
of open file descriptors allowed (e.g. by systemd service settings)
resulting in error message:

> Too many open files