### PR TITLE
D-Bus API: clarify license for rauc-installer.xml (fixes #468)

### DIFF
--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -1,3 +1,4 @@
+<!-- License note: This file is considered data and thus no license is needed for any usage. -->
 <node>
   <interface name="de.pengutronix.rauc.Installer">
     <!--


### PR DESCRIPTION
As this file contains the same information you can get from
the D-Bus introspection API, the file is considered as simple data.

Add an explicit note in the file to document this.

Signed-off-by: Michael Heimpold <michael.heimpold@in-tech.com>