### PR TITLE
Allow to Enable CRL handling in RAUC's Bundle Verification

### DIFF
--- a/include/config_file.h
+++ b/include/config_file.h
@@ -45,6 +45,7 @@ typedef struct {
 	gchar *statusfile_path;
 	gchar *keyring_path;
 	gchar *keyring_directory;
+	gboolean keyring_check_crl;
 	gboolean use_bundle_signing_time;
 
 	gchar *autoinstall_path;

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -720,6 +720,10 @@ static X509_STORE* setup_store(GError **error)
 		return NULL;
 	}
 
+	/* Enable CRL checking if configured */
+	if (r_context()->config->keyring_check_crl)
+		X509_STORE_set_flags(store, X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL | X509_V_FLAG_EXTENDED_CRL_SUPPORT);
+
 	return store;
 }
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -228,6 +228,18 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	c->keyring_directory = resolve_path(filename,
 			key_file_consume_string(key_file, "keyring", "directory", NULL));
 
+	c->keyring_check_crl = g_key_file_get_boolean(key_file, "keyring", "check-crl", &ierror);
+	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND) ||
+	    g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_GROUP_NOT_FOUND)) {
+		c->keyring_check_crl = FALSE;
+		g_clear_error(&ierror);
+	} else if (ierror) {
+		g_propagate_error(error, ierror);
+		res = FALSE;
+		goto free;
+	}
+	g_key_file_remove_key(key_file, "keyring", "check-crl", NULL);
+
 	c->use_bundle_signing_time = g_key_file_get_boolean(key_file, "keyring", "use-bundle-signing-time", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND) ||
 	    g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_GROUP_NOT_FOUND)) {

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -254,13 +254,13 @@ test_expect_success PKCS11 "rauc bundle with PKCS11 (key 1)" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test.conf info out.raucb
 "
 
-test_expect_success PKCS11 "rauc bundle with PKCS11 (key 2)" "
+test_expect_success PKCS11 "rauc bundle with PKCS11 (key 2, revoked)" "
   rm -f out.raucb &&
   rauc \
     --cert 'pkcs11:token=rauc;object=autobuilder-2' \
     --key 'pkcs11:token=rauc;object=autobuilder-2' \
     bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
-  rauc -c $SHARNESS_TEST_DIRECTORY/test.conf info out.raucb
+  test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test.conf info out.raucb
 "
 
 test_expect_success PKCS11 "rauc bundle with PKCS11 (key mismatch)" "

--- a/test/test-global.conf
+++ b/test/test-global.conf
@@ -13,6 +13,7 @@ post-install=bin/postinstall.sh
 
 [keyring]
 path=openssl-ca/dev-ca.pem
+check-crl=true
 
 [slot.rescue.0]
 device=images/rescue-0

--- a/test/test.conf
+++ b/test/test.conf
@@ -13,6 +13,7 @@ post-install=bin/postinstall.sh
 
 [keyring]
 path=openssl-ca/dev-ca.pem
+check-crl=true
 
 [slot.rescue.0]
 device=images/rescue-0


### PR DESCRIPTION
In order to actually use a provided CRL for checking, some flags need to
be set in OpenSSL. These were unset up to now. As a result of this, a
keyring / cert store file or directory could have contained a CRL, but
the Bundle verification process in RAUC simply ignored it.

This patch now introduces the `[keyring]` section option `check-crl` that
allows enabling CRL handling for RAUC's signature verification.

The reason why this cannot be enabled by default is that OpenSSL would
enforce having a CRL in a cert store. This will not only break existing
setups but also make the simplest case (a simple self-signed
certificate for now) more complex.

Although, we cannot enable CRLs by default, there may be setups
that probably already have a CRL in their key store.

To more visibly tell them to enable the 'check-crl' flag, we check stores for
containing files that have the standardized CRL header in it. If these are
present and check-crl is not enabled, we print a warning to inform the user
about the ineffectiveness of their CRLs.

Fixes: #556 