### PR TITLE
install: add support for external devices

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,6 +130,7 @@ check_PROGRAMS = \
 	test/bootchooser.test \
 	test/checksum.test \
 	test/config_file.test \
+	test/context.test \
 	test/manifest.test \
 	test/signature.test \
 	test/update_handler.test \
@@ -189,6 +190,9 @@ test_checksum_test_LDADD = librauctest.la
 
 test_config_file_test_SOURCES = test/config_file.c
 test_config_file_test_LDADD = librauctest.la
+
+test_context_test_SOURCES = test/context.c
+test_context_test_LDADD = librauctest.la
 
 test_manifest_test_SOURCES = test/manifest.c
 test_manifest_test_LDADD = librauctest.la

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -299,7 +299,7 @@ Identification via Kernel Commandline
 RAUC evaluates different kernel commandline parameters in the order they are
 listed below.
 
-.. rubric:: ``rauc.slot=``
+.. rubric:: ``rauc.slot=`` and ``rauc.external``
 
 This is the generic way to explicitly set information about which slot was
 booted by the bootloader.
@@ -313,6 +313,14 @@ mechanism (such as a 'last-resort' recovery fallback that never gets explicitly
 selected) you can also give the name of the slot::
 
   rauc.slot=recovery.0
+
+When booting from a source not configured in your system.conf (for example from
+a USB memory stick), you can tell rauc explicitly with the flag ``
+rauc.external``.
+This means that all slots are known to be inactive and will be valid
+installation targets.
+A possible use case for this is to use RAUC during a bootstrapping procedure to
+perform an initial installation.
 
 .. rubric:: ``bootchooser.active=``
 

--- a/include/context.h
+++ b/include/context.h
@@ -49,6 +49,12 @@ typedef struct {
 
 	/* for storing installation runtime informations */
 	RContextInstallationInfo *install_info;
+
+	/* mock data for testing, zero during normal usage */
+	struct {
+		/* mock contents of /proc/cmdline */
+		const gchar *proc_cmdline;
+	} mock;
 } RaucContext;
 
 typedef struct {

--- a/src/context.c
+++ b/src/context.c
@@ -36,6 +36,9 @@ static const gchar* get_cmdline_bootname(void)
 	if (!g_file_get_contents("/proc/cmdline", &contents, NULL, NULL))
 		return NULL;
 
+	if (strstr(contents, "rauc.external") != NULL)
+		return "_external_";
+
 	bootname = regex_match("rauc\\.slot=(\\S+)", contents);
 	if (bootname)
 		return bootname;

--- a/src/context.c
+++ b/src/context.c
@@ -30,7 +30,9 @@ static const gchar* get_cmdline_bootname(void)
 	g_autofree gchar *realdev = NULL;
 	const char *bootname = NULL;
 
-	if (!g_file_get_contents("/proc/cmdline", &contents, NULL, NULL))
+	if (context->mock.proc_cmdline)
+		contents = g_strdup(context->mock.proc_cmdline);
+	else if (!g_file_get_contents("/proc/cmdline", &contents, NULL, NULL))
 		return NULL;
 
 	if (strstr(contents, "rauc.external") != NULL)

--- a/src/context.c
+++ b/src/context.c
@@ -28,10 +28,7 @@ static const gchar* get_cmdline_bootname(void)
 {
 	g_autofree gchar *contents = NULL;
 	g_autofree gchar *realdev = NULL;
-	static const char *bootname = NULL;
-
-	if (bootname != NULL)
-		return bootname;
+	const char *bootname = NULL;
 
 	if (!g_file_get_contents("/proc/cmdline", &contents, NULL, NULL))
 		return NULL;

--- a/src/install.c
+++ b/src/install.c
@@ -181,6 +181,12 @@ gboolean determine_slot_states(GError **error)
 			goto out;
 		}
 
+		if (g_strcmp0(r_context()->bootslot, "_external_") == 0) {
+			g_message("Detected explicit external boot, ignoring missing active slot");
+			res = TRUE;
+			goto out;
+		}
+
 		g_set_error_literal(
 				error,
 				R_SLOT_ERROR,

--- a/test/context.c
+++ b/test/context.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <locale.h>
+#include <glib.h>
+
+#include <context.h>
+
+#include "common.h"
+
+static void external_boot(void)
+{
+	r_context_conf()->mock.proc_cmdline = "quiet root=/dev/dummy rauc.external rootwait";
+	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+
+	g_assert_cmpstr(r_context()->bootslot, ==, "_external_");
+
+	r_context_conf()->mock.proc_cmdline = NULL;
+	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+}
+
+static void nfs_boot(void)
+{
+	r_context_conf()->mock.proc_cmdline = "quiet root=/dev/nfs";
+	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+
+	g_assert_cmpstr(r_context()->bootslot, ==, "/dev/nfs");
+
+	r_context_conf()->mock.proc_cmdline = NULL;
+	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+}
+
+int main(int argc, char *argv[])
+{
+	setlocale(LC_ALL, "C");
+
+	g_test_init(&argc, &argv, NULL);
+
+	g_test_add_func("/context/external_boot", external_boot);
+
+	g_test_add_func("/context/nfs_boot", nfs_boot);
+
+	return g_test_run();
+}


### PR DESCRIPTION
This adds the support to use external devices. By external I mean
devices not known by RAUC (listed within the system.conf). So we are
able to use RAUC to initialise the system from a 'special' medium e.g. a
usb-stick which isn't part of the 'normal' update system. To signal it
to RAUC I introduced a cmdline flag called 'rauc.slot.external'. If the
flag is present RAUC won't try to find an active 'normal' slot.

Signed-off-by: Marco Felsch <m.felsch@pengutronix.de>