### PR TITLE
src/update_handler: use g_seekable_tell() to get size of written data

### DIFF
--- a/include/bundle.h
+++ b/include/bundle.h
@@ -16,7 +16,7 @@ typedef struct {
 	gchar *path;
 	gchar *origpath;
 	gchar *storepath;
-	gsize size;
+	goffset size;
 	GBytes *sigdata;
 	gchar *mount_point;
 	STACK_OF(X509) *verified_chain;

--- a/include/checksum.h
+++ b/include/checksum.h
@@ -14,7 +14,7 @@ GQuark r_checksum_error_quark(void);
 typedef struct {
 	GChecksumType type;
 	gchar *digest;
-	gsize size;
+	goffset size;
 } RaucChecksum;
 
 /**

--- a/include/mount.h
+++ b/include/mount.h
@@ -19,7 +19,7 @@
  *
  * @return True if succeeded, False if failed
  */
-gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar* type, gsize size, const gchar *extra_options, GError **error);
+gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar* type, goffset size, const gchar *extra_options, GError **error);
 
 /**
  * Loopback mount a file.
@@ -31,7 +31,7 @@ gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar*
  *
  * @return True if succeeded, False if failed
  */
-gboolean r_mount_loop(const gchar *filename, const gchar *mountpoint, gsize size, GError **error);
+gboolean r_mount_loop(const gchar *filename, const gchar *mountpoint, goffset size, GError **error);
 
 /**
  * Unmount a slot or a file.

--- a/include/signature.h
+++ b/include/signature.h
@@ -93,7 +93,7 @@ gboolean cms_verify(GBytes *content, GBytes *sig, X509_STORE *store, CMS_Content
  *
  * @return TRUE if succeeded, FALSE if failed
  */
-gboolean cms_verify_file(const gchar *filename, GBytes *sig, gsize limit, X509_STORE *store, CMS_ContentInfo **cms, GError **error);
+gboolean cms_verify_file(const gchar *filename, GBytes *sig, goffset limit, X509_STORE *store, CMS_ContentInfo **cms, GError **error);
 
 /**
  * Calculates hash for certificate pubkey info.

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -400,7 +400,7 @@ out:
 	return res;
 }
 
-static gboolean truncate_bundle(const gchar *inpath, const gchar *outpath, gsize size, GError **error)
+static gboolean truncate_bundle(const gchar *inpath, const gchar *outpath, goffset size, GError **error)
 {
 	g_autoptr(GFile) infile = NULL;
 	g_autoptr(GFile) outfile = NULL;

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -17,10 +17,10 @@ G_STATIC_ASSERT(RAUC_DEFAULT_CHECKSUM != 0);
 G_DEFINE_QUARK(r-checksum-error-quark, r_checksum_error)
 
 static gboolean
-update_from_file(GChecksum *ctx, const gchar *filename, gsize *total, GError **error)
+update_from_file(GChecksum *ctx, const gchar *filename, goffset *total, GError **error)
 {
 	g_auto(filedesc) fd = -1;
-	gsize size = 0;
+	goffset size = 0;
 	gssize r;
 	guchar buf[4096];
 
@@ -51,7 +51,7 @@ gboolean compute_checksum(RaucChecksum *checksum, const gchar *filename, GError 
 {
 	g_autoptr(GChecksum) ctx = NULL;
 	GChecksumType type = checksum->type;
-	gsize total = 0;
+	goffset total = 0;
 
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 

--- a/src/main.c
+++ b/src/main.c
@@ -683,7 +683,7 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 		formatter_shell_append_n(text, "RAUC_IMAGE_CLASS", cnt, img->slotclass);
 		formatter_shell_append_n(text, "RAUC_IMAGE_VARIANT", cnt, img->variant);
 		formatter_shell_append_n(text, "RAUC_IMAGE_DIGEST", cnt, img->checksum.digest);
-		g_string_append_printf(text, "RAUC_IMAGE_SIZE_%d=%"G_GSIZE_FORMAT "\n", cnt, img->checksum.size);
+		g_string_append_printf(text, "RAUC_IMAGE_SIZE_%d=%"G_GOFFSET_FORMAT "\n", cnt, img->checksum.size);
 
 		hooks = g_ptr_array_new();
 		if (img->hooks.pre_install == TRUE) {
@@ -712,7 +712,7 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 		g_string_append_printf(text, "RAUC_FILE_CLASS_%d=%s\n", cnt, file->slotclass);
 		g_string_append_printf(text, "RAUC_FILE_DEST_%d=%s\n", cnt, file->destname);
 		g_string_append_printf(text, "RAUC_FILE_DIGEST_%d=%s\n", cnt, file->checksum.digest);
-		g_string_append_printf(text, "RAUC_FILE_SIZE_%d=%"G_GSIZE_FORMAT "\n", cnt, file->checksum.size);
+		g_string_append_printf(text, "RAUC_FILE_SIZE_%d=%"G_GOFFSET_FORMAT "\n", cnt, file->checksum.size);
 		cnt++;
 	}
 
@@ -753,7 +753,7 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 		if (img->variant)
 			g_string_append_printf(text, "\tVariant:   %s\n", img->variant);
 		g_string_append_printf(text, "\tChecksum:  %s\n", img->checksum.digest);
-		g_string_append_printf(text, "\tSize:      %"G_GSIZE_FORMAT "\n", img->checksum.size);
+		g_string_append_printf(text, "\tSize:      %"G_GOFFSET_FORMAT "\n", img->checksum.size);
 
 		hooks = g_ptr_array_new();
 		if (img->hooks.pre_install == TRUE) {
@@ -785,7 +785,7 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 		g_string_append_printf(text, "\tSlotclass: %s\n", file->slotclass);
 		g_string_append_printf(text, "\tDest:      %s\n", file->destname);
 		g_string_append_printf(text, "\tChecksum:  %s\n", file->checksum.digest);
-		g_string_append_printf(text, "\tSize:      %"G_GSIZE_FORMAT "\n", file->checksum.size);
+		g_string_append_printf(text, "\tSize:      %"G_GOFFSET_FORMAT "\n", file->checksum.size);
 		cnt++;
 	}
 
@@ -1038,7 +1038,7 @@ static void r_string_append_slot(GString *text, RaucSlot *slot, RaucStatusPrint 
 		if (slot_state->checksum.digest && slot_state->checksum.type == G_CHECKSUM_SHA256) {
 			g_string_append_printf(text, "\n          checksum:");
 			g_string_append_printf(text, "\n              sha256=%s", slot_state->checksum.digest);
-			g_string_append_printf(text, "\n              size=%"G_GSIZE_FORMAT, slot_state->checksum.size);
+			g_string_append_printf(text, "\n              size=%"G_GOFFSET_FORMAT, slot_state->checksum.size);
 		}
 		if (slot_state->installed_timestamp) {
 			g_string_append_printf(text, "\n          installed:");
@@ -1166,7 +1166,7 @@ static gchar* r_status_formatter_shell(RaucStatusPrint *status)
 			formatter_shell_append_n(text, "RAUC_SLOT_STATUS_BUNDLE_DESCRIPTION", slotcnt, slot_state->bundle_description);
 			formatter_shell_append_n(text, "RAUC_SLOT_STATUS_BUNDLE_BUILD", slotcnt, slot_state->bundle_build);
 			formatter_shell_append_n(text, "RAUC_SLOT_STATUS_CHECKSUM_SHA256", slotcnt, slot_state->checksum.digest);
-			str = g_strdup_printf("%"G_GSIZE_FORMAT, slot_state->checksum.size);
+			str = g_strdup_printf("%"G_GOFFSET_FORMAT, slot_state->checksum.size);
 			formatter_shell_append_n(text, "RAUC_SLOT_STATUS_CHECKSUM_SIZE", slotcnt, str);
 			g_free(str);
 			formatter_shell_append_n(text, "RAUC_SLOT_STATUS_INSTALLED_TIMESTAMP", slotcnt, slot_state->installed_timestamp);

--- a/src/mount.c
+++ b/src/mount.c
@@ -6,7 +6,7 @@
 #include "mount.h"
 #include "utils.h"
 
-gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar* type, gsize size, const gchar* extra_options, GError **error)
+gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar* type, goffset size, const gchar* extra_options, GError **error)
 {
 	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
@@ -24,7 +24,7 @@ gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar*
 	}
 	if (size != 0) {
 		g_ptr_array_add(args, g_strdup("-o"));
-		g_ptr_array_add(args, g_strdup_printf("ro,loop,sizelimit=%"G_GSIZE_FORMAT, size));
+		g_ptr_array_add(args, g_strdup_printf("ro,loop,sizelimit=%"G_GOFFSET_FORMAT, size));
 	}
 	if (extra_options) {
 		g_ptr_array_add(args, g_strdup("-o"));
@@ -58,7 +58,7 @@ out:
 }
 
 
-gboolean r_mount_loop(const gchar *filename, const gchar *mountpoint, gsize size, GError **error)
+gboolean r_mount_loop(const gchar *filename, const gchar *mountpoint, goffset size, GError **error)
 {
 	return r_mount_full(filename, mountpoint, "squashfs", size, NULL, error);
 }

--- a/src/network.c
+++ b/src/network.c
@@ -159,7 +159,7 @@ gboolean download_file_checksum(const gchar *target, const gchar *url,
 	g_autofree gchar *tmppath = NULL;
 	gboolean res = FALSE;
 
-	tmpname = g_strdup_printf(".rauc_%s_%"G_GSIZE_FORMAT, checksum->digest,
+	tmpname = g_strdup_printf(".rauc_%s_%"G_GOFFSET_FORMAT, checksum->digest,
 			checksum->size);
 	dir = g_path_get_dirname(target);
 	tmppath = g_build_filename(dir, tmpname, NULL);

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -141,7 +141,7 @@ static gboolean copy_raw_image(RaucImage *image, GUnixOutputStream *outstream, G
 		return FALSE;
 	} else if (size != (gssize)image->checksum.size) {
 		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
-				"Written size (%"G_GSIZE_FORMAT ") != image size (%"G_GSIZE_FORMAT ")", size, (gssize)image->checksum.size);
+				"Written size (%"G_GSIZE_FORMAT ") != image size (%"G_GOFFSET_FORMAT ")", size, image->checksum.size);
 		return FALSE;
 	}
 
@@ -1166,9 +1166,9 @@ static gboolean img_to_boot_mbr_switch_handler(RaucImage *image, RaucSlot *dest_
 	g_message("Found inactive boot partition %d (pos. %"G_GUINT64_FORMAT "B, size %"G_GUINT64_FORMAT "B)",
 			inactive_part, dest_partition.start, dest_partition.size);
 
-	if (dest_partition.size < image->checksum.size) {
+	if (dest_partition.size < (guint64)image->checksum.size) {
 		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
-				"Size of image (%"G_GSIZE_FORMAT ") does not fit to slot size %"G_GUINT64_FORMAT,
+				"Size of image (%"G_GOFFSET_FORMAT ") does not fit to slot size %"G_GUINT64_FORMAT,
 				image->checksum.size, dest_partition.size);
 		res = FALSE;
 		goto out;

--- a/test/signature.c
+++ b/test/signature.c
@@ -162,17 +162,19 @@ static void signature_verify_invalid(SignatureFixture *fixture,
 static void signature_verify_file(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
+	gboolean res;
 	fixture->sig = read_file("test/openssl-ca/manifest-r1.sig", NULL);
 	g_assert_nonnull(fixture->sig);
 
 	// Test valid manifest
-	g_assert_true(cms_verify_file("test/openssl-ca/manifest",
+	res = cms_verify_file("test/openssl-ca/manifest",
 			fixture->sig,
 			0,
 			fixture->store,
 			&fixture->cms,
-			&fixture->error));
-	g_assert_null(fixture->error);
+			&fixture->error);
+	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->cms);
 
 	g_clear_pointer(&fixture->cms, CMS_ContentInfo_free);
@@ -217,23 +219,26 @@ static void signature_loopback(SignatureFixture *fixture,
 static void signature_get_cert_chain(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
+	gboolean res;
 	fixture->sig = read_file("test/openssl-ca/manifest-r1.sig", NULL);
 	g_assert_nonnull(fixture->sig);
 
-	g_assert_true(cms_verify(fixture->content,
+	res = cms_verify(fixture->content,
 			fixture->sig,
 			fixture->store,
 			&fixture->cms,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->cms);
 
 	/* Verify obtaining cert chain works */
-	g_assert_true(cms_get_cert_chain(fixture->cms,
+	res = cms_get_cert_chain(fixture->cms,
 			fixture->store,
 			&fixture->verified_chain,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->verified_chain);
 
 	/* Chain length must be 3 (release-1 -> rel -> root) */
@@ -243,6 +248,7 @@ static void signature_get_cert_chain(SignatureFixture *fixture,
 static void signature_selfsigned(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
+	gboolean res;
 	X509_STORE *root_store = X509_STORE_new();
 	g_assert_nonnull(root_store);
 	g_assert_true(X509_STORE_load_locations(root_store, "test/openssl-ca/root/ca.cert.pem", NULL));
@@ -252,27 +258,29 @@ static void signature_selfsigned(SignatureFixture *fixture,
 			"test/openssl-ca/root/private/ca.key.pem",
 			NULL,
 			&fixture->error);
-	g_assert_nonnull(fixture->sig);
 	g_assert_no_error(fixture->error);
+	g_assert_nonnull(fixture->sig);
 
 	g_clear_error(&fixture->error);
 
-	g_assert_true(cms_verify(fixture->content,
+	res = cms_verify(fixture->content,
 			fixture->sig,
 			root_store,
 			&fixture->cms,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->cms);
 
 	g_clear_error(&fixture->error);
 
 	/* Verify obtaining cert chain works */
-	g_assert_true(cms_get_cert_chain(fixture->cms,
+	res = cms_get_cert_chain(fixture->cms,
 			root_store,
 			&fixture->verified_chain,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->verified_chain);
 
 	/* Chain length for self-signed must be 1 */
@@ -282,6 +290,7 @@ static void signature_selfsigned(SignatureFixture *fixture,
 static void signature_intermediate(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
+	gboolean res;
 	GPtrArray *interfiles = NULL;
 	X509_STORE *prov_store = X509_STORE_new();
 	g_assert_nonnull(prov_store);
@@ -293,8 +302,8 @@ static void signature_intermediate(SignatureFixture *fixture,
 			"test/openssl-ca/rel/private/release-1.pem",
 			NULL,
 			&fixture->error);
-	g_assert_nonnull(fixture->sig);
 	g_assert_no_error(fixture->error);
+	g_assert_nonnull(fixture->sig);
 
 	/* Without explicit intermediate certificate, this must fail */
 	g_assert_false(cms_verify(fixture->content,
@@ -321,20 +330,22 @@ static void signature_intermediate(SignatureFixture *fixture,
 	g_assert_nonnull(fixture->sig);
 
 	/* With intermediate certificate, this must succeed */
-	g_assert_true(cms_verify(fixture->content,
+	res = cms_verify(fixture->content,
 			fixture->sig,
 			prov_store,
 			&fixture->cms,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->cms);
 
 	/* Verify obtaining cert chain works */
-	g_assert_true(cms_get_cert_chain(fixture->cms,
+	res = cms_get_cert_chain(fixture->cms,
 			prov_store,
 			&fixture->verified_chain,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->verified_chain);
 
 	/* Chain length must be 3 (release-1 -> rel -> root) */
@@ -344,6 +355,7 @@ static void signature_intermediate(SignatureFixture *fixture,
 static void signature_intermediate_file(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
+	gboolean res;
 	GPtrArray *interfiles = NULL;
 	X509_STORE *prov_store = X509_STORE_new();
 	g_assert_nonnull(prov_store);
@@ -354,8 +366,8 @@ static void signature_intermediate_file(SignatureFixture *fixture,
 			"test/openssl-ca/rel/private/release-1.pem",
 			NULL,
 			&fixture->error);
-	g_assert_nonnull(fixture->sig);
 	g_assert_no_error(fixture->error);
+	g_assert_nonnull(fixture->sig);
 
 	/* Without explicit intermediate certificate, this must fail */
 	g_assert_false(cms_verify_file("test/openssl-ca/manifest",
@@ -383,21 +395,23 @@ static void signature_intermediate_file(SignatureFixture *fixture,
 	g_assert_nonnull(fixture->sig);
 
 	/* With intermediate certificate, this must succeed */
-	g_assert_true(cms_verify_file("test/openssl-ca/manifest",
+	res = cms_verify_file("test/openssl-ca/manifest",
 			fixture->sig,
 			0,
 			fixture->store,
 			&fixture->cms,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->cms);
 
 	/* Verify obtaining cert chain works */
-	g_assert_true(cms_get_cert_chain(fixture->cms,
+	res = cms_get_cert_chain(fixture->cms,
 			fixture->store,
 			&fixture->verified_chain,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->verified_chain);
 
 	/* Chain length must be 3 (release-1 -> rel -> root) */
@@ -407,6 +421,7 @@ static void signature_intermediate_file(SignatureFixture *fixture,
 static void signature_cmsverify_path(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
+	gboolean res;
 	X509_STORE *a_store = X509_STORE_new();
 	g_assert_nonnull(a_store);
 	g_assert_true(X509_STORE_load_locations(a_store, "test/openssl-ca/dir/a.cert.pem", NULL));
@@ -417,24 +432,26 @@ static void signature_cmsverify_path(SignatureFixture *fixture,
 			"test/openssl-ca/dir/private/a.key.pem",
 			NULL,
 			&fixture->error);
-	g_assert_nonnull(fixture->sig);
 	g_assert_no_error(fixture->error);
+	g_assert_nonnull(fixture->sig);
 
 	g_clear_error(&fixture->error);
 
 	/* Verify against "A" cert */
-	g_assert_true(cms_verify(fixture->content,
+	res = cms_verify(fixture->content,
 			fixture->sig,
 			a_store,
 			&fixture->cms,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->cms);
 }
 
 static void signature_cmsverify_dir_combined(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
+	gboolean res;
 	X509_STORE *ab_dir_store = X509_STORE_new();
 	g_assert_nonnull(ab_dir_store);
 	g_assert_true(X509_STORE_load_locations(ab_dir_store, NULL, "test/openssl-ca/dir/hash/ab"));
@@ -445,23 +462,25 @@ static void signature_cmsverify_dir_combined(SignatureFixture *fixture,
 			"test/openssl-ca/dir/private/a.key.pem",
 			NULL,
 			&fixture->error);
-	g_assert_nonnull(fixture->sig);
 	g_assert_no_error(fixture->error);
+	g_assert_nonnull(fixture->sig);
 	g_clear_error(&fixture->error);
 
 	/* Verify against certs stored in combined directory (A+B) */
-	g_assert_true(cms_verify(fixture->content,
+	res = cms_verify(fixture->content,
 			fixture->sig,
 			ab_dir_store,
 			&fixture->cms,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->cms);
 }
 
 static void signature_cmsverify_dir_single_fail(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
+	gboolean res;
 	X509_STORE *a_store = X509_STORE_new();
 	X509_STORE *ab_dir_store = X509_STORE_new();
 	g_assert_nonnull(a_store);
@@ -476,17 +495,18 @@ static void signature_cmsverify_dir_single_fail(SignatureFixture *fixture,
 			"test/openssl-ca/dir/private/b.key.pem",
 			NULL,
 			&fixture->error);
-	g_assert_nonnull(fixture->sig);
 	g_assert_no_error(fixture->error);
+	g_assert_nonnull(fixture->sig);
 	g_clear_error(&fixture->error);
 
 	/* Verify against certs stored in combined directory (A+B) */
-	g_assert_true(cms_verify(fixture->content,
+	res = cms_verify(fixture->content,
 			fixture->sig,
 			ab_dir_store,
 			&fixture->cms,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->cms);
 
 	/* Verify failure against certs stored in "A" only directory */
@@ -502,6 +522,7 @@ static void signature_cmsverify_dir_single_fail(SignatureFixture *fixture,
 static void signature_cmsverify_pathdir_dir(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
+	gboolean res;
 	X509_STORE *a_dir_b_store = X509_STORE_new();
 	g_assert_nonnull(a_dir_b_store);
 	g_assert_true(X509_STORE_load_locations(a_dir_b_store, "test/openssl-ca/dir/b.cert.pem", "test/openssl-ca/dir/hash/a"));
@@ -512,23 +533,25 @@ static void signature_cmsverify_pathdir_dir(SignatureFixture *fixture,
 			"test/openssl-ca/dir/private/a.key.pem",
 			NULL,
 			&fixture->error);
-	g_assert_nonnull(fixture->sig);
 	g_assert_no_error(fixture->error);
+	g_assert_nonnull(fixture->sig);
 	g_clear_error(&fixture->error);
 
 	/* Verify against certs stored in directory(A) + path(B) */
-	g_assert_true(cms_verify(fixture->content,
+	res = cms_verify(fixture->content,
 			fixture->sig,
 			a_dir_b_store,
 			&fixture->cms,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->cms);
 }
 
 static void signature_cmsverify_pathdir_path(SignatureFixture *fixture,
 		gconstpointer user_data)
 {
+	gboolean res;
 	X509_STORE *a_dir_b_store = X509_STORE_new();
 	g_assert_nonnull(a_dir_b_store);
 	g_assert_true(X509_STORE_load_locations(a_dir_b_store, "test/openssl-ca/dir/b.cert.pem", "test/openssl-ca/dir/hash/a"));
@@ -540,17 +563,18 @@ static void signature_cmsverify_pathdir_path(SignatureFixture *fixture,
 			NULL,
 			&fixture->error);
 
-	g_assert_nonnull(fixture->sig);
 	g_assert_no_error(fixture->error);
+	g_assert_nonnull(fixture->sig);
 	g_clear_error(&fixture->error);
 
 	/* Verify against certs stored in directory(A) + path(B) */
-	g_assert_true(cms_verify(fixture->content,
+	res = cms_verify(fixture->content,
 			fixture->sig,
 			a_dir_b_store,
 			&fixture->cms,
-			&fixture->error));
+			&fixture->error);
 	g_assert_no_error(fixture->error);
+	g_assert_true(res);
 	g_assert_nonnull(fixture->cms);
 }
 


### PR DESCRIPTION
Documentation of g_output_stream_splice() says:

> Note that if the number of bytes spliced is greater than G_MAXSSIZE,
> then that will be returned, and there is no way to determine the actual
> number of bytes spliced.

As copy_raw_image() performs a sanity check if returned size matches
expected write size, it will not be possible to install an image whose
size exceeds G_MAXSSIZE.

Thus instead of letting g_output_stream_splice() close the output stream, we
leave it open to use g_seekable_tell() on it and obtain the actual size
read (written), even if it exceeds gssize.

Fixes #463.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>