### PR TITLE
service: add annotation for InstallBundle method

### DIFF
--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -20,6 +20,7 @@
     <method name="InstallBundle">
       <arg name="source" type="s"/>
       <arg name="args" type="a{sv}" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
     </method>
 
    <!--


### PR DESCRIPTION
An annotation is required for the recently added `InstallBundle` method as well when using qdbusxml2cpp.