### PR TITLE
docs/reference: switch to horizontal ellipsis

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -419,7 +419,7 @@ Command Line Tool
 .. code-block:: man
 
   Usage:
-    rauc [OPTION...] <COMMAND>
+    rauc [OPTION…] <COMMAND>
 
   Options:
     -c, --conf=FILENAME               config file


### PR DESCRIPTION
Synchronize the documentation to glib's commit [1] contained in release 2.51.0
for the first time which changed the output format from '[OPTION...]' to
'[OPTION…]' (using the unicode character U+2026 "horizontal ellipsis").

[1] 10c490cdfe3a ("Use Unicode in translatable strings")

Signed-off-by: Ulrich Ölmann <u.oelmann@pengutronix.de>