### PR TITLE
src/context: fix leaking string returned by realpath()

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -28,7 +28,7 @@ static const gchar* get_cmdline_bootname(void)
 	g_autofree gchar *contents = NULL;
 	static const char *bootname = NULL;
 	gchar buf[PATH_MAX + 1];
-	gchar *realdev = NULL;
+	g_autofree gchar *realdev = NULL;
 
 	if (bootname != NULL)
 		return bootname;


### PR DESCRIPTION
We did not free the string returned by realpath(). This we fix by using
g_autofree now.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>