### PR TITLE
Promote Central Slot Status Usage More Obviously

### DIFF
--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -116,21 +116,22 @@ RAUC hashes each image or archive when packing it into a bundle and stores this
 hash in the bundle's manifest file.
 This hash allows to reliably identify and distinguish the image's content.
 
-When installing an image to a writable file system, RAUC will write an
-additional slot status file after having completed the write operation
-successfully.
-This file contains the slots hash.
+When installing an image, RAUC can write the images hash together with some
+status information to a central or per-slot status file
+(refer :ref:`statusfile <statusfile>` option).
 
 The next time RAUC attempts to install an image to this slot, it will first
-check the current hash of the slot by reading its status file, if possible.
-If this hash equals the hash of the image to write, RAUC will skip updating this
-slot as a performance optimization.
+check the current hash of the slot by reading its status information, if
+available.
+If this hash equals the hash of the image to write, RAUC can skip updating this
+slot as a configurable performance optimization
+(refer :ref:`install-same <install-same>` per-slot option).
 
 This is especially useful when having a setup with, for example, two redundant
 application file systems and two redundant root file systems. In case you
-update the application file system content much more frequently, RAUC will save
-update time by skipping the root file system automatically and only installing
-the changed application.
+update the application file system content much more frequently while keeping
+the exact same rootfs content, RAUC will save update time by skipping the root
+file system automatically and only installing the changed application.
 
 Boot Slot Selection
 -------------------

--- a/docs/checklist.rst
+++ b/docs/checklist.rst
@@ -16,6 +16,7 @@ General
 * Bundles are created automatically by a build system ☐
 * Bundle deployment mechanism defined (pull or push via the network, from
   USB/SD, …) ☐
+* Proper slot status file location(s) defined (preferably central status) ☐
 
 Slot Layout
 -----------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -29,6 +29,7 @@ Example configuration:
   [system]
   compatible=FooCorp Super BarBazzer
   bootloader=barebox
+  statusfile=/data/central-status.raucs
 
   [keyring]
   path=/etc/rauc/keyring.pem

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -297,6 +297,8 @@ hierarchical separator.
   Marks the slot as existing but not updatable. May be used for sanity checking
   or informative purpose. A ``readonly`` slot cannot be a target slot.
 
+.. _install-same:
+
 ``install-same=<true/false>``
   If set to ``false``, this will tell RAUC to skip writing slots that already
   have the same content as the one that should be installed.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -97,10 +97,19 @@ Example configuration:
 .. _statusfile:
 
 ``statusfile``
-  If this key exists, it points to a file where slot status information should
-  be stored (e.g. slot specific metadata, see :ref:`slot-status`).
-  This file should be located on a filesystem which is not overwritten during
-  updates.
+  This key should be set to point to a central file where slot status
+  information should be stored (e.g. slot-specific metadata, see
+  :ref:`slot-status`).
+  This file must be located on a non-redundant filesystem which is not
+  overwritten during updates.
+  In most cases, a central status file is preferable to per-slot status files
+  as it allows to store data also for read-only or (temporary) filesystem-less
+  slots.
+  However, if a per-slot status is required as one of the above-noted
+  requirements cannot be met, one can use the value ``per-slot`` to document
+  this decision.
+  For background compatibility this option is not mandatory and will default to
+  per-slot status files if not set.
 
 ``max-bundle-download-size``
   Defines the maximum downloadable bundle size in bytes, and thus must be

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -46,6 +46,8 @@ static void config_file_fixture_tear_down(ConfigFileFixture *fixture,
 static void config_file_full_config(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
+	GError *ierror = NULL;
+	gboolean res;
 	GList *slotlist;
 	RaucConfig *config;
 	RaucSlot *slot;
@@ -106,7 +108,9 @@ install-same=false\n";
 	gchar* pathname = write_tmp_file(fixture->tmpdir, "full_config.conf", cfg_file, NULL);
 	g_assert_nonnull(pathname);
 
-	g_assert_true(load_config(pathname, &config, NULL));
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_assert_nonnull(config);
 	g_assert_cmpstr(config->system_compatible, ==, "FooCorp Super BarBazzer");
 	g_assert_cmpstr(config->system_bootloader, ==, "barebox");
@@ -417,6 +421,7 @@ static void config_file_no_max_bundle_download_size(ConfigFileFixture *fixture,
 {
 	RaucConfig *config;
 	GError *ierror = NULL;
+	gboolean res;
 	gchar* pathname;
 
 	const gchar *cfg_file = "\
@@ -427,8 +432,9 @@ bootloader=barebox\n";
 	pathname = write_tmp_file(fixture->tmpdir, "no_max_bundle_download_size.conf", cfg_file, NULL);
 	g_assert_nonnull(pathname);
 
-	g_assert_true(load_config(pathname, &config, &ierror));
-	g_assert_null(ierror);
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_assert_nonnull(config);
 	g_assert_cmpuint(config->max_bundle_download_size, ==, DEFAULT_MAX_BUNDLE_DOWNLOAD_SIZE);
 
@@ -473,6 +479,7 @@ static void config_file_activate_installed_set_to_true(ConfigFileFixture *fixtur
 {
 	RaucConfig *config;
 	GError *ierror = NULL;
+	gboolean res;
 	gchar* pathname;
 
 	const gchar *cfg_file = "\
@@ -486,8 +493,9 @@ activate-installed=true\n";
 	pathname = write_tmp_file(fixture->tmpdir, "invalid_bootloader.conf", cfg_file, NULL);
 	g_assert_nonnull(pathname);
 
-	g_assert_true(load_config(pathname, &config, &ierror));
-	g_assert_null(ierror);
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_assert_nonnull(config);
 	g_assert_true(config->activate_installed);
 
@@ -499,6 +507,7 @@ static void config_file_activate_installed_set_to_false(ConfigFileFixture *fixtu
 {
 	RaucConfig *config;
 	GError *ierror = NULL;
+	gboolean res;
 	gchar* pathname;
 
 	const gchar *cfg_file = "\
@@ -512,8 +521,9 @@ activate-installed=false\n";
 	pathname = write_tmp_file(fixture->tmpdir, "invalid_bootloader.conf", cfg_file, NULL);
 	g_assert_nonnull(pathname);
 
-	g_assert_true(load_config(pathname, &config, &ierror));
-	g_assert_null(ierror);
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_assert_nonnull(config);
 	g_assert_false(config->activate_installed);
 
@@ -525,6 +535,7 @@ static void config_file_system_variant(ConfigFileFixture *fixture,
 {
 	RaucConfig *config;
 	GError *ierror = NULL;
+	gboolean res;
 	gchar* pathname;
 
 	const gchar *cfg_file_no_variant = "\
@@ -565,7 +576,9 @@ variant-name=xxx";
 	pathname = write_tmp_file(fixture->tmpdir, "no_variant.conf", cfg_file_no_variant, NULL);
 	g_assert_nonnull(pathname);
 
-	g_assert_true(load_config(pathname, &config, &ierror));
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_free(pathname);
 	g_assert_null(ierror);
 	g_assert_nonnull(config);
@@ -576,7 +589,9 @@ variant-name=xxx";
 	pathname = write_tmp_file(fixture->tmpdir, "name_variant.conf", cfg_file_name_variant, NULL);
 	g_assert_nonnull(pathname);
 
-	g_assert_true(load_config(pathname, &config, &ierror));
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_free(pathname);
 	g_assert_null(ierror);
 	g_assert_nonnull(config);
@@ -588,7 +603,9 @@ variant-name=xxx";
 	pathname = write_tmp_file(fixture->tmpdir, "dtb_variant.conf", cfg_file_dtb_variant, NULL);
 	g_assert_nonnull(pathname);
 
-	g_assert_true(load_config(pathname, &config, &ierror));
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_free(pathname);
 	g_assert_null(ierror);
 	g_assert_nonnull(config);
@@ -600,7 +617,9 @@ variant-name=xxx";
 	pathname = write_tmp_file(fixture->tmpdir, "file_variant.conf", cfg_file_file_variant, NULL);
 	g_assert_nonnull(pathname);
 
-	g_assert_true(load_config(pathname, &config, &ierror));
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_free(pathname);
 	g_assert_null(ierror);
 	g_assert_nonnull(config);
@@ -621,6 +640,7 @@ static void config_file_no_extra_mount_opts(ConfigFileFixture *fixture,
 {
 	RaucConfig *config;
 	GError *ierror = NULL;
+	gboolean res;
 	g_autofree gchar* pathname = NULL;
 	RaucSlot *slot = NULL;
 
@@ -638,8 +658,9 @@ device=/dev/null\n";
 	pathname = write_tmp_file(fixture->tmpdir, "extra_mount.conf", cfg_file, NULL);
 	g_assert_nonnull(pathname);
 
-	g_assert_true(load_config(pathname, &config, &ierror));
-	g_assert_null(ierror);
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_assert_nonnull(config);
 
 
@@ -656,6 +677,7 @@ static void config_file_extra_mount_opts(ConfigFileFixture *fixture,
 {
 	RaucConfig *config;
 	GError *ierror = NULL;
+	gboolean res;
 	g_autofree gchar* pathname = NULL;
 	RaucSlot *slot = NULL;
 
@@ -674,8 +696,9 @@ extra-mount-opts=ro,noatime\n";
 	pathname = write_tmp_file(fixture->tmpdir, "extra_mount.conf", cfg_file, NULL);
 	g_assert_nonnull(pathname);
 
-	g_assert_true(load_config(pathname, &config, &ierror));
-	g_assert_null(ierror);
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_assert_nonnull(config);
 
 	slot = g_hash_table_lookup(config->slots, "rootfs.0");
@@ -690,6 +713,7 @@ static void config_file_statusfile_missing(ConfigFileFixture *fixture,
 {
 	RaucConfig *config;
 	GError *ierror = NULL;
+	gboolean res;
 	gchar* pathname;
 
 	const gchar *cfg_file = "\
@@ -702,8 +726,9 @@ mountprefix=/mnt/myrauc/\n";
 	pathname = write_tmp_file(fixture->tmpdir, "valid_bootloader.conf", cfg_file, NULL);
 	g_assert_nonnull(pathname);
 
-	g_assert_true(load_config(pathname, &config, &ierror));
-	g_assert_null(ierror);
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_assert_nonnull(config);
 	g_assert_nonnull(config->statusfile_path);
 	g_assert_cmpstr(config->statusfile_path, ==, "per-slot");
@@ -714,8 +739,12 @@ mountprefix=/mnt/myrauc/\n";
 
 static void config_file_test_read_slot_status(void)
 {
+	GError *ierror = NULL;
+	gboolean res;
 	RaucSlotStatus *ss = g_new0(RaucSlotStatus, 1);
-	g_assert_true(read_slot_status("test/rootfs.raucs", ss, NULL));
+	res = read_slot_status("test/rootfs.raucs", ss, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 	g_assert_nonnull(ss);
 	g_assert_cmpstr(ss->status, ==, "ok");
 	g_assert_cmpint(ss->checksum.type, ==, G_CHECKSUM_SHA256);

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -705,7 +705,8 @@ mountprefix=/mnt/myrauc/\n";
 	g_assert_true(load_config(pathname, &config, &ierror));
 	g_assert_null(ierror);
 	g_assert_nonnull(config);
-	g_assert_null(config->statusfile_path);
+	g_assert_nonnull(config->statusfile_path);
+	g_assert_cmpstr(config->statusfile_path, ==, "per-slot");
 
 	free_config(config);
 }


### PR DESCRIPTION
Using a single central slot status file in RAUC has several advantages. Thus we should be more explicit in notifying the user of this feature.

This now:
* adds a check to the design checlist
* explicitly mentions benefits in documentations
* adds an info message when not using the central status