### PR TITLE
switch CI to use QEMU instead of UML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+dist: bionic
 sudo: required
 services:
   - docker
@@ -36,11 +37,14 @@ jobs:
 
         # Create container and export env variables for Coverity scan
         - env | grep -E "TRAVIS|COV|TOOL|URL" > .cov-env
+        - cat /proc/cpuinfo
+        - sudo chmod 666 /dev/kvm
+        - ls -l /dev
         - |
             docker run -dit --privileged \
             --env-file .cov-env \
             -v "$PWD":/home/travis -w /home/travis \
-            --tmpfs /tmp/uml:exec,mode=777 \
+            --tmpfs /tmp/qemu:exec,mode=777 \
             --tmpfs /tmp:exec \
             -v ${TOOL_BASE}:${TOOL_BASE} \
             -u travis $ci_env \
@@ -59,7 +63,7 @@ jobs:
         - docker exec -it rauc-ci make -j2
         - docker exec -it rauc-ci make doc SPHINXOPTS=-W
         - docker exec -it rauc-ci make check TESTS=
-        - docker exec -it rauc-ci /bin/sh -c 'export TMPDIR=/tmp/uml && ./uml-test'
+        - docker exec -it rauc-ci /bin/sh -c 'export TMPDIR=/tmp/qemu && ./qemu-test'
         - docker exec -it rauc-ci make distcheck
         - docker exec -it rauc-ci /bin/sh -c 'cd /home/travis/contrib/cgi && ./autogen.sh && ./configure && make clean && make -j2 && make distcheck'
         - ./uncrustify.sh && git diff --exit-code

--- a/README.rst
+++ b/README.rst
@@ -190,11 +190,11 @@ Running the Test Suite
 
 ::
 
-    sudo apt-get install user-mode-linux slirp squashfs-tools
+    sudo apt-get install qemu-system-x86 squashfs-tools
     # Optional to run all tests:
     # sudo apt-get install faketime casync grub-common softhsm2 opensc opensc-pkcs11 libengine-pkcs11-openssl
     make check
-    ./uml-test
+    ./qemu-test
 
 Creating a Bundle (Host)
 ------------------------

--- a/qemu-test
+++ b/qemu-test
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -e
+
+rm -f qemu-test-ok
+
+# TODO use virtfs with multidevs=remap on qemu 4.2
+# https://github.com/qemu/qemu/commit/1a6ed33cc56997479bbe5b48337ff8da44585bd4
+
+KERNEL_URL="https://github.com/jluebbe/linux/releases/download/rauc-test-20200207-1/bzImage"
+KERNEL_SHA256SUM="0c54ff90a1cb03c14afa5d61df876ead7b50c6053ffabf99f99fb69098adc877"
+
+check_kernel() {
+  if test -f bzImage && echo "$KERNEL_SHA256SUM bzImage" | sha256sum --check --status; then
+    return 0
+  fi
+  curl -L "$KERNEL_URL" -o bzImage.tmp
+  if echo "$KERNEL_SHA256SUM bzImage.tmp" | sha256sum --check --status; then
+    mv bzImage.tmp bzImage
+  else
+    echo "bad bzImage hash"
+    return 1
+  fi
+}
+
+check_kernel || exit 1
+
+# make sure the tests are built
+make TESTS= check > /dev/null
+
+qemu-system-x86_64 \
+  -enable-kvm \
+  -machine q35 \
+  -kernel bzImage \
+  -nographic -serial mon:stdio \
+  -no-reboot \
+  -virtfs local,id=rootfs,path=/,security_model=none,mount_tag=/dev/root \
+  -nic user,model=virtio-net-pci \
+  -append "loglevel=6 console=ttyS0 root=/dev/root rootfstype=9p rw init=$(pwd)/qemu-test-init rauc.slot=system0"
+
+test -f qemu-test-ok

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+set -ex
+
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+mount -t proc none /proc
+mount -t sysfs none /sys
+mount -t tmpfs none /mnt
+mount -t tmpfs none /tmp
+
+# loopback interface
+ip addr add 127.0.0.1 dev lo
+ip link set lo up
+
+# main interface
+ip link set eth0 up
+ip addr add 10.0.2.15/24 dev eth0
+ip link set eth0 up
+ip route add default via 10.0.2.2
+# /etc is not writable from here
+echo "nameserver 10.0.2.3" > /tmp/resolv.conf
+mount --bind /tmp/resolv.conf /etc/resolv.conf
+
+# switch to rauc dir
+cd "$(dirname "$0")"
+
+# fake entropy
+test/fakerand
+
+# grub env
+mkdir -p /tmp/boot/grub
+mount --bind /tmp/boot /boot
+grub-editenv test/grubenv.test create
+touch /tmp/boot/grub/grubenv
+mount --bind test/grubenv.test /tmp/boot/grub/grubenv
+
+# dbus daemon
+cp -a /etc/dbus-1/system.d /tmp
+cp -a data/de.pengutronix.rauc.conf /tmp/system.d
+chown root:root /tmp/system.d/de.pengutronix.rauc.conf
+chmod 644 /tmp/system.d/de.pengutronix.rauc.conf
+mount --bind /tmp/system.d /etc/dbus-1/system.d
+mount -t tmpfs none /var/run
+mkdir -p /var/run/dbus
+time dbus-daemon --system --fork --nopidfile --nosyslog --print-address
+
+echo "system ready"
+
+if make check; then
+  touch qemu-test-ok
+else
+  cat test-suite.log
+fi
+poweroff -f


### PR DESCRIPTION
Replace UML with QEMU for run-time tests. This will make it easier to test more complex setups (such as UBIFS on nandsim). Also, it should reduce the CI maintenance effort needed caused by the unusual UML dependency.