### PR TITLE
docs/using.rst: remove note on mandatory .raucb suffix

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -39,9 +39,7 @@ describes the content of the bundle for the RAUC updater on the target:
 which image to install to which slot, which scripts to execute etc.
 Note that all files in ``<input-dir>`` will be included in the bundle,
 not just those specified in the manifest.
-``<output-file>`` must be the path of the bundle file to create. Note that RAUC
-bundles must always have a ``.raucb`` file name suffix in order to ensure that
-RAUC treats them as bundles.
+``<output-file>`` must be the path of the bundle file to create.
 
 Instead of the ``certfile`` and ``keyfile`` arguments, PKCS#11 URLs such as
 ``'pkcs11:token=rauc;object=autobuilder-1'`` can be used to avoid storing


### PR DESCRIPTION
This is no longer valid since commit 9660b57c1959f62b1c584e483e29d94fe2486b47
('src/main: do not reject local bundles that do not have a .raucb extension')

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>