### PR TITLE
improve qemu-test helper

### DIFF
--- a/qemu-test
+++ b/qemu-test
@@ -36,6 +36,6 @@ qemu-system-x86_64 \
   -no-reboot \
   -virtfs local,id=rootfs,path=/,security_model=none,mount_tag=/dev/root \
   -nic user,model=virtio-net-pci \
-  -append "loglevel=6 console=ttyS0 root=/dev/root rootfstype=9p rw init=$(pwd)/qemu-test-init rauc.slot=system0"
+  -append "loglevel=6 console=ttyS0 root=/dev/root rootfstype=9p rw init=$(pwd)/qemu-test-init rauc.slot=system0 $*"
 
 test -f qemu-test-ok

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -9,6 +9,15 @@ mount -t sysfs none /sys
 mount -t tmpfs none /mnt
 mount -t tmpfs none /tmp
 
+# parse cmdline
+for x in $(cat /proc/cmdline); do
+  if [ "$x" = "shell" ]; then
+    SHELL=1
+  fi
+done
+
+hostname qemu-test
+
 # loopback interface
 ip addr add 127.0.0.1 dev lo
 ip link set lo up
@@ -46,6 +55,11 @@ mkdir -p /var/run/dbus
 time dbus-daemon --system --fork --nopidfile --nosyslog --print-address
 
 echo "system ready"
+
+if [ -n "$SHELL" ]; then
+  setsid bash </dev/ttyS0 >/dev/ttyS0 2>&1 || echo exit-code=$?
+  echo o > /proc/sysrq-trigger
+fi
 
 if make check; then
   touch qemu-test-ok

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -52,4 +52,4 @@ if make check; then
 else
   cat test-suite.log
 fi
-poweroff -f
+echo o > /proc/sysrq-trigger

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -64,6 +64,10 @@ fi
 if make check; then
   touch qemu-test-ok
 else
-  cat test-suite.log
+  cat test-suite.log || true
+  # show system status on error
+  mount || true
+  df -h || true
+  free || true
 fi
 echo o > /proc/sysrq-trigger


### PR DESCRIPTION
- Add a mechanism to start a shell in the qemu environment for development.
- Avoid using the poweroff binary, which is not available every and use sysrq instead.
- Show remaining mounts and free/df after a failed test.