### PR TITLE
use glib's mount monitoring to update mount info on changes

### DIFF
--- a/include/install.h
+++ b/include/install.h
@@ -123,3 +123,8 @@ gboolean install_run(RaucInstallArgs *args);
  *         or NULL if an error occurred
  */
 GList* get_install_images(const RaucManifest *manifest, GHashTable *target_group, GError **error);
+
+/**
+ * Iterates over slots and updates their mount information
+ */
+void update_mount_info(void);

--- a/src/install.c
+++ b/src/install.c
@@ -1007,15 +1007,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	g_assert_nonnull(bundlefile);
 	g_assert_null(r_context()->install_info->mounted_bundle);
 
-	r_context_begin_step("do_install_bundle", "Installing", 5);
-
-	r_context_begin_step("determine_slot_states", "Determining slot states", 0);
-	res = determine_slot_states(&ierror);
-	r_context_end_step("determine_slot_states", res);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
-	}
+	r_context_begin_step("do_install_bundle", "Installing", 4);
 
 	// TODO: mount info in context ?
 	install_args_update(args, "Checking and mounting bundle...");

--- a/src/install.c
+++ b/src/install.c
@@ -66,25 +66,13 @@ static gchar *resolve_loop_device(const gchar *devicepath)
 	return g_strchomp(content);
 }
 
-gboolean determine_slot_states(GError **error)
+void update_mount_info(void)
 {
-	GList *slotlist = NULL;
-	GList *mountlist = NULL;
-	RaucSlot *booted = NULL;
 	GHashTableIter iter;
 	RaucSlot *slot;
-	gboolean res = FALSE;
+	GList *mountlist = NULL;
 
 	g_assert_nonnull(r_context()->config);
-
-	if (r_context()->config->slots == NULL) {
-		g_set_error_literal(
-				error,
-				R_SLOT_ERROR,
-				R_SLOT_ERROR_NO_CONFIG,
-				"No slot configuration found");
-		goto out;
-	}
 	g_assert_nonnull(r_context()->config->slots);
 
 	/* Clear all previously detected external mount points as we will
@@ -123,6 +111,28 @@ gboolean determine_slot_states(GError **error)
 		}
 	}
 	g_list_free_full(mountlist, (GDestroyNotify)g_unix_mount_free);
+
+}
+
+gboolean determine_slot_states(GError **error)
+{
+	GList *slotlist = NULL;
+	RaucSlot *booted = NULL;
+	gboolean res = FALSE;
+
+	g_assert_nonnull(r_context()->config);
+
+	if (r_context()->config->slots == NULL) {
+		g_set_error_literal(
+				error,
+				R_SLOT_ERROR,
+				R_SLOT_ERROR_NO_CONFIG,
+				"No slot configuration found");
+		goto out;
+	}
+	g_assert_nonnull(r_context()->config->slots);
+
+	update_mount_info();
 
 	if (r_context()->bootslot == NULL) {
 		g_set_error_literal(

--- a/src/main.c
+++ b/src/main.c
@@ -249,6 +249,13 @@ static gboolean install_start(int argc, char **argv)
 			goto out_loop;
 		}
 	} else {
+		if (!determine_slot_states(&error)) {
+			g_printerr("Failed to determine slot states: %s\n", error->message);
+			g_clear_error(&error);
+			r_exit_status = 1;
+			goto out_loop;
+		}
+
 		install_run(args);
 	}
 


### PR DESCRIPTION
This allows us to move from a pull mechanism that requires re-reading all mounts when we need recent information to a push mechanism allowing us to read information once and only update them in case of being notified about changes.