### PR TITLE
curl: Enable decoding from server's Content-Encoding

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ AC_ARG_ENABLE([network],
 AM_CONDITIONAL([WANT_NETWORK], [test x$enable_network != xno])
 AS_IF([test "x$enable_network" != "xno"], [
        AC_DEFINE([ENABLE_NETWORK], [1], [Define to 1 to enable building with network update support])
-       PKG_CHECK_MODULES([CURL], [libcurl])
+       PKG_CHECK_MODULES([CURL], [libcurl >= 7.21.6])
 ], [
        AC_DEFINE([ENABLE_NETWORK], [0])
 ])

--- a/src/network.c
+++ b/src/network.c
@@ -93,6 +93,8 @@ static gboolean transfer(RaucTransfer *xfer, GError **error)
 	curl_easy_setopt(curl, CURLOPT_XFERINFODATA, xfer);
 	curl_easy_setopt(curl, CURLOPT_FAILONERROR, xfer);
 	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
+	/* decode all supported Accept-Encoding headers */
+	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
 
 	/* set error buffer empty before perorming a request */
 	errbuf[0] = 0;


### PR DESCRIPTION
I would like to consume RAUC bundles straight from our CI environment which uses OpenStack Swift as a backend for artifact storage, and OpenDev's Zuul as the CI runner. As it happens, our CI jobs [sends file content to Swift with a `Content-Encoding: gzip`](https://review.opendev.org/688154), and Swift appears to always send the file with that `Content-Encoding` no matter what `Accept-Encoding` the HTTP client sends in their request.

This patch simply uses curl's list of default supported `Content-Encoding` decoders (that's the special magic `""` value of this header). The end result is that our boxes can now fetch stuff from our CI environment without any problems.

TL;DR: this should save some bandwidth at essentially a zero cost, and it unbreaks updates from network under at least one scenario.