### PR TITLE
Improve configure.ac to properly use pkg-config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,10 +89,9 @@ rauc_CFLAGS = $(AM_CFLAGS) $(JSON_GLIB_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 rauc_LDFLAGS = $(AM_LDFLAGS) $(JSON_GLIB_LDFLAGS) $(CODE_COVERAGE_LDFLAGS)
 rauc_LDADD = $(JSON_GLIB_LIBS) $(librauc_la_LIBADD) librauc.la
 
-if SYSTEMD
-systemdunitdir=$(SYSTEMD_UNITDIR)
+if ENABLE_SERVICE
+systemdunitdir=$(SYSTEMD_SYSTEMUNITDIR)
 nodist_systemdunit_DATA = data/rauc.service
-endif
 
 dbussystemservicedir = $(DBUS_SYSTEMSERVICEDIR)
 nodist_dbussystemservice_DATA = data/de.pengutronix.rauc.service
@@ -105,6 +104,7 @@ dist_dbusinterfaces_DATA = src/de.pengutronix.rauc.Installer.xml
 
 dbuswrapperdir = $(libexecdir)
 nodist_dbuswrapper_SCRIPTS = data/rauc-service.sh
+endif
 
 EXTRA_DIST += data/rauc.service.in \
 	      data/de.pengutronix.rauc.service.in \

--- a/configure.ac
+++ b/configure.ac
@@ -44,9 +44,20 @@ AC_ARG_ENABLE([service],
 )
 AS_IF([test "x$enable_service" != "xno"], [
 	AC_DEFINE([ENABLE_SERVICE], [1], [Define to 1 to enable background service])
+	AC_ARG_VAR([DBUS_POLICYDIR], [Directory used to store dbus policy config files @<:@default=$DBUS_DATADIR/dbus-1/system.d@:>@])
+	AS_VAR_IF([DBUS_POLICYDIR],,
+		  [PKG_CHECK_VAR([DBUS_DATADIR], [dbus-1], [datadir],, [AC_MSG_ERROR([Failed to determine dbus data directory])])
+		   AS_VAR_SET([DBUS_POLICYDIR], [$DBUS_DATADIR/dbus-1/system.d])])
+
+	PKG_CHECK_VAR([DBUS_SYSTEMBUSSERVICEDIR], [dbus-1], [system_bus_services_dir],, [AC_MSG_ERROR([Failed to determine dbus system bus services directory])])
+
+	PKG_CHECK_VAR([DBUS_INTERFACESDIR], [dbus-1], [interfaces_dir],, [AC_MSG_ERROR([Failed to determine dbus interfaces directory])])
+
+	PKG_CHECK_VAR([SYSTEMD_SYSTEMUNITDIR], [systemd], [systemdsystemunitdir],, [AC_MSG_ERROR([Failed to determine systemd unit directory])])
 ], [
 	AC_DEFINE([ENABLE_SERVICE], [0])
 ])
+AM_CONDITIONAL([ENABLE_SERVICE], [test "x$enable_service" != "xno"])
 
 AC_ARG_ENABLE([create],
 	AS_HELP_STRING([--disable-create], [Disable bundle creation and modification commands])
@@ -83,27 +94,7 @@ AS_IF([test "x$enable_json" != "xno"], [
        AC_DEFINE([ENABLE_JSON], [0])
 ])
 
-
 AX_CHECK_OPENSSL([],[AC_MSG_ERROR([OpenSSL not found])])
-
-AC_ARG_WITH([systemdunitdir],
-        AC_HELP_STRING([--with-systemdunitdir=DIR], [path to systemd service directory]),
-        [],
-        [with_systemdunitdir="$($PKG_CONFIG --variable=systemdsystemunitdir systemd)"])
-if (test -n "${with_systemdunitdir}"); then
-	SYSTEMD_UNITDIR="${with_systemdunitdir}"
-	AC_SUBST(SYSTEMD_UNITDIR)
-fi
-AM_CONDITIONAL(SYSTEMD, test -n "${with_systemdunitdir}")
-
-AC_ARG_VAR([DBUS_POLICYDIR], [Directory used to store dbus policy config files @<:@default=$DBUS_DATADIR/dbus-1/system.d@:>@])
-AS_VAR_IF([DBUS_POLICYDIR],,
-	  [PKG_CHECK_VAR([DBUS_DATADIR], [dbus-1], [datadir],, [AC_MSG_ERROR([Failed to determine dbus data directory])])
-	   AS_VAR_SET([DBUS_POLICYDIR], [$DBUS_DATADIR/dbus-1/system.d])])
-
-PKG_CHECK_VAR([DBUS_SYSTEMBUSSERVICEDIR], [dbus-1], [system_bus_services_dir],, [AC_MSG_ERROR([Failed to determine dbus system bus services directory])])
-
-PKG_CHECK_VAR([DBUS_INTERFACESDIR], [dbus-1], [interfaces_dir],, [AC_MSG_ERROR([Failed to determine dbus interfaces directory])])
 
 # Checks for header files.
 

--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,6 @@ AC_ARG_ENABLE([service],
 )
 AS_IF([test "x$enable_service" != "xno"], [
 	AC_DEFINE([ENABLE_SERVICE], [1], [Define to 1 to enable background service])
-	PKG_CHECK_MODULES([DBUS1], [dbus-1])
 ], [
 	AC_DEFINE([ENABLE_SERVICE], [0])
 ])
@@ -97,26 +96,14 @@ if (test -n "${with_systemdunitdir}"); then
 fi
 AM_CONDITIONAL(SYSTEMD, test -n "${with_systemdunitdir}")
 
-AC_ARG_WITH([dbuspolicydir],
-        AS_HELP_STRING([--with-dbuspolicydir=DIR], [D-Bus policy directory]),
-        [],
-        [with_dbuspolicydir="$($PKG_CONFIG --variable=datadir dbus-1)/dbus-1/system.d"])
-DBUS_POLICYDIR="${with_dbuspolicydir}"
-AC_SUBST(DBUS_POLICYDIR)
+AC_ARG_VAR([DBUS_POLICYDIR], [Directory used to store dbus policy config files @<:@default=$DBUS_DATADIR/dbus-1/system.d@:>@])
+AS_VAR_IF([DBUS_POLICYDIR],,
+	  [PKG_CHECK_VAR([DBUS_DATADIR], [dbus-1], [datadir],, [AC_MSG_ERROR([Failed to determine dbus data directory])])
+	   AS_VAR_SET([DBUS_POLICYDIR], [$DBUS_DATADIR/dbus-1/system.d])])
 
-AC_ARG_WITH([dbussystemservicedir],
-        AS_HELP_STRING([--with-dbussystemservicedir=DIR], [D-Bus system service directory]),
-        [],
-        [with_dbussystemservicedir="$($PKG_CONFIG --variable=system_bus_services_dir dbus-1)"])
-DBUS_SYSTEMSERVICEDIR="${with_dbussystemservicedir}"
-AC_SUBST(DBUS_SYSTEMSERVICEDIR)
+PKG_CHECK_VAR([DBUS_SYSTEMBUSSERVICEDIR], [dbus-1], [system_bus_services_dir],, [AC_MSG_ERROR([Failed to determine dbus system bus services directory])])
 
-AC_ARG_WITH([dbusinterfacesdir],
-        AS_HELP_STRING([--with-dbusinterfacesdir=DIR], [D-Bus interfaces directory]),
-        [],
-        [with_dbusinterfacesdir="$($PKG_CONFIG --variable=interfaces_dir dbus-1)"])
-DBUS_INTERFACESDIR="${with_dbusinterfacesdir}"
-AC_SUBST(DBUS_INTERFACESDIR)
+PKG_CHECK_VAR([DBUS_INTERFACESDIR], [dbus-1], [interfaces_dir],, [AC_MSG_ERROR([Failed to determine dbus interfaces directory])])
 
 # Checks for header files.
 


### PR DESCRIPTION
This improves the configure script on some edges. So querying the `pkg-config` database for `systemd` and `dbus-1` is simplified and still more robust as errors are catched. Also the checks are not done when they are irrelevant (i.e. with `./configure --disable-service`).

As a side effect all the `--with-...dir` options (which don't really fit the usual semantic of autoconf's --with-...) are dropped and the paths can instead be overwritten using e.g.

    ./configure DBUS_POLICYDIR=/path/to/where/you/want/it/

