### PR TITLE
Skip using the active slot as a seed when installing bundles

### DIFF
--- a/contrib/cgi/src/cgi.c
+++ b/contrib/cgi/src/cgi.c
@@ -681,7 +681,7 @@ static gint cgi_handler(int argc, char **argv)
 			goto remove_bundle_on_error;
 
 		/* start rauc install */
-		if (!r_installer_call_install_sync(installer, BUNDLE_TARGET_LOCATION, NULL, &error))
+		if (!r_installer_call_install_sync(installer, BUNDLE_TARGET_LOCATION, FALSE, NULL, &error))
 			goto remove_bundle_on_error;
 
 		print_headers("200 OK", "text/plain");

--- a/include/context.h
+++ b/include/context.h
@@ -15,7 +15,7 @@ typedef struct {
 	/* The bundle currently mounted by RAUC */
 	RaucBundle *mounted_bundle;
 	/* Whether to skip the active slot as a seed */
-        gboolean ignore_slot_as_seed;
+	gboolean ignore_slot_as_seed;
 } RContextInstallationInfo;
 
 typedef struct {

--- a/include/context.h
+++ b/include/context.h
@@ -14,6 +14,8 @@ typedef void (*progress_callback) (gint percentage, const gchar *message,
 typedef struct {
 	/* The bundle currently mounted by RAUC */
 	RaucBundle *mounted_bundle;
+	/* Whether to skip the active slot as a seed */
+        gboolean ignore_slot_as_seed;
 } RContextInstallationInfo;
 
 typedef struct {
@@ -45,8 +47,6 @@ typedef struct {
 	gchar *handlerextra;
 	/* ignore compatible check */
 	gboolean ignore_compatible;
-	/* ignore using slot as seed */
-	gboolean ignore_slot_as_seed;
 
 	/* for storing installation runtime informations */
 	RContextInstallationInfo *install_info;

--- a/include/context.h
+++ b/include/context.h
@@ -45,6 +45,8 @@ typedef struct {
 	gchar *handlerextra;
 	/* ignore compatible check */
 	gboolean ignore_compatible;
+	/* ignore using slot as seed */
+	gboolean ignore_slot_as_seed;
 
 	/* for storing installation runtime informations */
 	RContextInstallationInfo *install_info;

--- a/include/install.h
+++ b/include/install.h
@@ -24,6 +24,7 @@ typedef enum {
 
 typedef struct {
 	gchar *name;
+	gboolean ignore_slot_as_seed;
 	GSourceFunc notify;
 	GSourceFunc cleanup;
 	GMutex status_mutex;

--- a/src/install.c
+++ b/src/install.c
@@ -1014,6 +1014,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	}
 
 	r_context()->install_info->mounted_bundle = bundle;
+	r_context()->install_info->ignore_slot_as_seed = args->ignore_slot_as_seed;
 
 	manifestpath = g_build_filename(bundle->mount_point, "manifest.raucm", NULL);
 	res = load_manifest_file(manifestpath, &manifest, &ierror);
@@ -1041,6 +1042,8 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 		}
 	}
 
+	if(args->ignore_slot_as_seed)
+	        g_message("Not using slot as a seed for the installation");
 
 	if (manifest->handler_name) {
 		g_message("Using custom handler: %s", manifest->handler_name);

--- a/src/install.c
+++ b/src/install.c
@@ -1042,8 +1042,8 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 		}
 	}
 
-	if(args->ignore_slot_as_seed)
-	        g_message("Not using slot as a seed for the installation");
+	if (args->ignore_slot_as_seed)
+		g_message("Not using slot as a seed for the installation");
 
 	if (manifest->handler_name) {
 		g_message("Using custom handler: %s", manifest->handler_name);

--- a/src/main.c
+++ b/src/main.c
@@ -25,7 +25,7 @@
 GMainLoop *r_loop = NULL;
 int r_exit_status = 0;
 
-gboolean install_ignore_compatible, install_progressbar = FALSE;
+gboolean install_ignore_compatible, install_progressbar, install_ignore_slot_as_seed = FALSE;
 gboolean info_noverify, info_dumpcert = FALSE;
 gboolean status_detailed = FALSE;
 gchar *output_format = NULL;
@@ -220,6 +220,7 @@ static gboolean install_start(int argc, char **argv)
 	args->status_result = 2;
 
 	r_context_conf()->ignore_compatible = install_ignore_compatible;
+	r_context_conf()->ignore_slot_as_seed = install_ignore_slot_as_seed;
 
 	r_loop = g_main_loop_new(NULL, FALSE);
 	if (ENABLE_SERVICE) {
@@ -1703,6 +1704,7 @@ typedef struct {
 
 GOptionEntry entries_install[] = {
 	{"ignore-compatible", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_compatible, "disable compatible check", NULL},
+	{"ignore-seed", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_slot_as_seed, "disable using slot as seed", NULL},
 	{"progress", '\0', 0, G_OPTION_ARG_NONE, &install_progressbar, "show progress bar", NULL},
 	{0}
 };

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include <json-glib/json-gobject.h>
 #endif
 #include <stdio.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
@@ -41,7 +42,7 @@ static gchar* make_progress_line(gint percentage)
 
 	/* obtain terminal window parameters */
 	if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == -1) {
-		g_warning("Unable to obtain window parameters: %s", strerror(errno));
+		g_warning("Unable to obtain window parameters: %s", g_strerror(errno));
 		/* default to 80 */
 		w.ws_col = 80;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -216,12 +216,12 @@ static gboolean install_start(int argc, char **argv)
 
 	args = install_args_new();
 	args->name = g_steal_pointer(&bundlelocation);
+	args->ignore_slot_as_seed = install_ignore_slot_as_seed;
 	args->notify = install_notify;
 	args->cleanup = install_cleanup;
 	args->status_result = 2;
 
 	r_context_conf()->ignore_compatible = install_ignore_compatible;
-	r_context_conf()->ignore_slot_as_seed = install_ignore_slot_as_seed;
 
 	r_loop = g_main_loop_new(NULL, FALSE);
 	if (ENABLE_SERVICE) {
@@ -244,7 +244,7 @@ static gboolean install_start(int argc, char **argv)
 			goto out_loop;
 		}
 		g_debug("Trying to contact rauc service");
-		if (!r_installer_call_install_sync(installer, args->name, NULL,
+		if (!r_installer_call_install_sync(installer, args->name, args->ignore_slot_as_seed, NULL,
 				&error)) {
 			g_printerr("Failed %s\n", error->message);
 			g_error_free(error);
@@ -1705,7 +1705,7 @@ typedef struct {
 
 GOptionEntry entries_install[] = {
 	{"ignore-compatible", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_compatible, "disable compatible check", NULL},
-	{"ignore-seed", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_slot_as_seed, "disable using slot as seed", NULL},
+	{"ignore-slot-seed", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_slot_as_seed, "disable using slot as seed", NULL},
 	{"progress", '\0', 0, G_OPTION_ARG_NONE, &install_progressbar, "show progress bar", NULL},
 	{0}
 };

--- a/src/rauc-installer.xml
+++ b/src/rauc-installer.xml
@@ -8,6 +8,7 @@
     -->
     <method name="Install">
       <arg name="source" type="s"/>
+      <arg name="ignore_slot_as_seed" type="b" direction="in"/>
     </method>
 
    <!--

--- a/src/service.c
+++ b/src/service.c
@@ -53,7 +53,7 @@ static gboolean service_install_cleanup(gpointer data)
 
 static gboolean r_on_handle_install(RInstaller *interface,
 		GDBusMethodInvocation  *invocation,
-		const gchar *source)
+		const gchar *source, const gboolean arg_ignore_slot_as_seed)
 {
 	RaucInstallArgs *args = install_args_new();
 	gboolean res;
@@ -65,8 +65,10 @@ static gboolean r_on_handle_install(RInstaller *interface,
 		goto out;
 
 	args->name = g_strdup(source);
+	args->ignore_slot_as_seed = arg_ignore_slot_as_seed;
 	args->notify = service_install_notify;
 	args->cleanup = service_install_cleanup;
+	g_message("r_on_handle_install: ignore_slot_as_seed = %s", arg_ignore_slot_as_seed ? "true" : "false");
 
 	r_installer_set_operation(r_installer, "installing");
 	g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_installer));

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -261,7 +261,7 @@ static gboolean casync_extract_image(RaucImage *image, gchar *dest, GError **err
 			}
 			seed_mounted = TRUE;
 		}
-		if (!r_context()->ignore_compatible) {
+		if (!r_context()->install_info->ignore_slot_as_seed) {
 			g_debug("Adding as casync directory tree seed: %s", seedslot->mount_point);
 			seed = g_strdup(seedslot->mount_point);
 		}else {

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -261,9 +261,12 @@ static gboolean casync_extract_image(RaucImage *image, gchar *dest, GError **err
 			}
 			seed_mounted = TRUE;
 		}
-
-		g_debug("Adding as casync directory tree seed: %s", seedslot->mount_point);
-		seed = g_strdup(seedslot->mount_point);
+		if (!r_context()->ignore_compatible) {
+			g_debug("Adding as casync directory tree seed: %s", seedslot->mount_point);
+			seed = g_strdup(seedslot->mount_point);
+		}else {
+			g_debug("Skipping to use tree seed: %s", seedslot->mount_point);
+		}
 	} else {
 		g_debug("Adding as casync blob seed: %s", seedslot->device);
 		seed = g_strdup(seedslot->device);

--- a/test/service.c
+++ b/test/service.c
@@ -203,7 +203,7 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 	g_assert_nonnull(bundlepath);
 
 	/* Actually install bundle */
-	ret = r_installer_call_install_sync(installer, bundlepath, NULL,
+	ret = r_installer_call_install_sync(installer, bundlepath, FALSE, NULL,
 			&error);
 	g_assert_no_error(error);
 	g_assert_true(ret);


### PR DESCRIPTION
As a workaround for resource intensive and slow install procedures when using casync and tar images (see https://github.com/rauc/rauc/issues/511) I created an option for the install command, which skips using the active slot as a seed when running casync.

This enables the following use case:
- Remote repository chunk store contains only chunks for most recent update
- Images have a .caexclude file included, which prevents /var/tmp/update.casync.castr from being chunked
- Device does the bind-mount & `casync make --store  /var/tmp/update.casync.castr /var/tmp/update.casync.caidx /mnt/rauc/` step in the background once.
- Device does an rsync with --delete on remote chunks store / index file / raucb
- Device installs without using slot as seed `rauc install --ignore-seed bundle.raucb`

The workaround decribed splits the long running operations into separate units, which can be run independently and frees the device to do a full `casync make` on every update. Downside is that additional storage is used permanently. But that's probably good, as it makes it clear how much space is actually left, if updates should still work.
