### PR TITLE
Introduce --signing-keyring to fix post-signing verification for 'rauc resign'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,9 @@ Release 1.2 (development)
 
 .. rubric:: Enhancements
 
+* Added ``--signing-keyring`` argument to specify a distinct keyring for
+  post-signing verification. This allows for example to use ``rauc resign``
+  with certs not verifying against the original keyring.
 * Output of 'rauc status' is now grouped by slot groups to make it easier to
   identify the redundancy setup.
   Previously, the present slots were printed in a random order which was

--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,7 @@ AC_CONFIG_LINKS([test/openssl-ca/dev/autobuilder-2.cert.pem:test/openssl-ca/dev/
 AC_CONFIG_LINKS([test/openssl-ca/dev/private/autobuilder-1.pem:test/openssl-ca/dev/private/autobuilder-1.pem])
 AC_CONFIG_LINKS([test/openssl-ca/dev/private/autobuilder-2.pem:test/openssl-ca/dev/private/autobuilder-2.pem])
 AC_CONFIG_LINKS([test/openssl-ca/dev-ca.pem:test/openssl-ca/dev-ca.pem])
+AC_CONFIG_LINKS([test/openssl-ca/dev-only-ca.pem:test/openssl-ca/dev-only-ca.pem])
 AC_CONFIG_LINKS([test/openssl-ca/rel-ca.pem:test/openssl-ca/rel-ca.pem])
 AC_CONFIG_LINKS([test/openssl-ca/provisioning-ca.pem:test/openssl-ca/provisioning-ca.pem])
 AC_CONFIG_LINKS([test/openssl-ca/rel/release-1.cert.pem:test/openssl-ca/rel/release-1.cert.pem])

--- a/include/context.h
+++ b/include/context.h
@@ -33,6 +33,7 @@ typedef struct {
 	gchar *keypath;
 	gchar *keyringpath;
 	gchar *keyringdirectory;
+	gchar *signing_keyringpath;
 	gchar **intermediatepaths;
 	/* optional global mount prefix overwrite */
 	gchar *mountprefix;

--- a/include/signature.h
+++ b/include/signature.h
@@ -73,14 +73,13 @@ GBytes *cms_sign_file(const gchar *filename, const gchar *certfile, const gchar 
  *
  * @param content content to verify against signature
  * @param sig signature used to verify
+ * @param store X509 store to use for verification
  * @param cms Return location for the CMS_ContentInfo used for verification
- * @param store Return location for the X509 store used for verification
  * @param error return location for a GError, or NULL
  *
  * @return TRUE if succeeded, FALSE if failed
  */
-gboolean cms_verify(GBytes *content, GBytes *sig, CMS_ContentInfo **cms, X509_STORE **store, GError **error);
-
+gboolean cms_verify(GBytes *content, GBytes *sig, X509_STORE *store, CMS_ContentInfo **cms, GError **error);
 
 /**
  * Verify signature for given file.
@@ -88,13 +87,13 @@ gboolean cms_verify(GBytes *content, GBytes *sig, CMS_ContentInfo **cms, X509_ST
  * @param filename name of file with content to verify against signature
  * @param sig signature used to verify
  * @param limit size of content to use, 0 if all should be included
+ * @param store X509 store to use for verification
  * @param cms Return location for the CMS_ContentInfo used for verification
- * @param store Return location for the X509 store used for verification
  * @param error return location for a GError, or NULL
  *
  * @return TRUE if succeeded, FALSE if failed
  */
-gboolean cms_verify_file(const gchar *filename, GBytes *sig, gsize limit, CMS_ContentInfo **cms, X509_STORE **store, GError **error);
+gboolean cms_verify_file(const gchar *filename, GBytes *sig, gsize limit, X509_STORE *store, CMS_ContentInfo **cms, GError **error);
 
 /**
  * Calculates hash for certificate pubkey info.

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -789,12 +789,32 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, gboolean ver
 	}
 
 	if (verify) {
+		const gchar *load_capath = r_context()->config->keyring_path;
+		const gchar *load_cadir = r_context()->config->keyring_directory;
 		CMS_ContentInfo *cms = NULL;
 		X509_STORE *store = NULL;
 
+		if (!(store = X509_STORE_new())) {
+			g_set_error_literal(
+					error,
+					R_SIGNATURE_ERROR,
+					R_SIGNATURE_ERROR_X509_NEW,
+					"failed to allocate new X509 store");
+			goto out;
+		}
+		if (!X509_STORE_load_locations(store, load_capath, load_cadir)) {
+			g_set_error(
+					error,
+					R_SIGNATURE_ERROR,
+					R_SIGNATURE_ERROR_CA_LOAD,
+					"failed to load CA file '%s' and/or directory '%s'", load_capath, load_cadir);
+
+			goto out;
+		}
+
 		g_message("Verifying bundle... ");
 		/* the squashfs image size is in offset */
-		res = cms_verify_file(ibundle->path, ibundle->sigdata, offset, &cms, &store, &ierror);
+		res = cms_verify_file(ibundle->path, ibundle->sigdata, offset, store, &cms, &ierror);
 		if (!res) {
 			g_propagate_error(error, ierror);
 			goto out;

--- a/src/context.c
+++ b/src/context.c
@@ -565,10 +565,12 @@ void r_context_clean(void)
 		g_free(context->keypath);
 		g_free(context->keyringpath);
 		g_free(context->keyringdirectory);
+		g_free(context->signing_keyringpath);
 		context->certpath = NULL;
 		context->keypath = NULL;
 		context->keyringpath = NULL;
 		context->keyringdirectory = NULL;
+		context->signing_keyringpath = NULL;
 
 		if (context->config) {
 			context->config->keyring_path = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,7 @@ gboolean install_ignore_compatible, install_progressbar = FALSE;
 gboolean info_noverify, info_dumpcert = FALSE;
 gboolean status_detailed = FALSE;
 gchar *output_format = NULL;
+gchar *signing_keyring = NULL;
 
 static gchar* make_progress_line(gint percentage)
 {
@@ -1706,6 +1707,21 @@ GOptionEntry entries_install[] = {
 	{0}
 };
 
+GOptionEntry entries_bundle[] = {
+	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
+	{0}
+};
+
+GOptionEntry entries_resign[] = {
+	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
+	{0}
+};
+
+GOptionEntry entries_convert[] = {
+	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
+	{0}
+};
+
 GOptionEntry entries_info[] = {
 	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &info_noverify, "disable bundle verification", NULL},
 	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format", "FORMAT"},
@@ -1741,6 +1757,9 @@ static void cmdline_handler(int argc, char **argv)
 		{0}
 	};
 	GOptionGroup *install_group = g_option_group_new("install", "Install options:", "help dummy", NULL, NULL);
+	GOptionGroup *bundle_group = g_option_group_new("bundle", "Bundle options:", "help dummy", NULL, NULL);
+	GOptionGroup *resign_group = g_option_group_new("resign", "Resign options:", "help dummy", NULL, NULL);
+	GOptionGroup *convert_group = g_option_group_new("convert", "Convert options:", "help dummy", NULL, NULL);
 	GOptionGroup *info_group = g_option_group_new("info", "Info options:", "help dummy", NULL, NULL);
 	GOptionGroup *status_group = g_option_group_new("status", "Status options:", "help dummy", NULL, NULL);
 
@@ -1750,10 +1769,10 @@ static void cmdline_handler(int argc, char **argv)
 	RaucCommand rcommands[] = {
 		{UNKNOWN, "help", "<COMMAND>", "Print help", unknown_start, NULL, TRUE},
 		{INSTALL, "install", "install <BUNDLE>", "Install a bundle", install_start, install_group, FALSE},
-		{BUNDLE, "bundle", "bundle <INPUTDIR> <BUNDLENAME>", "Create a bundle from a content directory", bundle_start, NULL, FALSE},
-		{RESIGN, "resign", "resign <BUNDLENAME>", "Resign an already signed bundle", resign_start, NULL, FALSE},
+		{BUNDLE, "bundle", "bundle <INPUTDIR> <BUNDLENAME>", "Create a bundle from a content directory", bundle_start, bundle_group, FALSE},
+		{RESIGN, "resign", "resign <BUNDLENAME>", "Resign an already signed bundle", resign_start, resign_group, FALSE},
 		{EXTRACT, "extract", "extract <BUNDLENAME> <OUTPUTDIR>", "Extract the bundle content", extract_start, NULL, FALSE},
-		{CONVERT, "convert", "convert <INBUNDLE> <OUTBUNDLE>", "Convert to casync index bundle and store", convert_start, NULL, FALSE},
+		{CONVERT, "convert", "convert <INBUNDLE> <OUTBUNDLE>", "Convert to casync index bundle and store", convert_start, convert_group, FALSE},
 		{CHECKSUM, "checksum", "checksum <DIRECTORY>", "Deprecated", checksum_start, NULL, FALSE},
 		{INFO, "info", "info <FILE>", "Print bundle info", info_start, info_group, FALSE},
 		{STATUS, "status", "status", "Show system status", status_start, status_group, TRUE},
@@ -1767,6 +1786,9 @@ static void cmdline_handler(int argc, char **argv)
 	RaucCommand *rcommand = NULL;
 
 	g_option_group_add_entries(install_group, entries_install);
+	g_option_group_add_entries(bundle_group, entries_bundle);
+	g_option_group_add_entries(resign_group, entries_resign);
+	g_option_group_add_entries(convert_group, entries_convert);
 	g_option_group_add_entries(info_group, entries_info);
 	g_option_group_add_entries(status_group, entries_status);
 
@@ -1887,6 +1909,8 @@ static void cmdline_handler(int argc, char **argv)
 			r_context_conf()->keypath = keypath;
 		if (keyring)
 			r_context_conf()->keyringpath = keyring;
+		if (signing_keyring)
+			r_context_conf()->signing_keyringpath = signing_keyring;
 		if (intermediate)
 			r_context_conf()->intermediatepaths = intermediate;
 		if (mount)

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -157,6 +157,9 @@ static void bundle_test_extract_manifest(BundleFixture *fixture,
 	free_bundle(bundle);
 }
 
+// Hack to pull-in context for testing modification
+extern RaucContext *context;
+
 static void bundle_test_resign(BundleFixture *fixture,
 		gconstpointer user_data)
 {
@@ -187,8 +190,8 @@ static void bundle_test_resign(BundleFixture *fixture,
 	g_assert_true(res);
 
 	/* Use 'rel' key pair for resigning */
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
+	context->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
+	context->keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
 
 	res = resign_bundle(bundle, resignbundle, &ierror);
 	g_assert_no_error(ierror);

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -192,6 +192,7 @@ static void bundle_test_resign(BundleFixture *fixture,
 	/* Use 'rel' key pair for resigning */
 	context->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
 	context->keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
+	context->signing_keyringpath = g_strdup("test/openssl-ca/rel-ca.pem");
 
 	res = resign_bundle(bundle, resignbundle, &ierror);
 	g_assert_no_error(ierror);

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -7,6 +7,7 @@
 #include <bundle.h>
 #include <context.h>
 #include <manifest.h>
+#include <signature.h>
 #include <utils.h>
 
 #include "common.h"
@@ -172,13 +173,18 @@ static void bundle_test_resign(BundleFixture *fixture,
 	 * the context's 'pending' flag which would cause a re-initialization
 	 * of context and thus overwrite content of 'config' member. */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	g_assert_false(check_bundle(fixture->bundlename, &bundle, TRUE, NULL));
+	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
+	g_clear_error(&ierror);
+	g_assert_false(res);
 
 	g_clear_pointer(&bundle, free_bundle);
 
 	/* Verify input bundle with 'dev' keyring */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-ca.pem");
-	g_assert_true(check_bundle(fixture->bundlename, &bundle, TRUE, NULL));
+	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 
 	/* Use 'rel' key pair for resigning */
 	r_context_conf()->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
@@ -196,13 +202,17 @@ static void bundle_test_resign(BundleFixture *fixture,
 	 * installing development bundles as well as moving to production
 	 * bundles. */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-ca.pem");
-	g_assert_true(check_bundle(resignbundle, &bundle, TRUE, NULL));
+	res = check_bundle(resignbundle, &bundle, TRUE, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 
 	g_clear_pointer(&bundle, free_bundle);
 
 	/* Verify resigned bundle with rel keyring */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	g_assert_true(check_bundle(resignbundle, &bundle, TRUE, NULL));
+	res = check_bundle(resignbundle, &bundle, TRUE, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 
 	g_clear_pointer(&bundle, free_bundle);
 }

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -181,7 +181,7 @@ static void bundle_test_resign(BundleFixture *fixture,
 	g_clear_pointer(&bundle, free_bundle);
 
 	/* Verify input bundle with 'dev' keyring */
-	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-ca.pem");
+	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-only-ca.pem");
 	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
@@ -201,10 +201,11 @@ static void bundle_test_resign(BundleFixture *fixture,
 	 * both the production and the development certificate to allow
 	 * installing development bundles as well as moving to production
 	 * bundles. */
-	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-ca.pem");
+	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-only-ca.pem");
 	res = check_bundle(resignbundle, &bundle, TRUE, &ierror);
-	g_assert_no_error(ierror);
-	g_assert_true(res);
+	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
+	g_clear_error(&ierror);
+	g_assert_false(res);
 
 	g_clear_pointer(&bundle, free_bundle);
 

--- a/test/openssl-ca.sh
+++ b/test/openssl-ca.sh
@@ -141,6 +141,7 @@ echo "Build CA PEM"
 cd $BASE
 cat root/ca.cert.pem root/crl.pem rel/crl.pem dev/crl.pem > provisioning-ca.pem
 cat root/ca.cert.pem root/crl.pem rel/ca.cert.pem rel/crl.pem dev/ca.cert.pem dev/crl.pem > dev-ca.pem
+cat root/ca.cert.pem root/crl.pem dev/ca.cert.pem dev/crl.pem > dev-only-ca.pem
 cat root/ca.cert.pem root/crl.pem rel/ca.cert.pem rel/crl.pem > rel-ca.pem
 
 echo "Build Directory Test Keys"

--- a/test/openssl-ca/dev-only-ca.pem
+++ b/test/openssl-ca/dev-only-ca.pem
@@ -1,0 +1,183 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: O=Test Org, CN=Test Org Provisioning CA Root
+        Validity
+            Not Before: Jan  1 00:00:00 1970 GMT
+            Not After : Dec 31 23:59:59 9999 GMT
+        Subject: O=Test Org, CN=Test Org Provisioning CA Root
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:db:e6:0b:9b:bf:7b:cd:3a:b7:03:2e:fe:a8:45:
+                    18:de:69:ee:af:fd:3c:23:5e:6a:f7:14:a6:08:97:
+                    0a:62:45:72:4b:1d:0d:49:35:32:37:8a:81:92:90:
+                    93:9e:28:1a:a2:2b:55:03:3a:0a:22:8d:b5:50:9a:
+                    31:0c:59:88:92:05:ad:31:06:bf:7b:e0:11:81:25:
+                    16:db:69:37:fa:fe:8b:e6:dd:4d:10:24:d3:61:b6:
+                    3d:8f:1f:20:64:7d:35:3c:1f:24:fc:3b:71:0e:bf:
+                    2d:09:ec:30:28:d6:e5:49:17:f9:68:9e:1d:09:04:
+                    16:85:21:28:c0:c7:00:ef:f5:8f:26:2e:d0:f2:07:
+                    df:ad:c6:9f:21:bb:b4:bc:e6:c2:93:b9:ea:82:61:
+                    70:fb:49:d5:92:96:5f:a6:39:e0:a3:7c:15:c2:0e:
+                    1e:bc:f7:c5:24:e7:20:a2:f2:84:38:63:90:f9:f2:
+                    f0:03:f8:94:19:69:49:ac:36:b2:03:97:a6:ed:28:
+                    bf:fd:80:0c:fa:90:b9:27:ce:f3:9f:8e:9b:99:f6:
+                    18:80:df:77:bf:ec:3d:ec:6c:96:ca:54:9e:d5:52:
+                    9a:b4:66:2a:6d:12:65:29:89:af:0b:76:49:3d:cf:
+                    a3:7b:90:5c:f9:5e:8f:a2:86:a9:db:4a:eb:b4:48:
+                    29:33
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                20:02:A1:59:1C:07:94:4A:AA:25:27:C9:49:60:BB:14:0F:83:12:08
+            X509v3 Authority Key Identifier: 
+                keyid:20:02:A1:59:1C:07:94:4A:AA:25:27:C9:49:60:BB:14:0F:83:12:08
+                DirName:/O=Test Org/CN=Test Org Provisioning CA Root
+                serial:01
+
+            X509v3 Basic Constraints: 
+                CA:TRUE
+    Signature Algorithm: sha256WithRSAEncryption
+         3b:b3:4a:89:bb:3c:5f:ed:53:5d:16:a2:c9:ce:85:ba:a0:d1:
+         e5:d1:0b:13:df:5b:0a:61:4a:59:ba:27:8b:45:34:1e:5f:6e:
+         1f:13:88:d3:68:9a:22:42:81:d7:da:f5:da:35:ee:ec:1e:60:
+         fd:f9:81:69:b2:4a:1b:64:57:e2:53:ea:bf:7a:51:f0:8f:f6:
+         9f:0f:fd:1e:04:df:0b:0d:4e:03:d5:72:31:2f:fd:1a:e2:b5:
+         1b:33:85:fa:07:57:9b:37:32:23:c8:b2:58:97:03:87:ff:76:
+         49:9f:5b:9e:3c:57:f9:f8:3d:90:0f:92:bc:d2:e6:d0:37:54:
+         c5:1c:7b:e1:48:79:29:78:2f:95:e3:88:95:02:33:96:7d:37:
+         99:53:c3:51:0b:02:c4:35:bd:8e:f9:b3:d7:12:87:63:b7:38:
+         76:21:81:28:bf:5e:67:18:d5:62:8d:b5:a5:59:79:df:db:f7:
+         95:4e:43:29:c2:51:a4:02:c1:5a:21:ac:f4:7a:75:ba:ef:c7:
+         18:26:e1:a2:dc:c3:e7:16:dc:94:e0:2c:53:a5:8d:75:44:67:
+         59:1c:68:64:c8:f9:6b:ec:f8:5b:56:d2:75:2c:90:c3:84:68:
+         b6:eb:7e:7a:9a:04:b8:cd:0b:f4:af:8f:5c:90:7f:d1:97:dc:
+         13:9d:13:05
+-----BEGIN CERTIFICATE-----
+MIIDizCCAnOgAwIBAgIBATANBgkqhkiG9w0BAQsFADA7MREwDwYDVQQKDAhUZXN0
+IE9yZzEmMCQGA1UEAwwdVGVzdCBPcmcgUHJvdmlzaW9uaW5nIENBIFJvb3QwIhgP
+MTk3MDAxMDEwMDAwMDBaGA85OTk5MTIzMTIzNTk1OVowOzERMA8GA1UECgwIVGVz
+dCBPcmcxJjAkBgNVBAMMHVRlc3QgT3JnIFByb3Zpc2lvbmluZyBDQSBSb290MIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2+YLm797zTq3Ay7+qEUY3mnu
+r/08I15q9xSmCJcKYkVySx0NSTUyN4qBkpCTnigaoitVAzoKIo21UJoxDFmIkgWt
+MQa/e+ARgSUW22k3+v6L5t1NECTTYbY9jx8gZH01PB8k/DtxDr8tCewwKNblSRf5
+aJ4dCQQWhSEowMcA7/WPJi7Q8gffrcafIbu0vObCk7nqgmFw+0nVkpZfpjngo3wV
+wg4evPfFJOcgovKEOGOQ+fLwA/iUGWlJrDayA5em7Si//YAM+pC5J87zn46bmfYY
+gN93v+w97GyWylSe1VKatGYqbRJlKYmvC3ZJPc+je5Bc+V6Pooap20rrtEgpMwID
+AQABo4GVMIGSMB0GA1UdDgQWBBQgAqFZHAeUSqolJ8lJYLsUD4MSCDBjBgNVHSME
+XDBagBQgAqFZHAeUSqolJ8lJYLsUD4MSCKE/pD0wOzERMA8GA1UECgwIVGVzdCBP
+cmcxJjAkBgNVBAMMHVRlc3QgT3JnIFByb3Zpc2lvbmluZyBDQSBSb290ggEBMAwG
+A1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBADuzSom7PF/tU10WosnOhbqg
+0eXRCxPfWwphSlm6J4tFNB5fbh8TiNNomiJCgdfa9do17uweYP35gWmyShtkV+JT
+6r96UfCP9p8P/R4E3wsNTgPVcjEv/RritRszhfoHV5s3MiPIsliXA4f/dkmfW548
+V/n4PZAPkrzS5tA3VMUce+FIeSl4L5XjiJUCM5Z9N5lTw1ELAsQ1vY75s9cSh2O3
+OHYhgSi/XmcY1WKNtaVZed/b95VOQynCUaQCwVohrPR6dbrvxxgm4aLcw+cW3JTg
+LFOljXVEZ1kcaGTI+Wvs+FtW0nUskMOEaLbrfnqaBLjNC/Svj1yQf9GX3BOdEwU=
+-----END CERTIFICATE-----
+-----BEGIN X509 CRL-----
+MIIBgDBqMA0GCSqGSIb3DQEBCwUAMDsxETAPBgNVBAoMCFRlc3QgT3JnMSYwJAYD
+VQQDDB1UZXN0IE9yZyBQcm92aXNpb25pbmcgQ0EgUm9vdBcNMTUwNDI0MTQxNDA4
+WhcNMjgxMjMxMTQxNDA4WjANBgkqhkiG9w0BAQsFAAOCAQEAo31STXRKkYbqedhd
+W2CZ8+lDyyeh2L4myRVtbu2nf9h7bpGI09x8WkBqTQoNRuXhBxLE4R26JugKaKtI
+bSucSECGwpV0j2G5KBneAEIzB+NRmvED1eqApoBEYk+iAm7wnxzC53lu+KUwDU4K
+9CUG7b6bFilLatXKPOArO0pRACRuS700u7LVrNNwDoV+41g8yEVRX7Wwj+U+iQPS
+kG/AyRGbW4kh1y2vzc+GstUKeZRXY5ENizqSSXCYN9nEwaYZUNeKSz66qMueG1zO
+LvQpGWKB0F2wkM9nAsVqNRLt9smNhZ6sZYU8YSbQkWpFnrhgaRTd26letlpvy9U/
+8ctX+A==
+-----END X509 CRL-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: O=Test Org, CN=Test Org Provisioning CA Root
+        Validity
+            Not Before: Jan  1 00:00:00 1970 GMT
+            Not After : Dec 31 23:59:59 9999 GMT
+        Subject: O=Test Org, CN=Test Org Provisioning CA Development
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c5:e5:39:6a:55:29:10:b1:50:c8:11:98:58:fe:
+                    09:9c:34:e6:ac:20:2b:fd:4d:63:b4:d7:92:60:ad:
+                    8a:28:ec:0f:d7:ba:8b:1d:74:e9:52:24:49:6a:9d:
+                    ca:0e:02:72:b2:7a:c2:1e:e3:df:cf:5a:62:db:28:
+                    e8:98:74:90:ef:4a:f0:f0:6c:ed:21:ba:26:5e:f0:
+                    ba:79:ad:a6:36:43:d1:e2:74:c6:84:af:44:ac:55:
+                    1e:bb:79:88:36:80:b9:42:1e:8c:b7:5e:cd:60:7f:
+                    e9:75:79:80:20:cc:1f:27:87:fd:74:bb:93:be:4f:
+                    66:a2:cc:32:9f:96:cc:40:d0:11:21:a8:32:dd:7f:
+                    e3:8d:14:9e:67:fc:92:e2:3c:53:2d:e7:05:bc:ad:
+                    20:42:31:68:86:e8:57:62:92:f6:00:86:be:74:e7:
+                    b1:dd:c4:00:88:a6:f4:1b:81:e5:ce:57:f4:83:cd:
+                    5d:48:31:7a:3a:dd:10:d7:a3:13:9f:13:7e:7d:cc:
+                    2e:27:5d:b1:35:97:48:f0:a9:e4:f4:72:1c:cf:54:
+                    b3:0a:f4:13:0b:af:9f:27:d5:d1:b7:63:0d:23:76:
+                    cd:dc:19:f6:c7:9f:06:45:e3:79:ed:f5:7a:34:fb:
+                    ce:42:78:07:85:65:ee:67:96:e4:b5:83:4a:0d:4e:
+                    f4:d3
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                80:5A:06:66:1D:27:94:AC:D4:4A:FB:3E:FE:E4:FC:9C:BC:75:55:FE
+            X509v3 Authority Key Identifier: 
+                keyid:20:02:A1:59:1C:07:94:4A:AA:25:27:C9:49:60:BB:14:0F:83:12:08
+                DirName:/O=Test Org/CN=Test Org Provisioning CA Root
+                serial:01
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:0
+    Signature Algorithm: sha256WithRSAEncryption
+         b9:47:70:46:cc:d0:a0:57:b2:2c:18:80:45:b5:ef:aa:47:47:
+         f9:c5:33:5d:93:da:ee:29:a6:bc:83:73:b0:fb:63:b9:71:67:
+         dd:8e:ab:b0:15:c2:e6:a6:5e:67:b1:0a:3e:1f:ed:56:93:d1:
+         23:7d:c3:7c:75:90:5c:8f:fa:6f:6e:16:07:cb:77:a7:a7:f3:
+         30:62:69:de:24:0b:1c:f1:c9:90:c4:95:ae:ae:39:2f:20:5c:
+         d7:89:9f:c6:0b:8f:0a:4c:b4:2b:b0:f4:6c:24:17:98:49:7c:
+         96:a9:9f:ff:3d:7e:9f:b6:c5:b3:a9:67:71:c8:96:6b:b9:0b:
+         9d:39:e7:e1:e5:27:64:dc:be:c2:82:7a:e2:30:fe:29:c1:39:
+         98:99:70:5e:34:2d:1e:e2:4e:92:c5:f3:a2:b3:24:3a:9f:f2:
+         1d:10:1e:af:e4:c5:81:53:61:90:91:52:9e:0e:38:94:e7:2f:
+         1e:34:8b:54:2c:9a:45:1e:f2:75:d9:ce:ec:a7:a3:59:8d:bf:
+         b2:49:8c:6a:61:b2:b6:70:24:66:80:30:85:f1:f0:28:89:8b:
+         52:87:fd:52:c1:a5:d6:41:7c:c6:64:91:98:5f:cc:1b:48:4e:
+         54:7b:77:ab:00:f5:d8:fa:76:75:50:0d:44:c3:d1:90:0c:93:
+         75:0f:10:dc
+-----BEGIN CERTIFICATE-----
+MIIDlTCCAn2gAwIBAgIBAzANBgkqhkiG9w0BAQsFADA7MREwDwYDVQQKDAhUZXN0
+IE9yZzEmMCQGA1UEAwwdVGVzdCBPcmcgUHJvdmlzaW9uaW5nIENBIFJvb3QwIhgP
+MTk3MDAxMDEwMDAwMDBaGA85OTk5MTIzMTIzNTk1OVowQjERMA8GA1UECgwIVGVz
+dCBPcmcxLTArBgNVBAMMJFRlc3QgT3JnIFByb3Zpc2lvbmluZyBDQSBEZXZlbG9w
+bWVudDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMXlOWpVKRCxUMgR
+mFj+CZw05qwgK/1NY7TXkmCtiijsD9e6ix106VIkSWqdyg4CcrJ6wh7j389aYtso
+6Jh0kO9K8PBs7SG6Jl7wunmtpjZD0eJ0xoSvRKxVHrt5iDaAuUIejLdezWB/6XV5
+gCDMHyeH/XS7k75PZqLMMp+WzEDQESGoMt1/440Unmf8kuI8Uy3nBbytIEIxaIbo
+V2KS9gCGvnTnsd3EAIim9BuB5c5X9IPNXUgxejrdENejE58Tfn3MLiddsTWXSPCp
+5PRyHM9Uswr0EwuvnyfV0bdjDSN2zdwZ9sefBkXjee31ejT7zkJ4B4Vl7meW5LWD
+Sg1O9NMCAwEAAaOBmDCBlTAdBgNVHQ4EFgQUgFoGZh0nlKzUSvs+/uT8nLx1Vf4w
+YwYDVR0jBFwwWoAUIAKhWRwHlEqqJSfJSWC7FA+DEgihP6Q9MDsxETAPBgNVBAoM
+CFRlc3QgT3JnMSYwJAYDVQQDDB1UZXN0IE9yZyBQcm92aXNpb25pbmcgQ0EgUm9v
+dIIBATAPBgNVHRMECDAGAQH/AgEAMA0GCSqGSIb3DQEBCwUAA4IBAQC5R3BGzNCg
+V7IsGIBFte+qR0f5xTNdk9ruKaa8g3Ow+2O5cWfdjquwFcLmpl5nsQo+H+1Wk9Ej
+fcN8dZBcj/pvbhYHy3enp/MwYmneJAsc8cmQxJWurjkvIFzXiZ/GC48KTLQrsPRs
+JBeYSXyWqZ//PX6ftsWzqWdxyJZruQudOefh5Sdk3L7CgnriMP4pwTmYmXBeNC0e
+4k6SxfOisyQ6n/IdEB6v5MWBU2GQkVKeDjiU5y8eNItULJpFHvJ12c7sp6NZjb+y
+SYxqYbK2cCRmgDCF8fAoiYtSh/1SwaXWQXzGZJGYX8wbSE5Ue3erAPXY+nZ1UA1E
+w9GQDJN1DxDc
+-----END CERTIFICATE-----
+-----BEGIN X509 CRL-----
+MIIBnjCBhzANBgkqhkiG9w0BAQsFADBCMREwDwYDVQQKDAhUZXN0IE9yZzEtMCsG
+A1UEAwwkVGVzdCBPcmcgUHJvdmlzaW9uaW5nIENBIERldmVsb3BtZW50Fw0xNTA0
+MjQxNDE0MDhaFw0yODEyMzExNDE0MDhaMBQwEgIBAhcNMTUwNDI0MTQxNDA4WjAN
+BgkqhkiG9w0BAQsFAAOCAQEARTyH2YnWKeTVFy8Yb/kiThaK0qay40Fyxb+zkVFH
+dKUNh4GViWHLxaqUSnGw+UaHKoMEONul0llYxGN6sbeRRQHYmJh2bmXVPBANNMON
+WOPYyRNa5I+EsaMKYRvlPCadxnUyy/bn2eJeieOX+qookU2+WnUUQWfRtP4KYbXQ
+1gi+HEWcu2GXqxaoZda54rOr8WAMhR0OHwfnBfuoBC9oQiqIkbVgf0aVsOa7AWi3
+PH5REoeY61Slr/RsO+EFQdnzlBHZVeYF8+NaoeEh1uVnRNa0Qo1oaA4kElNagyNk
++X1KrTl2C+x5CavD1vPf2nqQe2xTigr1BCUbKNIRNm8d9A==
+-----END X509 CRL-----

--- a/test/signature.c
+++ b/test/signature.c
@@ -554,28 +554,6 @@ static void signature_cmsverify_pathdir_path(SignatureFixture *fixture,
 	g_assert_nonnull(fixture->cms);
 }
 
-static void signature_cmsverify_nocert(SignatureFixture *fixture,
-		gconstpointer user_data)
-{
-	/* Sign with "A" key and cert */
-	fixture->sig = cms_sign(fixture->content,
-			"test/openssl-ca/dir/a.cert.pem",
-			"test/openssl-ca/dir/private/a.key.pem",
-			NULL,
-			&fixture->error);
-	g_assert_nonnull(fixture->sig);
-	g_assert_no_error(fixture->error);
-	g_clear_error(&fixture->error);
-
-	/* Verify error when not given directory or path */
-	g_assert_false(cms_verify(fixture->content,
-			fixture->sig,
-			fixture->store,
-			&fixture->cms,
-			&fixture->error));
-	g_assert_error(fixture->error, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_CA_LOAD);
-}
-
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -604,7 +582,6 @@ int main(int argc, char *argv[])
 	g_test_add("/signature/cmsverify_dir_single_fail", SignatureFixture, NULL, signature_set_up, signature_cmsverify_dir_single_fail, signature_tear_down);
 	g_test_add("/signature/cmsverify_pathdir_dir", SignatureFixture, NULL, signature_set_up, signature_cmsverify_pathdir_dir, signature_tear_down);
 	g_test_add("/signature/cmsverify_pathdir_path", SignatureFixture, NULL, signature_set_up, signature_cmsverify_pathdir_path, signature_tear_down);
-	g_test_add("/signature/cmsverify_nocert", SignatureFixture, NULL, signature_set_up, signature_cmsverify_nocert, signature_tear_down);
 
 	return g_test_run();
 }

--- a/test/signature.c
+++ b/test/signature.c
@@ -24,7 +24,11 @@ static void signature_set_up(SignatureFixture *fixture,
 	fixture->sig = NULL;
 	fixture->error = NULL;
 	fixture->cms = NULL;
-	fixture->store = NULL;
+
+	fixture->store = X509_STORE_new();
+	g_assert_nonnull(fixture->store);
+	g_assert_true(X509_STORE_load_locations(fixture->store, "test/openssl-ca/dev-ca.pem", NULL));
+
 	fixture->verified_chain = NULL;
 }
 
@@ -46,13 +50,13 @@ static void signature_tear_down(SignatureFixture *fixture,
 static void signature_sign(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
+	gchar *certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
+	gchar *keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
 
 	// Test valid signing
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
-			r_context()->keypath,
+			certpath,
+			keypath,
 			NULL,
 			&fixture->error);
 	g_assert_nonnull(fixture->sig);
@@ -62,7 +66,7 @@ static void signature_sign(SignatureFixture *fixture,
 
 	// Test signing fails with invalid key
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
+			certpath,
 			"test/random.dat",
 			NULL,
 			&fixture->error);
@@ -74,7 +78,7 @@ static void signature_sign(SignatureFixture *fixture,
 	// Test signing fails with invalid cert
 	fixture->sig = cms_sign(fixture->content,
 			"test/random.dat",
-			r_context()->keypath,
+			keypath,
 			NULL,
 			&fixture->error);
 	g_assert_null(fixture->sig);
@@ -84,13 +88,13 @@ static void signature_sign(SignatureFixture *fixture,
 static void signature_sign_file(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
+	gchar *certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
+	gchar *keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
 
 	// Test valid file
 	fixture->sig = cms_sign_file("test/openssl-ca/manifest",
-			r_context()->certpath,
-			r_context()->keypath,
+			certpath,
+			keypath,
 			NULL,
 			&fixture->error);
 	g_assert_nonnull(fixture->sig);
@@ -101,8 +105,8 @@ static void signature_sign_file(SignatureFixture *fixture,
 
 	// Test non-existing file
 	fixture->sig = cms_sign_file("path/to/nonexisting/file",
-			r_context()->certpath,
-			r_context()->keypath,
+			certpath,
+			keypath,
 			NULL,
 			&fixture->error);
 	g_assert_null(fixture->sig);
@@ -113,8 +117,8 @@ static void signature_sign_file(SignatureFixture *fixture,
 
 	// Test invalid certificate (use key instead)
 	fixture->sig = cms_sign_file("test/openssl-ca/manifest",
-			r_context()->keypath,
-			r_context()->keypath,
+			keypath,
+			keypath,
 			NULL,
 			&fixture->error);
 	g_assert_null(fixture->sig);
@@ -124,19 +128,19 @@ static void signature_sign_file(SignatureFixture *fixture,
 static void signature_verify_valid(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
+	gboolean res;
+
 	fixture->sig = read_file("test/openssl-ca/manifest-r1.sig", NULL);
 	g_assert_nonnull(fixture->sig);
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/dev-ca.pem");
-	r_context();
 
-	g_assert_true(cms_verify(fixture->content,
+	res = cms_verify(fixture->content,
 			fixture->sig,
+			fixture->store,
 			&fixture->cms,
-			&fixture->store,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->cms);
-	g_assert_nonnull(fixture->store);
 }
 
 static void signature_verify_invalid(SignatureFixture *fixture,
@@ -144,18 +148,15 @@ static void signature_verify_invalid(SignatureFixture *fixture,
 {
 	fixture->sig = read_file("test/random.dat", NULL);
 	g_assert_nonnull(fixture->sig);
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/dev-ca.pem");
-	r_context();
 
 	// Test against invalid signature
 	g_assert_false(cms_verify(fixture->content,
 			fixture->sig,
+			fixture->store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_error(fixture->error, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_PARSE);
 	g_assert_null(fixture->cms);
-	g_assert_null(fixture->store);
 }
 
 static void signature_verify_file(SignatureFixture *fixture,
@@ -163,33 +164,28 @@ static void signature_verify_file(SignatureFixture *fixture,
 {
 	fixture->sig = read_file("test/openssl-ca/manifest-r1.sig", NULL);
 	g_assert_nonnull(fixture->sig);
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/dev-ca.pem");
-	r_context();
 
 	// Test valid manifest
 	g_assert_true(cms_verify_file("test/openssl-ca/manifest",
 			fixture->sig,
 			0,
+			fixture->store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_null(fixture->error);
 	g_assert_nonnull(fixture->cms);
-	g_assert_nonnull(fixture->store);
 
-	g_clear_pointer(&fixture->store, X509_STORE_free);
 	g_clear_pointer(&fixture->cms, CMS_ContentInfo_free);
 
 	// Test valid manifest with invalid size limit
 	g_assert_false(cms_verify_file("test/openssl-ca/manifest",
 			fixture->sig,
 			42,
+			fixture->store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_error(fixture->error, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_assert_null(fixture->cms);
-	g_assert_null(fixture->store);
 
 	g_clear_error(&fixture->error);
 
@@ -197,29 +193,25 @@ static void signature_verify_file(SignatureFixture *fixture,
 	g_assert_false(cms_verify_file("path/to/nonexisting/file",
 			fixture->sig,
 			0,
+			fixture->store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_error(fixture->error, G_FILE_ERROR, G_FILE_ERROR_NOENT);
 	g_assert_null(fixture->cms);
-	g_assert_null(fixture->store);
 }
 
 static void signature_loopback(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/dev-ca.pem");
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/rel/release-1.cert.pem",
+			"test/openssl-ca/rel/private/release-1.pem",
 			NULL,
 			NULL);
 	g_assert_nonnull(fixture->sig);
-	g_assert_true(cms_verify(fixture->content, fixture->sig, NULL, NULL, NULL));
+	g_assert_true(cms_verify(fixture->content, fixture->sig, fixture->store, NULL, NULL));
 	((char *)g_bytes_get_data(fixture->content, NULL))[0] = 0x00;
-	g_assert_false(cms_verify(fixture->content, fixture->sig, NULL, NULL, NULL));
+	g_assert_false(cms_verify(fixture->content, fixture->sig, fixture->store, NULL, NULL));
 }
 
 static void signature_get_cert_chain(SignatureFixture *fixture,
@@ -228,17 +220,13 @@ static void signature_get_cert_chain(SignatureFixture *fixture,
 	fixture->sig = read_file("test/openssl-ca/manifest-r1.sig", NULL);
 	g_assert_nonnull(fixture->sig);
 
-	/* We verify against the dev-ca keychain */
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/dev-ca.pem");
-
 	g_assert_true(cms_verify(fixture->content,
 			fixture->sig,
+			fixture->store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_no_error(fixture->error);
 	g_assert_nonnull(fixture->cms);
-	g_assert_nonnull(fixture->store);
 
 	/* Verify obtaining cert chain works */
 	g_assert_true(cms_get_cert_chain(fixture->cms,
@@ -255,15 +243,13 @@ static void signature_get_cert_chain(SignatureFixture *fixture,
 static void signature_selfsigned(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
-	/* We sign with root CA key and cert */
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/root/ca.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/root/private/ca.key.pem");
-	/* We also verify against the root CA */
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/root/ca.cert.pem");
+	X509_STORE *root_store = X509_STORE_new();
+	g_assert_nonnull(root_store);
+	g_assert_true(X509_STORE_load_locations(root_store, "test/openssl-ca/root/ca.cert.pem", NULL));
 
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/root/ca.cert.pem",
+			"test/openssl-ca/root/private/ca.key.pem",
 			NULL,
 			&fixture->error);
 	g_assert_nonnull(fixture->sig);
@@ -273,18 +259,17 @@ static void signature_selfsigned(SignatureFixture *fixture,
 
 	g_assert_true(cms_verify(fixture->content,
 			fixture->sig,
+			root_store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_no_error(fixture->error);
 	g_assert_nonnull(fixture->cms);
-	g_assert_nonnull(fixture->store);
 
 	g_clear_error(&fixture->error);
 
 	/* Verify obtaining cert chain works */
 	g_assert_true(cms_get_cert_chain(fixture->cms,
-			fixture->store,
+			root_store,
 			&fixture->verified_chain,
 			&fixture->error));
 	g_assert_no_error(fixture->error);
@@ -298,33 +283,29 @@ static void signature_intermediate(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
 	GPtrArray *interfiles = NULL;
-
-	/* We sign with the release key */
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
+	X509_STORE *prov_store = X509_STORE_new();
+	g_assert_nonnull(prov_store);
+	/* We verify against the provisioning CA */
+	g_assert_true(X509_STORE_load_locations(prov_store, "test/openssl-ca/provisioning-ca.pem", NULL));
 
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/rel/release-1.cert.pem",
+			"test/openssl-ca/rel/private/release-1.pem",
 			NULL,
 			&fixture->error);
 	g_assert_nonnull(fixture->sig);
 	g_assert_no_error(fixture->error);
 
-	/* We verify against the provisioning CA */
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/provisioning-ca.pem");
 	/* Without explicit intermediate certificate, this must fail */
 	g_assert_false(cms_verify(fixture->content,
 			fixture->sig,
+			prov_store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_error(fixture->error, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_assert_null(fixture->cms);
-	g_assert_null(fixture->store);
 
 	g_clear_pointer(&fixture->cms, CMS_ContentInfo_free);
-	g_clear_pointer(&fixture->store, X509_STORE_free);
 	g_clear_error(&fixture->error);
 
 	/* Include the missing link in the signature */
@@ -333,8 +314,8 @@ static void signature_intermediate(SignatureFixture *fixture,
 	g_ptr_array_add(interfiles, NULL);
 
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/rel/release-1.cert.pem",
+			"test/openssl-ca/rel/private/release-1.pem",
 			(gchar**) g_ptr_array_free(interfiles, FALSE),
 			NULL);
 	g_assert_nonnull(fixture->sig);
@@ -342,16 +323,15 @@ static void signature_intermediate(SignatureFixture *fixture,
 	/* With intermediate certificate, this must succeed */
 	g_assert_true(cms_verify(fixture->content,
 			fixture->sig,
+			prov_store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_no_error(fixture->error);
 	g_assert_nonnull(fixture->cms);
-	g_assert_nonnull(fixture->store);
 
 	/* Verify obtaining cert chain works */
 	g_assert_true(cms_get_cert_chain(fixture->cms,
-			fixture->store,
+			prov_store,
 			&fixture->verified_chain,
 			&fixture->error));
 	g_assert_no_error(fixture->error);
@@ -365,35 +345,29 @@ static void signature_intermediate_file(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
 	GPtrArray *interfiles = NULL;
-
-	/* We sign with the release key */
-	r_context_conf();
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/rel/release-1.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/rel/private/release-1.pem");
+	X509_STORE *prov_store = X509_STORE_new();
+	g_assert_nonnull(prov_store);
+	g_assert_true(X509_STORE_load_locations(prov_store, "test/openssl-ca/provisioning-ca.pem", NULL));
 
 	fixture->sig = cms_sign_file("test/openssl-ca/manifest",
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/rel/release-1.cert.pem",
+			"test/openssl-ca/rel/private/release-1.pem",
 			NULL,
 			&fixture->error);
 	g_assert_nonnull(fixture->sig);
 	g_assert_no_error(fixture->error);
 
-	/* We verify against the provisioning CA */
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/provisioning-ca.pem");
 	/* Without explicit intermediate certificate, this must fail */
 	g_assert_false(cms_verify_file("test/openssl-ca/manifest",
 			fixture->sig,
 			0,
+			prov_store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_error(fixture->error, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_assert_null(fixture->cms);
-	g_assert_null(fixture->store);
 
 	g_clear_pointer(&fixture->cms, CMS_ContentInfo_free);
-	g_clear_pointer(&fixture->store, X509_STORE_free);
 	g_clear_error(&fixture->error);
 
 	/* Include the missing link in the signature */
@@ -402,8 +376,8 @@ static void signature_intermediate_file(SignatureFixture *fixture,
 	g_ptr_array_add(interfiles, NULL);
 
 	fixture->sig = cms_sign_file("test/openssl-ca/manifest",
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/rel/release-1.cert.pem",
+			"test/openssl-ca/rel/private/release-1.pem",
 			(gchar**) g_ptr_array_free(interfiles, FALSE),
 			NULL);
 	g_assert_nonnull(fixture->sig);
@@ -412,12 +386,11 @@ static void signature_intermediate_file(SignatureFixture *fixture,
 	g_assert_true(cms_verify_file("test/openssl-ca/manifest",
 			fixture->sig,
 			0,
+			fixture->store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_no_error(fixture->error);
 	g_assert_nonnull(fixture->cms);
-	g_assert_nonnull(fixture->store);
 
 	/* Verify obtaining cert chain works */
 	g_assert_true(cms_get_cert_chain(fixture->cms,
@@ -434,14 +407,14 @@ static void signature_intermediate_file(SignatureFixture *fixture,
 static void signature_cmsverify_path(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/dir/a.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/dir/private/a.key.pem");
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/dir/a.cert.pem");
+	X509_STORE *a_store = X509_STORE_new();
+	g_assert_nonnull(a_store);
+	g_assert_true(X509_STORE_load_locations(a_store, "test/openssl-ca/dir/a.cert.pem", NULL));
 
 	/* Sign with "A" key and cert */
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/dir/a.cert.pem",
+			"test/openssl-ca/dir/private/a.key.pem",
 			NULL,
 			&fixture->error);
 	g_assert_nonnull(fixture->sig);
@@ -452,25 +425,24 @@ static void signature_cmsverify_path(SignatureFixture *fixture,
 	/* Verify against "A" cert */
 	g_assert_true(cms_verify(fixture->content,
 			fixture->sig,
+			a_store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_no_error(fixture->error);
 	g_assert_nonnull(fixture->cms);
-	g_assert_nonnull(fixture->store);
 }
 
 static void signature_cmsverify_dir_combined(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/dir/a.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/dir/private/a.key.pem");
-	r_context_conf()->keyringdirectory = g_strdup("test/openssl-ca/dir/hash/ab");
+	X509_STORE *ab_dir_store = X509_STORE_new();
+	g_assert_nonnull(ab_dir_store);
+	g_assert_true(X509_STORE_load_locations(ab_dir_store, NULL, "test/openssl-ca/dir/hash/ab"));
 
 	/* Sign with "A" key and cert */
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/dir/a.cert.pem",
+			"test/openssl-ca/dir/private/a.key.pem",
 			NULL,
 			&fixture->error);
 	g_assert_nonnull(fixture->sig);
@@ -480,24 +452,28 @@ static void signature_cmsverify_dir_combined(SignatureFixture *fixture,
 	/* Verify against certs stored in combined directory (A+B) */
 	g_assert_true(cms_verify(fixture->content,
 			fixture->sig,
+			ab_dir_store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_no_error(fixture->error);
 	g_assert_nonnull(fixture->cms);
-	g_assert_nonnull(fixture->store);
 }
 
 static void signature_cmsverify_dir_single_fail(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/dir/b.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/dir/private/b.key.pem");
+	X509_STORE *a_store = X509_STORE_new();
+	X509_STORE *ab_dir_store = X509_STORE_new();
+	g_assert_nonnull(a_store);
+	g_assert_nonnull(ab_dir_store);
+	g_assert_true(X509_STORE_load_locations(a_store, "test/openssl-ca/dir/a.cert.pem", NULL));
+	g_assert_true(X509_STORE_load_locations(ab_dir_store, NULL, "test/openssl-ca/dir/hash/ab"));
+
 
 	/* Sign with "B" key and cert */
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/dir/b.cert.pem",
+			"test/openssl-ca/dir/private/b.key.pem",
 			NULL,
 			&fixture->error);
 	g_assert_nonnull(fixture->sig);
@@ -505,27 +481,20 @@ static void signature_cmsverify_dir_single_fail(SignatureFixture *fixture,
 	g_clear_error(&fixture->error);
 
 	/* Verify against certs stored in combined directory (A+B) */
-	r_context_conf()->keyringdirectory = g_strdup("test/openssl-ca/dir/hash/ab");
-	r_context();
 	g_assert_true(cms_verify(fixture->content,
 			fixture->sig,
+			ab_dir_store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_no_error(fixture->error);
 	g_assert_nonnull(fixture->cms);
-	g_assert_nonnull(fixture->store);
 
 	/* Verify failure against certs stored in "A" only directory */
 	g_clear_pointer(&fixture->cms, CMS_ContentInfo_free);
-	g_clear_pointer(&fixture->store, X509_STORE_free);
-	g_free(r_context_conf()->keyringdirectory);
-	r_context_conf()->keyringdirectory = g_strdup("test/openssl-ca/dir/hash/a");
-	r_context();
 	g_assert_false(cms_verify(fixture->content,
 			fixture->sig,
+			a_store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_error(fixture->error, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 }
@@ -533,15 +502,14 @@ static void signature_cmsverify_dir_single_fail(SignatureFixture *fixture,
 static void signature_cmsverify_pathdir_dir(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/dir/a.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/dir/private/a.key.pem");
-	r_context_conf()->keyringdirectory = g_strdup("test/openssl-ca/dir/hash/a");
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/dir/b.cert.pem");
+	X509_STORE *a_dir_b_store = X509_STORE_new();
+	g_assert_nonnull(a_dir_b_store);
+	g_assert_true(X509_STORE_load_locations(a_dir_b_store, "test/openssl-ca/dir/b.cert.pem", "test/openssl-ca/dir/hash/a"));
 
 	/* Sign with "A" key and cert */
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/dir/a.cert.pem",
+			"test/openssl-ca/dir/private/a.key.pem",
 			NULL,
 			&fixture->error);
 	g_assert_nonnull(fixture->sig);
@@ -551,26 +519,24 @@ static void signature_cmsverify_pathdir_dir(SignatureFixture *fixture,
 	/* Verify against certs stored in directory(A) + path(B) */
 	g_assert_true(cms_verify(fixture->content,
 			fixture->sig,
+			a_dir_b_store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_no_error(fixture->error);
 	g_assert_nonnull(fixture->cms);
-	g_assert_nonnull(fixture->store);
 }
 
 static void signature_cmsverify_pathdir_path(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/dir/b.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/dir/private/b.key.pem");
-	r_context_conf()->keyringdirectory = g_strdup("test/openssl-ca/dir/hash/a");
-	r_context_conf()->keyringpath = g_strdup("test/openssl-ca/dir/b.cert.pem");
+	X509_STORE *a_dir_b_store = X509_STORE_new();
+	g_assert_nonnull(a_dir_b_store);
+	g_assert_true(X509_STORE_load_locations(a_dir_b_store, "test/openssl-ca/dir/b.cert.pem", "test/openssl-ca/dir/hash/a"));
 
 	/* Sign with "B" key and cert */
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/dir/b.cert.pem",
+			"test/openssl-ca/dir/private/b.key.pem",
 			NULL,
 			&fixture->error);
 
@@ -581,24 +547,20 @@ static void signature_cmsverify_pathdir_path(SignatureFixture *fixture,
 	/* Verify against certs stored in directory(A) + path(B) */
 	g_assert_true(cms_verify(fixture->content,
 			fixture->sig,
+			a_dir_b_store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_no_error(fixture->error);
 	g_assert_nonnull(fixture->cms);
-	g_assert_nonnull(fixture->store);
 }
 
 static void signature_cmsverify_nocert(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
-	r_context_conf()->certpath = g_strdup("test/openssl-ca/dir/a.cert.pem");
-	r_context_conf()->keypath = g_strdup("test/openssl-ca/dir/private/a.key.pem");
-
 	/* Sign with "A" key and cert */
 	fixture->sig = cms_sign(fixture->content,
-			r_context()->certpath,
-			r_context()->keypath,
+			"test/openssl-ca/dir/a.cert.pem",
+			"test/openssl-ca/dir/private/a.key.pem",
 			NULL,
 			&fixture->error);
 	g_assert_nonnull(fixture->sig);
@@ -608,8 +570,8 @@ static void signature_cmsverify_nocert(SignatureFixture *fixture,
 	/* Verify error when not given directory or path */
 	g_assert_false(cms_verify(fixture->content,
 			fixture->sig,
+			fixture->store,
 			&fixture->cms,
-			&fixture->store,
 			&fixture->error));
 	g_assert_error(fixture->error, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_CA_LOAD);
 }


### PR DESCRIPTION
When doing post-signing verification for 'rauc resign' we must be aware
that we need two different keyrings:

a) The one to verify the *original* bundle against
b) The one to verify the *resigned* bundle against

For now we only had the option `--keyring` and the same keyring was used
for both case a) and b).
While there are cases where this is valid (if the keyring accepts both
signatures), the default is that this will fail.

The existing '--keyring' parameter is already used for passing the
systems keyring to the RAUC service etc.
Thus for post-signing verification we must introduce another parameter to
explicitly pass the 'second' keyring. This is what we do here with the
'--verify-keyring' parameter.

Note that this will 'break' setups that did use the '--keyring'
verification feature before in the way that the bundle will be generated
but not verified. These setups need to migrate to the '--verify-keyring'
feature.

To be consistent, this option is added for subcommands 'bundle',
'resign', and 'convert'.


Apart from this, the series also fixes an invalid handling within the tests revealed in the context of this issue.

This aims to replace #461 by targeting the critics mentioned there.