### PR TITLE
A more fancy rauc status output

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -322,8 +322,6 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 			g_free(value);
 
 			slot->description = key_file_consume_string(key_file, groups[i], "description", NULL);
-			if (!slot->description)
-				slot->description = g_strdup("");
 
 			slot->sclass = g_intern_string(groupsplit[1]);
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include <json-glib/json-glib.h>
 #include <json-glib/json-gobject.h>
 #endif
+#include <locale.h>
 #include <stdio.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -31,6 +32,7 @@ gboolean status_detailed = FALSE;
 gchar *output_format = NULL;
 gchar *signing_keyring = NULL;
 gchar *mksquashfs_args = NULL;
+gboolean utf8_supported = FALSE;
 
 static gchar* make_progress_line(gint percentage)
 {
@@ -1942,6 +1944,11 @@ int main(int argc, char **argv)
 {
 	/* disable remote VFS */
 	g_assert(g_setenv("GIO_USE_VFS", "local", TRUE));
+
+	/* Locale needs to support UTF-8, try and flag if unsupported */
+	setlocale(LC_ALL, "");
+	if (g_get_charset(NULL))
+		utf8_supported = TRUE;
 
 	create_option_groups();
 	cmdline_handler(argc, argv);


### PR DESCRIPTION
Note that this is based on #477

So far, especially when having more complex slot setups, the output of
'rauc status' did not provide an easy and clear view of the slots
constellation and their respective status (booted, active, inactive).

This patch aims to fix this by giving a more tidied-up view with colors
and bold font for highlighting.

The (uncolored) variant woll look as follows:

```
=== System Info ===
Compatible:  Test Config
Variant:     myvariant
Booted from: rootfs.1 (system1)

=== Bootloader ===
Activated: rootfs.0 (system0)

=== Slot States ===
  [bootloader.0] (/tmp/boot-0, raw, inactive)
	description: 

○ [rootfs.1] (/tmp/rootfs-1, raw, booted)
	bootname: system1
	description: 
	boot status: good
    [appfs.1] (/tmp/appfs-1, raw, active)
	description: 

⏺ [rootfs.0] (/tmp/rootfs-0, raw, inactive)
	bootname: system0
	description: 
	boot status: good
    [appfs.0] (/tmp/appfs-0, raw, inactive)
	description: 


```