### PR TITLE
Small Fixes for Readable 'rauc status' Output

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -995,7 +995,7 @@ static void r_string_append_slot(GString *text, RaucSlot *slot, RaucStatusPrint 
 		if (utf8_supported)
 			g_string_append_unichar(text, slot == status->primary ? 0x23FA :  0x25CB);
 		else
-			g_string_append_c(text, slot == status->primary ? 'o' :  'x');
+			g_string_append(text, slot == status->primary ? KBLD "x"KNRM :  "o");
 	} else {
 		g_string_append_c(text, ' ');
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -999,7 +999,7 @@ static void r_string_append_slot(GString *text, RaucSlot *slot, RaucStatusPrint 
 	} else {
 		g_string_append_c(text, ' ');
 	}
-	g_string_append_printf(text, "%s%s%s"KBLD "[%s]"KNRM " (%s, %s, %s%s"KWHT ")"KNRM,
+	g_string_append_printf(text, "%s%s%s"KBLD "[%s]"KNRM " (%s, %s, %s%s"KNRM ")",
 			slot->parent ? "   " : " ",
 			slot->state & ST_ACTIVE ? KGRN : "",
 			slot->state == ST_BOOTED ? KGRN : "",


### PR DESCRIPTION
This fixes 'rauc status' printout by
* clarifying the marking of a booted slot
* fixing unintentional bold printing of closing bracket