### PR TITLE
remove surrounding whitespace from system variant

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -131,6 +131,7 @@ check_PROGRAMS = \
 	test/manifest.test \
 	test/signature.test \
 	test/update_handler.test \
+	test/utils.test \
 	test/install.test \
 	test/service.test \
 	test/bundle.test \
@@ -199,6 +200,9 @@ test_signature_test_LDADD = librauctest.la
 
 test_update_handler_test_SOURCES = test/update_handler.c
 test_update_handler_test_LDADD = librauc.la librauctest.la
+
+test_utils_test_SOURCES = test/utils.c
+test_utils_test_LDADD = librauctest.la
 
 test_install_test_SOURCES = test/install.c
 test_install_test_LDADD = librauctest.la

--- a/include/utils.h
+++ b/include/utils.h
@@ -136,3 +136,12 @@ guint64 key_file_consume_binary_suffixed_string(GKeyFile *key_file,
 		GError **error);
 
 gchar * r_realpath(const gchar *path);
+
+/**
+ * Remove surrounding whitespace and signal changes.
+ *
+ * @param str string to modify
+ *
+ * @return TRUE if whitespace was removed, FALSE otherwise
+ */
+gboolean r_whitespace_removed(gchar *str);

--- a/src/context.c
+++ b/src/context.c
@@ -249,11 +249,11 @@ static void r_context_configure(void)
 		g_hash_table_iter_init(&iter, vars);
 		while (g_hash_table_iter_next(&iter, (gpointer*) &key, (gpointer*) &value)) {
 			if (g_strcmp0(key, "RAUC_SYSTEM_SERIAL") == 0) {
-				r_context_conf()->system_serial = g_strdup(value);
+				context->system_serial = g_strdup(value);
 			} else if (g_strcmp0(key, "RAUC_SYSTEM_VARIANT") == 0) {
 				/* set variant (overrides possible previous value) */
-				g_free(r_context_conf()->config->system_variant);
-				r_context_conf()->config->system_variant = g_strdup(value);
+				g_free(context->config->system_variant);
+				context->config->system_variant = g_strdup(value);
 			} else {
 				g_message("Ignoring unknown variable %s", key);
 			}

--- a/src/context.c
+++ b/src/context.c
@@ -260,6 +260,9 @@ static void r_context_configure(void)
 		}
 	}
 
+	if (r_whitespace_removed(context->config->system_variant))
+		g_warning("Ignoring surrounding whitespace in system variant: %s", context->config->system_variant);
+
 	if (context->bootslot == NULL) {
 		context->bootslot = g_strdup(get_cmdline_bootname());
 	}

--- a/src/utils.c
+++ b/src/utils.c
@@ -263,3 +263,20 @@ gchar * r_realpath(const gchar *path)
 
 	return g_strdup(rpath);
 }
+
+gboolean r_whitespace_removed(gchar *str)
+{
+	gsize len;
+
+	if (str == NULL)
+		return FALSE;
+
+	len = strlen(str);
+
+	if (len == 0)
+		return FALSE;
+
+	g_strstrip(str);
+
+	return strlen(str) != len;
+}

--- a/test/utils.c
+++ b/test/utils.c
@@ -1,0 +1,45 @@
+#include <locale.h>
+#include <glib.h>
+
+#include "utils.h"
+
+static void whitespace_removed_test(void)
+{
+	gchar *str;
+
+	str = g_strdup("foo");
+	g_assert_false(r_whitespace_removed(str));
+	g_assert_cmpstr(str, ==, "foo");
+	g_free(str);
+
+	str = g_strdup(" foo");
+	g_assert_true(r_whitespace_removed(str));
+	g_assert_cmpstr(str, ==, "foo");
+	g_free(str);
+
+	str = g_strdup("foo ");
+	g_assert_true(r_whitespace_removed(str));
+	g_assert_cmpstr(str, ==, "foo");
+	g_free(str);
+
+	str = g_strdup(" foo ");
+	g_assert_true(r_whitespace_removed(str));
+	g_assert_cmpstr(str, ==, "foo");
+	g_free(str);
+
+	str = g_strdup("\r\n\t  foo  \t\r\n");
+	g_assert_true(r_whitespace_removed(str));
+	g_assert_cmpstr(str, ==, "foo");
+	g_free(str);
+}
+
+int main(int argc, char *argv[])
+{
+	setlocale(LC_ALL, "C");
+
+	g_test_init(&argc, &argv, NULL);
+
+	g_test_add_func("/utils/whitespace_removed", whitespace_removed_test);
+
+	return g_test_run();
+}


### PR DESCRIPTION
This was always intended to be a short string without whitespace. Remove the whitespace from when preparing the context. In the manifest, the variant is part of the image section name, so intentional surrounding whitespace would be very unusual.
