### PR TITLE
Various Fixes (including double-free) for slot status D-Bus error handling

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1505,7 +1505,7 @@ static gboolean retrieve_status_via_dbus(RaucStatusPrint **status_print, GError 
 
 	/* Obtain configured slots and their state */
 	if (!retrieve_slot_states_via_dbus(&istatus->slots, &ierror)) {
-		g_propagate_prefixed_error(error, ierror, "rauc status: error retrieving slot status via D-Bus: ");
+		g_propagate_error(error, ierror);
 		return FALSE;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -1502,7 +1502,6 @@ static gboolean retrieve_status_via_dbus(RaucStatusPrint **status_print, GError 
 	/* Obtain configured slots and their state */
 	if (!retrieve_slot_states_via_dbus(&istatus->slots, &ierror)) {
 		g_propagate_prefixed_error(error, ierror, "rauc status: error retrieving slot status via D-Bus: ");
-		g_error_free(ierror);
 		return FALSE;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -1366,6 +1366,8 @@ static gboolean retrieve_slot_states_via_dbus(GHashTable **slots, GError **error
 			G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
 			"de.pengutronix.rauc", "/", NULL, &ierror);
 	if (proxy == NULL) {
+		if (g_dbus_error_is_remote_error(ierror))
+			g_dbus_error_strip_remote_error(ierror);
 		g_set_error(error,
 				G_IO_ERROR,
 				G_IO_ERROR_FAILED,
@@ -1376,6 +1378,8 @@ static gboolean retrieve_slot_states_via_dbus(GHashTable **slots, GError **error
 
 	g_debug("Trying to contact rauc service");
 	if (!r_installer_call_get_slot_status_sync(proxy, &slot_status_array, NULL, &ierror)) {
+		if (g_dbus_error_is_remote_error(ierror))
+			g_dbus_error_strip_remote_error(ierror);
 		g_set_error(error,
 				G_IO_ERROR,
 				G_IO_ERROR_FAILED,

--- a/src/main.c
+++ b/src/main.c
@@ -1596,7 +1596,7 @@ static gboolean status_start(int argc, char **argv)
 	} else {
 		if (!retrieve_status_via_dbus(&status_print, &ierror)) {
 			message = g_strdup_printf(
-					"rauc status: error retrieving slot status via D-Bus: %s",
+					"error retrieving slot status via D-Bus: %s",
 					ierror->message);
 			g_error_free(ierror);
 			r_exit_status = 1;
@@ -1656,7 +1656,7 @@ static gboolean status_start(int argc, char **argv)
 
 out:
 	if (message)
-		g_message("rauc mark: %s", message);
+		g_message("rauc status: %s", message);
 	g_clear_pointer(&proxy, g_object_unref);
 
 	return TRUE;


### PR DESCRIPTION
This fixes double-free in case of concurrent accesses to the service via D-Bus.

It also shortens the resulting error message from 

> rauc-Message: 11:40:37.649: rauc mark: rauc status: error retrieving slot status via D-Bus: rauc status: error retrieving slot status via D-Bus: error calling D-Bus method "GetSlotStatus": GDBus.Error:org.gtk.GDBus.UnmappedGError.Quark._g_2dio_2derror_2dquark.Code30: already processing a different method

to

>  rauc-Message: 12:24:30.734: rauc status: error retrieving slot status via D-Bus: error calling D-Bus method "GetSlotStatus": already processing a different method
 

