### PR TITLE
bundle: fix result values for error paths

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -800,6 +800,7 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, gboolean ver
 					R_SIGNATURE_ERROR,
 					R_SIGNATURE_ERROR_X509_NEW,
 					"failed to allocate new X509 store");
+			res = FALSE;
 			goto out;
 		}
 		if (!X509_STORE_load_locations(store, load_capath, load_cadir)) {
@@ -808,7 +809,7 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, gboolean ver
 					R_SIGNATURE_ERROR,
 					R_SIGNATURE_ERROR_CA_LOAD,
 					"failed to load CA file '%s' and/or directory '%s'", load_capath, load_cadir);
-
+			res = FALSE;
 			goto out;
 		}
 

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -222,6 +222,18 @@ static void bundle_test_resign(BundleFixture *fixture,
 	g_clear_pointer(&bundle, free_bundle);
 }
 
+static void bundle_test_wrong_capath(BundleFixture *fixture,
+		gconstpointer user_data)
+{
+	RaucBundle *bundle = NULL;
+	GError *ierror = NULL;
+	r_context()->config->keyring_path = g_strdup("does/not/exist.pem");
+
+	g_assert_false(check_bundle(fixture->bundlename, &bundle, TRUE, &ierror));
+	g_assert_null(bundle);
+	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_CA_LOAD);
+}
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -255,6 +267,10 @@ int main(int argc, char *argv[])
 
 	g_test_add("/bundle/resign", BundleFixture, NULL,
 			bundle_fixture_set_up_bundle, bundle_test_resign,
+			bundle_fixture_tear_down);
+
+	g_test_add("/bundle/wrong_capath", BundleFixture, NULL,
+			bundle_fixture_set_up_bundle, bundle_test_wrong_capath,
 			bundle_fixture_tear_down);
 
 	return g_test_run();


### PR DESCRIPTION
The res variable can be set to TRUE by one of the preceding function
calls. Explicitly set the variable to FALSE for error paths.

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>