### PR TITLE
support --no-verify for rauc resign

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -118,6 +118,8 @@ This is what the ``resign`` command of RAUC is for::
 
 It verifies the bundle against the given keyring, strips the old signature and
 attaches a new one based on the key and cert files provided.
+If the old signature is no longer valid, you can use the ``--no-verify``
+argument to disable verification.
 
 Switching the Keyring -- SPKI hashes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rauc.1
+++ b/rauc.1
@@ -109,6 +109,15 @@ Create a bundle from a content directory.
 .RS 4
 Resign an already signed bundle.
 
+\fBOptions:\fR
+
+.RS 4
+
+.TP
+\fB\-\-no\-verify\fR
+disable bundle verification
+
+.RE
 .RE
 .PP
 \fBextract\fR \fIBUNDLE\fR \fIOUTPUTDIR\fR

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,8 @@ GMainLoop *r_loop = NULL;
 int r_exit_status = 0;
 
 gboolean install_ignore_compatible, install_progressbar = FALSE;
-gboolean info_noverify, info_dumpcert = FALSE;
+gboolean verification_disabled = FALSE;
+gboolean info_dumpcert = FALSE;
 gboolean status_detailed = FALSE;
 gchar *output_format = NULL;
 gchar *signing_keyring = NULL;
@@ -484,7 +485,7 @@ static gboolean resign_start(int argc, char **argv)
 		goto out;
 	}
 
-	if (!check_bundle(argv[2], &bundle, TRUE, &ierror)) {
+	if (!check_bundle(argv[2], &bundle, !verification_disabled, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -900,7 +901,7 @@ static gboolean info_start(int argc, char **argv)
 		goto out;
 	g_debug("input bundle: %s", bundlelocation);
 
-	res = check_bundle(bundlelocation, &bundle, !info_noverify, &error);
+	res = check_bundle(bundlelocation, &bundle, !verification_disabled, &error);
 	if (!res) {
 		g_printerr("%s\n", error->message);
 		g_clear_error(&error);
@@ -1710,6 +1711,7 @@ static GOptionEntry entries_bundle[] = {
 };
 
 static GOptionEntry entries_resign[] = {
+	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
 	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
 	{0}
 };
@@ -1722,7 +1724,7 @@ static GOptionEntry entries_convert[] = {
 };
 
 static GOptionEntry entries_info[] = {
-	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &info_noverify, "disable bundle verification", NULL},
+	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
 	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format", "FORMAT"},
 	{"dump-cert", '\0', 0, G_OPTION_ARG_NONE, &info_dumpcert, "dump certificate", NULL},
 	{0}

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -228,8 +228,7 @@ test_expect_success "rauc bundle" "
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
     bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
   rauc -c $SHARNESS_TEST_DIRECTORY/test.conf info out.raucb &&
-  test -f out.raucb &&
-  rm out.raucb
+  test -f out.raucb
 "
 
 test_expect_success "rauc bundle mksquashfs extra args" "
@@ -240,9 +239,7 @@ test_expect_success "rauc bundle mksquashfs extra args" "
     bundle \
     --mksquashfs-args=\"-comp xz -info -progress\" \
     $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
-  rauc -c $SHARNESS_TEST_DIRECTORY/test.conf info out.raucb &&
-  test -f out.raucb &&
-  rm out.raucb
+  rauc -c $SHARNESS_TEST_DIRECTORY/test.conf info out.raucb
 "
 
 test_expect_success PKCS11 "rauc bundle with PKCS11 (key 1)" "
@@ -433,84 +430,92 @@ use-bundle-signing-time=true
 cleanup rm $SHARNESS_TEST_DIRECTORY/use-bundle-signing-time.conf
 
 test_expect_success FAKETIME "rauc verify with 'use-bundle-signing-time': valid signing time, invalid current time" "
+  rm -f out.raucb &&
   faketime "2018-01-01" \
-  rauc \
+    rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
     --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
     bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
-  faketime "2022-01-01" rauc --conf $SHARNESS_TEST_DIRECTORY/use-bundle-signing-time.conf info out.raucb &&
-  rm out.raucb
+  test -f out.raucb &&
+  faketime "2022-01-01" rauc --conf $SHARNESS_TEST_DIRECTORY/use-bundle-signing-time.conf info out.raucb
 "
 
 test_expect_success FAKETIME "rauc verfiy with 'use-bundle-signing-time': invalid signing time, valid current time" "
+  rm -f out.raucb &&
   faketime "2022-01-01" \
-  rauc \
+    rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
     bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
-  test_must_fail faketime "2018-01-01" rauc --conf $SHARNESS_TEST_DIRECTORY/use-bundle-signing-time.conf info out.raucb &&
-  rm out.raucb
+  test -f out.raucb &&
+  test_must_fail faketime "2018-01-01" rauc --conf $SHARNESS_TEST_DIRECTORY/use-bundle-signing-time.conf info out.raucb
 "
 
 test_expect_success FAKETIME "rauc sign bundle with expired certificate" "
+  rm -f out.raucb &&
   test_must_fail faketime "2019-07-02" \
-  rauc \
+    rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
     --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
     bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
-    test ! -f out.raucb
+  test ! -f out.raucb
 "
 
 test_expect_success FAKETIME "rauc sign bundle with not yet valid certificate" "
+  rm -f out.raucb &&
   test_must_fail faketime "2017-01-01" \
-  rauc \
+    rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
     --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
-    bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
-    test ! -f out.raucb
+  bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
+  test ! -f out.raucb
 "
 
 test_expect_success FAKETIME "rauc sign bundle with almost expired certificate" "
+  rm -f out.raucb &&
   faketime "2019-06-15" \
-  rauc \
+    rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
     --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
     bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
-    test -f out.raucb &&
-    rm out.raucb
+  test -f out.raucb
 "
 
 test_expect_success FAKETIME "rauc sign bundle with valid certificate" "
+  rm -f out.raucb &&
   faketime "2019-01-01" \
-  rauc \
+    rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
     --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
     bundle $SHARNESS_TEST_DIRECTORY/install-content out.raucb &&
-    test -f out.raucb &&
-    rm out.raucb
+  test -f out.raucb
 "
 
 test_expect_success CASYNC "rauc convert" "
+  rm -f casync.raucb &&
   rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
     --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
-    convert $SHARNESS_TEST_DIRECTORY/good-bundle.raucb casync.raucb
+    convert $SHARNESS_TEST_DIRECTORY/good-bundle.raucb casync.raucb &&
+  test -f casync.raucb
 "
 
 test_expect_success CASYNC "rauc convert casync extra args" "
+  rm -f casync-extra-args.raucb &&
   rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
     --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
     convert \
     --casync-args=\"--chunk-size=64000\" \
-    $SHARNESS_TEST_DIRECTORY/good-bundle.raucb casync-extra-args.raucb
+    $SHARNESS_TEST_DIRECTORY/good-bundle.raucb casync-extra-args.raucb &&
+  test -f casync-extra-args.raucb
 "
 
 test_done


### PR DESCRIPTION
When the certificate used for signing a bundle has expired, it is useful to explicitly disable verification during resigning.