### PR TITLE
reduce rauc binary size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /build-aux/*
 !/build-aux/git-version-gen
 /test/*.test
+/test/*.map
 /test/services/de.pengutronix.rauc.service
 /*-generated.[ch]
 Makefile
@@ -14,6 +15,7 @@ config.status
 configure
 libtool
 rauc
+rauc.map
 stamp-h1
 .deps
 .dirstamp

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,8 +13,10 @@ CODE_COVERAGE_IGNORE_PATTERN = "*-generated.c"
 @CODE_COVERAGE_RULES@
 @VALGRIND_CHECK_RULES@
 
-AM_CFLAGS = -DG_LOG_DOMAIN=\"rauc\" $(WARN_CFLAGS) $(GLIB_CFLAGS) $(CURL_CFLAGS)
-AM_LDFLAGS = $(WARN_LDFLAGS) $(GLIB_LDFLAGS) $(CURL_LDFLAGS) $(OPENSSL_LDFLAGS)
+GC_CFLAGS = -fdata-sections -ffunction-sections
+GC_LDFLAGS = -Wl,--gc-sections -Wl,-Map,$@.map
+AM_CFLAGS = -DG_LOG_DOMAIN=\"rauc\" $(GC_CFLAGS) $(WARN_CFLAGS) $(GLIB_CFLAGS) $(CURL_CFLAGS)
+AM_LDFLAGS = $(GC_LDFLAGS) $(WARN_LDFLAGS) $(GLIB_LDFLAGS) $(CURL_LDFLAGS) $(OPENSSL_LDFLAGS)
 AM_CPPFLAGS = -I${top_srcdir}/include -include ${top_builddir}/config.h $(OPENSSL_INCLUDES)
 
 gdbus_installer_generated = \
@@ -254,8 +256,10 @@ CLEANFILES = $(gdbus_installer_generated) \
 	     $(nodist_systemdunit_DATA) \
 	     $(nodist_dbussystemservice_DATA) \
 	     $(nodist_dbuswrapper_SCRIPTS) \
+	     rauc.map \
 	     data/rauc.service \
 	     test/empty.dat \
+	     test/*.map \
 	     test/test-results/rauc.*.counts \
 	     test/savedmanifest.raucm \
 	     test/savedslot.raucs \

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,15 @@ AS_IF([test "x$enable_service" != "xno"], [
 	AC_DEFINE([ENABLE_SERVICE], [0])
 ])
 
+AC_ARG_ENABLE([create],
+	AS_HELP_STRING([--disable-create], [Disable bundle creation and modification commands])
+)
+AS_IF([test "x$enable_create" != "xno"], [
+	AC_DEFINE([ENABLE_CREATE], [1], [Define to 1 to enable bundle, resign and convert commands])
+], [
+	AC_DEFINE([ENABLE_CREATE], [0])
+])
+
 # Checks for libraries.
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.45.8 gio-2.0 gio-unix-2.0])
 

--- a/src/main.c
+++ b/src/main.c
@@ -282,6 +282,7 @@ out:
 	return TRUE;
 }
 
+G_GNUC_UNUSED
 static gboolean bundle_start(int argc, char **argv)
 {
 	GError *ierror = NULL;
@@ -445,6 +446,7 @@ out:
 	return TRUE;
 }
 
+G_GNUC_UNUSED
 static gboolean resign_start(int argc, char **argv)
 {
 	g_autoptr(RaucBundle) bundle = NULL;
@@ -540,6 +542,7 @@ out:
 	return TRUE;
 }
 
+G_GNUC_UNUSED
 static gboolean convert_start(int argc, char **argv)
 {
 	RaucBundle *bundle = NULL;
@@ -1707,14 +1710,16 @@ static void create_option_groups(void)
 	install_group = g_option_group_new("install", "Install options:", "help dummy", NULL, NULL);
 	g_option_group_add_entries(install_group, entries_install);
 
-	bundle_group  = g_option_group_new("bundle", "Bundle options:", "help dummy", NULL, NULL);
-	g_option_group_add_entries(bundle_group, entries_bundle);
+	if (ENABLE_CREATE) {
+		bundle_group  = g_option_group_new("bundle", "Bundle options:", "help dummy", NULL, NULL);
+		g_option_group_add_entries(bundle_group, entries_bundle);
 
-	resign_group  = g_option_group_new("resign", "Resign options:", "help dummy", NULL, NULL);
-	g_option_group_add_entries(resign_group, entries_resign);
+		resign_group  = g_option_group_new("resign", "Resign options:", "help dummy", NULL, NULL);
+		g_option_group_add_entries(resign_group, entries_resign);
 
-	convert_group = g_option_group_new("convert", "Convert options:", "help dummy", NULL, NULL);
-	g_option_group_add_entries(convert_group, entries_convert);
+		convert_group = g_option_group_new("convert", "Convert options:", "help dummy", NULL, NULL);
+		g_option_group_add_entries(convert_group, entries_convert);
+	}
 
 	info_group    = g_option_group_new("info", "Info options:", "help dummy", NULL, NULL);
 	g_option_group_add_entries(info_group, entries_info);
@@ -1751,10 +1756,12 @@ static void cmdline_handler(int argc, char **argv)
 	RaucCommand rcommands[] = {
 		{UNKNOWN, "help", "<COMMAND>", "Print help", unknown_start, NULL, TRUE},
 		{INSTALL, "install", "install <BUNDLE>", "Install a bundle", install_start, install_group, FALSE},
+#if ENABLE_CREATE == 1
 		{BUNDLE, "bundle", "bundle <INPUTDIR> <BUNDLENAME>", "Create a bundle from a content directory", bundle_start, bundle_group, FALSE},
 		{RESIGN, "resign", "resign <BUNDLENAME>", "Resign an already signed bundle", resign_start, resign_group, FALSE},
-		{EXTRACT, "extract", "extract <BUNDLENAME> <OUTPUTDIR>", "Extract the bundle content", extract_start, NULL, FALSE},
 		{CONVERT, "convert", "convert <INBUNDLE> <OUTBUNDLE>", "Convert to casync index bundle and store", convert_start, convert_group, FALSE},
+#endif
+		{EXTRACT, "extract", "extract <BUNDLENAME> <OUTPUTDIR>", "Extract the bundle content", extract_start, NULL, FALSE},
 		{INFO, "info", "info <FILE>", "Print bundle info", info_start, info_group, FALSE},
 		{STATUS, "status", "status", "Show system status", status_start, status_group, TRUE},
 		{WRITE_SLOT, "write-slot", "write-slot <SLOTNAME> <IMAGE>", "Write image to slot and bypass all update logic", write_slot_start, NULL, FALSE},
@@ -1772,10 +1779,12 @@ static void cmdline_handler(int argc, char **argv)
 	g_option_context_add_main_entries(context, entries, NULL);
 	g_option_context_set_description(context,
 			"List of rauc commands:\n"
+#if ENABLE_CREATE == 1
 			"  bundle\tCreate a bundle\n"
 			"  resign\tResign an already signed bundle\n"
-			"  extract\tExtract the bundle content\n"
 			"  convert\tConvert classic to casync bundle\n"
+#endif
+			"  extract\tExtract the bundle content\n"
 			"  install\tInstall a bundle\n"
 			"  info\t\tShow file information\n"
 #if ENABLE_SERVICE == 1

--- a/src/main.c
+++ b/src/main.c
@@ -1695,6 +1695,34 @@ GOptionEntry entries_status[] = {
 	{0}
 };
 
+static GOptionGroup *install_group;
+static GOptionGroup *bundle_group;
+static GOptionGroup *resign_group;
+static GOptionGroup *convert_group;
+static GOptionGroup *info_group;
+static GOptionGroup *status_group;
+
+static void create_option_groups(void)
+{
+	install_group = g_option_group_new("install", "Install options:", "help dummy", NULL, NULL);
+	g_option_group_add_entries(install_group, entries_install);
+
+	bundle_group  = g_option_group_new("bundle", "Bundle options:", "help dummy", NULL, NULL);
+	g_option_group_add_entries(bundle_group, entries_bundle);
+
+	resign_group  = g_option_group_new("resign", "Resign options:", "help dummy", NULL, NULL);
+	g_option_group_add_entries(resign_group, entries_resign);
+
+	convert_group = g_option_group_new("convert", "Convert options:", "help dummy", NULL, NULL);
+	g_option_group_add_entries(convert_group, entries_convert);
+
+	info_group    = g_option_group_new("info", "Info options:", "help dummy", NULL, NULL);
+	g_option_group_add_entries(info_group, entries_info);
+
+	status_group  = g_option_group_new("status", "Status options:", "help dummy", NULL, NULL);
+	g_option_group_add_entries(status_group, entries_status);
+}
+
 static void cmdline_handler(int argc, char **argv)
 {
 	gboolean help = FALSE, debug = FALSE, version = FALSE;
@@ -1716,12 +1744,6 @@ static void cmdline_handler(int argc, char **argv)
 		{"help", 'h', 0, G_OPTION_ARG_NONE, &help, NULL, NULL},
 		{0}
 	};
-	GOptionGroup *install_group = g_option_group_new("install", "Install options:", "help dummy", NULL, NULL);
-	GOptionGroup *bundle_group = g_option_group_new("bundle", "Bundle options:", "help dummy", NULL, NULL);
-	GOptionGroup *resign_group = g_option_group_new("resign", "Resign options:", "help dummy", NULL, NULL);
-	GOptionGroup *convert_group = g_option_group_new("convert", "Convert options:", "help dummy", NULL, NULL);
-	GOptionGroup *info_group = g_option_group_new("info", "Info options:", "help dummy", NULL, NULL);
-	GOptionGroup *status_group = g_option_group_new("status", "Status options:", "help dummy", NULL, NULL);
 
 	GError *error = NULL;
 	g_autofree gchar *text = NULL;
@@ -1743,13 +1765,6 @@ static void cmdline_handler(int argc, char **argv)
 	};
 	RaucCommand *rc;
 	RaucCommand *rcommand = NULL;
-
-	g_option_group_add_entries(install_group, entries_install);
-	g_option_group_add_entries(bundle_group, entries_bundle);
-	g_option_group_add_entries(resign_group, entries_resign);
-	g_option_group_add_entries(convert_group, entries_convert);
-	g_option_group_add_entries(info_group, entries_info);
-	g_option_group_add_entries(status_group, entries_status);
 
 	context = g_option_context_new("<COMMAND>");
 	g_option_context_set_help_enabled(context, FALSE);
@@ -1909,6 +1924,7 @@ int main(int argc, char **argv)
 	/* disable remote VFS */
 	g_assert(g_setenv("GIO_USE_VFS", "local", TRUE));
 
+	create_option_groups();
 	cmdline_handler(argc, argv);
 
 	return r_exit_status;

--- a/src/main.c
+++ b/src/main.c
@@ -1621,7 +1621,7 @@ out:
 	return TRUE;
 }
 
-#if ENABLE_SERVICE == 1
+G_GNUC_UNUSED
 static gboolean service_start(int argc, char **argv)
 {
 	g_debug("service start");
@@ -1630,7 +1630,6 @@ static gboolean service_start(int argc, char **argv)
 
 	return TRUE;
 }
-#endif
 
 static gboolean unknown_start(int argc, char **argv)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -1664,35 +1664,35 @@ typedef struct {
 	gboolean while_busy;
 } RaucCommand;
 
-GOptionEntry entries_install[] = {
+static GOptionEntry entries_install[] = {
 	{"ignore-compatible", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_compatible, "disable compatible check", NULL},
 	{"progress", '\0', 0, G_OPTION_ARG_NONE, &install_progressbar, "show progress bar", NULL},
 	{0}
 };
 
-GOptionEntry entries_bundle[] = {
+static GOptionEntry entries_bundle[] = {
 	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
 	{0}
 };
 
-GOptionEntry entries_resign[] = {
+static GOptionEntry entries_resign[] = {
 	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
 	{0}
 };
 
-GOptionEntry entries_convert[] = {
+static GOptionEntry entries_convert[] = {
 	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
 	{0}
 };
 
-GOptionEntry entries_info[] = {
+static GOptionEntry entries_info[] = {
 	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &info_noverify, "disable bundle verification", NULL},
 	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format", "FORMAT"},
 	{"dump-cert", '\0', 0, G_OPTION_ARG_NONE, &info_dumpcert, "dump certificate", NULL},
 	{0}
 };
 
-GOptionEntry entries_status[] = {
+static GOptionEntry entries_status[] = {
 	{"detailed", '\0', 0, G_OPTION_ARG_NONE, &status_detailed, "show more status details", NULL},
 	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format", "FORMAT"},
 	{0}


### PR DESCRIPTION
This adds some configure knobs that allows one to disable parts of rauc that are not useful on the target device, such as bundle creation or resigning. To get the full benefit of that, add compiler and linker options to discard unused functions and data at link time. Just to get an idea of the effect, I've built each patch in turn with of `--disable-service --disable-create` (the latter of course only has an effect later in the series). That gives

```
$ size rauc.bin.*
   text    data     bss     dec     hex filename
 214582    8080    1736  224398   36c8e rauc.bin.0
 214582    8080    1736  224398   36c8e rauc.bin.1
 174336    5000    1672  181008   2c310 rauc.bin.2
 174368    5000    1736  181104   2c370 rauc.bin.3
 156204    4512    1704  162420   27a74 rauc.bin.4
 156172    4512    1704  162388   27a54 rauc.bin.5
```
so altogether this cuts a bit over a quarter of the binary's size - but of course the actual savings will vary with compiler and not least target architecture.

rauc pulls in quite a few shared library dependencies, so 62K may not seem that significant. However, 
I'm looking at a target with a rootfs budget of about 50M, so I need to cut where I can. Also, we can add more knobs in the future which would allow removing even more code.