### PR TITLE
src/signature: fix error handling and memory leakage in cms_sign

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -407,6 +407,7 @@ GBytes *cms_sign(GBytes *content, const gchar *certfile, const gchar *keyfile, g
 					R_SIGNATURE_ERROR,
 					R_SIGNATURE_ERROR_X509_NEW,
 					"failed to allocate new X509 store");
+			g_clear_pointer(&res, g_bytes_unref);
 			goto out;
 		}
 		if (!X509_STORE_load_locations(store, keyring_path, NULL)) {
@@ -415,19 +416,20 @@ GBytes *cms_sign(GBytes *content, const gchar *certfile, const gchar *keyfile, g
 					R_SIGNATURE_ERROR,
 					R_SIGNATURE_ERROR_CA_LOAD,
 					"failed to load CA file '%s'", keyring_path);
+			g_clear_pointer(&res, g_bytes_unref);
 			goto out;
 		}
 
 		g_message("Keyring given, doing signature verification");
 		if (!cms_verify(content, res, store, &vcms, &ierror)) {
 			g_propagate_error(error, ierror);
-			res = NULL;
+			g_clear_pointer(&res, g_bytes_unref);
 			goto out;
 		}
 
 		if (!cms_get_cert_chain(vcms, store, &verified_chain, &ierror)) {
 			g_propagate_error(error, ierror);
-			res = NULL;
+			g_clear_pointer(&res, g_bytes_unref);
 			goto out;
 		}
 


### PR DESCRIPTION
As the title already indicates, this solves two issues at once, revealed
by a closer look at the code while discussing #544.

The first issue is that, if the keyring was passed to `cms_sign`, some
error paths in the keyring correctly handled setting the GError, but
left the `res` variable untouched.
While the `res` variable determines the return status (successful /
failed) of the function, this would have led to cases where `cms_sign`
indicated a successful return but actually failed.

While this was already handled in some cases by setting `res = NULL`,
in others it was not. However, also the `res = NULL` is quite problematic
as it causes leakage of the GBytes referenced by 'res' before.

The valid solution to handle both the reset of `res` to `NULL` and cause a
freeing of the memory is to use `g_clear_pointer(&res, g_bytes_unref)`.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>