### PR TITLE
Fixing a config_file test that suddenly broke..

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -132,4 +132,5 @@ void r_context_register_progress_callback(progress_callback progress_cb);
 
 RaucContext *r_context_conf(void);
 const RaucContext *r_context(void);
+void r_context_install_info_free(RContextInstallationInfo *info);
 void r_context_clean(void);

--- a/src/context.c
+++ b/src/context.c
@@ -573,6 +573,11 @@ void r_context_clean(void)
 		g_clear_pointer(&context->signing_keyringpath, g_free);
 		g_clear_pointer(&context->mksquashfs_args, g_free);
 		g_clear_pointer(&context->casync_args, g_free);
+		g_clear_pointer(&context->intermediatepaths, g_strfreev);
+		g_clear_pointer(&context->mountprefix, g_free);
+		g_clear_pointer(&context->bootslot, g_free);
+		g_clear_pointer(&context->system_serial, g_free);
+		g_clear_pointer(&context->handlerextra, g_free);
 
 		if (context->config) {
 			context->config->keyring_path = NULL;

--- a/src/context.c
+++ b/src/context.c
@@ -563,6 +563,13 @@ const RaucContext *r_context(void)
 	return context;
 }
 
+void r_context_install_info_free(RContextInstallationInfo *info)
+{
+	/* contains only reference to existing bundle instance */
+	info->mounted_bundle = NULL;
+	g_free(info);
+}
+
 void r_context_clean(void)
 {
 	if (context) {
@@ -578,6 +585,8 @@ void r_context_clean(void)
 		g_clear_pointer(&context->bootslot, g_free);
 		g_clear_pointer(&context->system_serial, g_free);
 		g_clear_pointer(&context->handlerextra, g_free);
+
+		g_clear_pointer(&context->install_info, r_context_install_info_free);
 
 		if (context->config) {
 			context->config->keyring_path = NULL;

--- a/src/context.c
+++ b/src/context.c
@@ -566,20 +566,13 @@ const RaucContext *r_context(void)
 void r_context_clean(void)
 {
 	if (context) {
-		g_free(context->certpath);
-		g_free(context->keypath);
-		g_free(context->keyringpath);
-		g_free(context->keyringdirectory);
-		g_free(context->signing_keyringpath);
-		g_free(context->mksquashfs_args);
-		g_free(context->casync_args);
-		context->certpath = NULL;
-		context->keypath = NULL;
-		context->keyringpath = NULL;
-		context->keyringdirectory = NULL;
-		context->signing_keyringpath = NULL;
-		context->mksquashfs_args = NULL;
-		context->casync_args = NULL;
+		g_clear_pointer(&context->certpath, g_free);
+		g_clear_pointer(&context->keypath, g_free);
+		g_clear_pointer(&context->keyringpath, g_free);
+		g_clear_pointer(&context->keyringdirectory, g_free);
+		g_clear_pointer(&context->signing_keyringpath, g_free);
+		g_clear_pointer(&context->mksquashfs_args, g_free);
+		g_clear_pointer(&context->casync_args, g_free);
 
 		if (context->config) {
 			context->config->keyring_path = NULL;

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -38,6 +38,7 @@ static void config_file_fixture_tear_down(ConfigFileFixture *fixture,
 {
 	g_assert_true(rm_tree(fixture->tmpdir, NULL));
 	g_free(fixture->tmpdir);
+	r_context_clean();
 }
 
 /* Test: Parse entire config file and check if derived slot / file structures

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -802,7 +802,8 @@ static void config_file_test_write_slot_status(void)
 	r_slot_free_status(ss);
 }
 
-static void config_file_system_serial(void)
+static void config_file_system_serial(ConfigFileFixture *fixture,
+		gconstpointer user_data)
 {
 	g_assert_nonnull(r_context()->system_serial);
 	g_assert_cmpstr(r_context()->system_serial, ==, "1234");
@@ -921,7 +922,9 @@ int main(int argc, char *argv[])
 			config_file_fixture_tear_down);
 	g_test_add_func("/config-file/read-slot-status", config_file_test_read_slot_status);
 	g_test_add_func("/config-file/write-read-slot-status", config_file_test_write_slot_status);
-	g_test_add_func("/config-file/system-serial", config_file_system_serial);
+	g_test_add("/config-file/system-serial", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_system_serial,
+			config_file_fixture_tear_down);
 	g_test_add("/config-file/statusfile-missing", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_statusfile_missing,
 			config_file_fixture_tear_down);


### PR DESCRIPTION
This collects all changes that needed to be done to reveal and fix the issue why in my setup the test `/config-file/system-serial` suddenly painted an annoying red in the green meadow of successful test runs.