### PR TITLE
src/main: add missing include of string.h

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include <json-glib/json-gobject.h>
 #endif
 #include <stdio.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 


### PR DESCRIPTION
For me, compiling rauc fails with:

> src/main.c:45:55: error: implicit declaration of function ‘strerror’ [-Werror=implicit-function-declaration]
>    g_warning("Unable to obtain window parameters: %s", strerror(errno));

Taking a closer look at main.c shows that the required <string.h> is
actually not included. Not sure how this ever worked or what pulls in
string.h on other systems, but this appears to be the right solution,
anyway.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>