### PR TITLE
Custom script

### DIFF
--- a/include/config_file.h
+++ b/include/config_file.h
@@ -34,6 +34,7 @@ typedef struct {
 	gchar *system_bootloader;
 	gchar *system_bb_statename;
 	gchar *grubenv_path;
+	gchar *custom_script;
 	gboolean efi_use_bootnext;
 	/* maximum filesize to download in bytes */
 	guint64 max_bundle_download_size;

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1375,6 +1375,206 @@ static gboolean efi_get_state(RaucSlot* slot, gboolean *good, GError **error)
 	return TRUE;
 }
 
+/* Wrapper for get commands accessing custom script
+ *
+ * @param cmd What to input as command to the custom backend. Mandatory.
+   Valid values:
+   - get-primary
+   - get-state
+ * @param bootname slot.bootname
+ * @param ret_str Return string from stdout after running the command
+ * @param error Return location for a GError
+ */
+static gboolean custom_backend_get(const gchar *cmd, gchar *bootname, GString **ret_str, GError **error)
+{
+	g_autoptr(GSubprocess) sub = NULL;
+	GError *ierror = NULL;
+	g_autoptr(GBytes) stdout_buf = NULL;
+	gint ret;
+	gchar *script_name = r_context()->config->custom_script;
+	gsize size;
+	const char *data;
+
+	g_return_val_if_fail(cmd, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (bootname)
+		sub = g_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE, &ierror, script_name, cmd, bootname, NULL);
+	else
+		sub = g_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE, &ierror, script_name, cmd, NULL);
+
+	if (!sub) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to start : %s", script_name);
+		return FALSE;
+	}
+
+	if (!g_subprocess_communicate(sub, NULL, NULL, &stdout_buf, NULL, &ierror)) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to run : %s", script_name);
+		return FALSE;
+	}
+	data = g_bytes_get_data(stdout_buf, &size);
+	// Drop terminating character
+	*ret_str = g_string_new_len(data, size - 1);
+
+	ret = g_subprocess_get_exit_status(sub);
+	if (ret != 0) {
+		g_set_error(
+				error,
+				G_SPAWN_EXIT_ERROR,
+				ret,
+				"%s failed with wrong exit code", script_name);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/* Wrapper for set commands accessing custom script
+ *
+ * @param cmd What to input as command to the custom backend. Mandatory.
+   Valid values:
+   - set-primary
+   - set-state
+ * @param bootname slot.bootname
+ * @param arg extra arguments if needed
+ * @param error Return location for a GError
+ */
+static gboolean custom_backend_set(const gchar *cmd, const gchar *bootname, const gchar *arg, GError **error)
+{
+	g_autoptr(GSubprocess) sub = NULL;
+	GError *ierror = NULL;
+	g_autoptr(GBytes) stdout_buf = NULL;
+
+	gchar *script_name = r_context()->config->custom_script;
+
+	g_return_val_if_fail(cmd, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (arg)
+		sub = g_subprocess_new(G_SUBPROCESS_FLAGS_NONE, &ierror, script_name, cmd, bootname, arg, NULL);
+	else
+		sub = g_subprocess_new(G_SUBPROCESS_FLAGS_NONE, &ierror, script_name, cmd, bootname, NULL);
+	if (!sub) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to start : %s", script_name);
+		return FALSE;
+	}
+
+	if (!g_subprocess_wait_check(sub, NULL, &ierror)) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to run: %s", script_name);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/* Set slot status values */
+static gboolean custom_set_state(RaucSlot *slot, gboolean good, GError **error)
+{
+	GError *ierror = NULL;
+	const gchar *cmd = "set-state";
+	const gchar *state = good ? "good" : "bad";
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (!custom_backend_set(cmd, slot->bootname, state, &ierror) ) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/* Get slot marked as primary one */
+static RaucSlot* custom_get_primary(GError **error)
+{
+	RaucSlot *slot;
+	GHashTableIter iter;
+	const gchar *cmd = "get-primary";
+	RaucSlot *primary = NULL;
+	GError *ierror = NULL;
+	g_autoptr(GString) ret_str = NULL;
+
+	// Get primary
+	if (!custom_backend_get(cmd, NULL, &ret_str, &ierror) ) {
+		g_propagate_error(error, ierror);
+		return NULL;
+	}
+
+	// Check result. Ensure returned bootname is in the list
+	g_hash_table_iter_init(&iter, r_context()->config->slots);
+	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
+		if (!slot->bootname)
+			continue;
+
+		if (g_strcmp0(ret_str->str, slot->bootname) == 0) {
+			primary = slot;
+		}
+	}
+
+	if (!primary) {
+		g_set_error_literal(
+				error,
+				R_BOOTCHOOSER_ERROR,
+				R_BOOTCHOOSER_ERROR_PARSE_FAILED,
+				"Unable to obtain primary element");
+	}
+
+	return primary;
+}
+
+/* Get state of current slot */
+static gboolean custom_get_state(RaucSlot *slot, gboolean *good, GError **error)
+{
+	GError *ierror = NULL;
+	const gchar *cmd = "get-state";
+	g_autoptr(GString) ret_str = NULL;
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (!custom_backend_get(cmd, slot->bootname, &ret_str, &ierror) ) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	if (g_strcmp0(ret_str->str, "good") != 0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/* Set slot as primary boot slot */
+static gboolean custom_set_primary(RaucSlot *slot, GError **error)
+{
+	GError *ierror = NULL;
+	const gchar *cmd = "set-primary";
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (!custom_backend_set(cmd, slot->bootname, NULL, &ierror) ) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+
 gboolean r_boot_get_state(RaucSlot* slot, gboolean *good, GError **error)
 {
 	gboolean res = FALSE;
@@ -1392,6 +1592,8 @@ gboolean r_boot_get_state(RaucSlot* slot, gboolean *good, GError **error)
 		res = uboot_get_state(slot, good, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "efi") == 0) {
 		res = efi_get_state(slot, good, &ierror);
+	} else if (g_strcmp0(r_context()->config->system_bootloader, "custom") == 0) {
+		res = custom_get_state(slot, good, &ierror);
 	} else {
 		g_set_error(
 				error,
@@ -1427,6 +1629,8 @@ gboolean r_boot_set_state(RaucSlot *slot, gboolean good, GError **error)
 		res = uboot_set_state(slot, good, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "efi") == 0) {
 		res = efi_set_state(slot, good, &ierror);
+	} else if (g_strcmp0(r_context()->config->system_bootloader, "custom") == 0) {
+		res = custom_set_state(slot, good, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "noop") == 0) {
 		g_message("noop bootloader: ignore setting slot %s status to %s", slot->name, good ? "good" : "bad");
 		res = TRUE;
@@ -1464,6 +1668,8 @@ RaucSlot* r_boot_get_primary(GError **error)
 		slot = uboot_get_primary(&ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "efi") == 0) {
 		slot = efi_get_primary(&ierror);
+	} else if (g_strcmp0(r_context()->config->system_bootloader, "custom") == 0) {
+		slot = custom_get_primary(&ierror);
 	} else {
 		g_set_error(
 				error,
@@ -1499,6 +1705,8 @@ gboolean r_boot_set_primary(RaucSlot *slot, GError **error)
 		res = uboot_set_primary(slot, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "efi") == 0) {
 		res = efi_set_primary(slot, &ierror);
+	} else if (g_strcmp0(r_context()->config->system_bootloader, "custom") == 0) {
+		res = custom_set_primary(slot, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "noop") == 0) {
 		g_message("noop bootloader: ignore setting slot %s as primary", slot->name);
 		res = TRUE;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -23,7 +23,7 @@ gboolean default_config(RaucConfig **config)
 	return TRUE;
 }
 
-static const gchar *supported_bootloaders[] = {"barebox", "grub", "uboot", "efi", "noop", NULL};
+static const gchar *supported_bootloaders[] = {"barebox", "grub", "uboot", "efi", "custom", "noop", NULL};
 
 gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 {
@@ -106,6 +106,13 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 			goto free;
 		}
 		g_key_file_remove_key(key_file, "system", "efi-use-bootnext", NULL);
+	} else if (g_strcmp0(c->system_bootloader, "custom") == 0) {
+		c->custom_script = resolve_path(filename,
+			key_file_consume_string(key_file, "system", "bootloader-custom-script", NULL));
+		if (!c->custom_script) {
+			g_printf("No custom script defined. defaulting to /usr/bin/foobar as default");
+			c->custom_script = g_strdup("/usr/bin/foobar");
+		}
 	}
 
 	c->max_bundle_download_size = g_key_file_get_uint64(key_file, "system", "max-bundle-download-size", &ierror);


### PR DESCRIPTION
Hi

We ran into a issue where we could not rely on the standard bootchoser for our given bootloader.
in this specific case, we were using U-Boot, and could not use the U-Boot environment for rauc status information.
So made an addition to make it possible to point to a script (or program), that can choose how and where to perform the storing.

Proposed API for custom backend script access:

    To obtain the primary slot
    <script> get-primary
    Returns a string that can be one of the bootnames specified in /etc/rauc/system.conf
    Return value is 0 if success, false if error
    
    To set the primary slot:
    <script> set-primary <slot.bootname>
    <slot.bootname> can be one of the bootnames specified in /etc/rauc/system.conf
    Returns empty output
    Return value is 0 if success, false if error
    
    To obtain the state:
    <script> get-state <slot.bootname>
    <slot.bootname> can be one of the bootnames specified in /etc/rauc/system.conf
    Returns a string that can be either "good" or "bad"
    Return value is 0 if success, false if error
    
    To set the state:
    <script> set-state <slot.bootname> <state>
    <slot.bootname> can be one of the bootnames specified in /etc/rauc/system.conf
    <state> can be either "good" or "bad"
    Returns empty output
    Return value is 0 if success, false if error
 