### PR TITLE
remove misleading reference to ext2 / ext3 support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Features
   * `EFI <https://de.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface>`_
 * Storage support:
 
-  * ext2/3/4 filesystem
+  * ext4 filesystem
   * eMMC boot partitions (atomic update)
   * vfat filesystem
   * UBI volumes

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -22,3 +22,21 @@ will be able to compile RAUC without service mode and without D-Bus support::
 
 Then every call of the command line tool will be executed directly rather than
 being forwarded to the RAUC service process running on your machine.
+
+Why does RAUC not have an ext2 / ext3 file type?
+------------------------------------------------
+
+ext4 is the successor of ext3. There is no advantage in using ext3 over ext4.
+
+Some people still tend to select ext2 when they want a file system without
+journaling. This is not necessary, as one can turn off journaling in ext4,
+either during creation::
+
+  mkfs.ext4 -O ^has_journal
+
+or later with::
+
+  tune2fs -O ^has_journal
+
+Note that even if there is only an ext4 slot type available, potentially each
+file system mountable as ext4 should work (with the filename suffix adapted).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -141,7 +141,7 @@ Key Features of RAUC
 
 * Storage support:
 
-  * ext2/3/4 filesystem
+  * ext4 filesystem
   * vfat filesystem
   * UBI volumes
   * UBIFS

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -228,7 +228,7 @@ cannot fully know how you intend to use your system.
     * ``CONFIG_FEATURE_SEAMLESS_XZ=y``
     * ``CONFIG_FEATURE_TAR_LONG_OPTIONS=y``
 
-:ext2/ext3/ext4: mkfs.ext2/mkfs.ext3/mkfs.ext4 (from `e2fsprogs
+:ext4: mkfs.ext4 (from `e2fsprogs
   <git://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git>`_)
 :vfat: mkfs.vfat (from `dosfstools
                   <https://github.com/dosfstools/dosfstools>`_)


### PR DESCRIPTION
Various places of the RAUC documentation noted ext2 and ext3 file system
support. This was quite misleading as RAUC has an ext4 file type, but
not an ext2 / ext3 type.

This removes the notions of ext2 and ext3 and adds a section in the FAQ
why they are intentionally not supported.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>