### PR TITLE
src/main: the 'convert' subcommand deserves --mksquashfs-args, too.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1684,6 +1684,7 @@ static GOptionEntry entries_resign[] = {
 
 static GOptionEntry entries_convert[] = {
 	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
+	{"mksquashfs-args", '\0', 0, G_OPTION_ARG_STRING, &mksquashfs_args, "mksquashfs extra args", "ARGS"},
 	{0}
 };
 


### PR DESCRIPTION
In 7a390661f089f438855d5ff3c61e7a43ca1ffb99 (#537) the --mksquashfs-args
argument was added for the 'bundle' subcommand.
However, the same method is also used when invoking the 'convert'
command.
Thus, we simply enable the option for 'convert' too here.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>