### PR TITLE
Fix U-Boot contrib script

### DIFF
--- a/contrib/uboot.sh
+++ b/contrib/uboot.sh
@@ -8,15 +8,15 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
     # skip remaining slots
   elif test "x${BOOT_SLOT}" = "xA"; then
     if test ${BOOT_A_LEFT} -gt 0; then
-      setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
+      setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       setenv load_kernel "nand read ${kernel_loadaddr} ${kernel_a_nandoffset} ${kernel_size}"
       setenv bootargs "${default_bootargs} root=/dev/mmcblk0p1 rauc.slot=A"
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
     if test ${BOOT_B_LEFT} -gt 0; then
-      setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
+      setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       setenv load_kernel "nand read ${kernel_loadaddr} ${kernel_b_nandoffset} ${kernel_size}"
       setenv bootargs "${default_bootargs} root=/dev/mmcblk0p2 rauc.slot=B"
     fi


### PR DESCRIPTION
Currently, the U-Boot contrib script decreases the boot attempt counter before
echoing the message about the valid slots being found, which results in the
following:

3 boot attempts -> prints 2 attempts left
2 boot attempts -> prints 1 attempt left
1 boot attempt -> prints 0 attempt left

The script should print the message first, then decrease the counter. This
commit fixes the issue.

Signed-off-by: Ellie Reeves <ellierevves@gmail.com>