### PR TITLE
add GPT boot partition support via boot-gpt-switch slot type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - ci_env=`bash <(curl -s https://codecov.io/env)`
     - COVERITY_SCAN_PROJECT_NAME="jluebbe/rauc"
     - COVERITY_SCAN_NOTIFICATION_EMAIL="jlu@pengutronix.de"
-    - COVERITY_SCAN_BUILD_COMMAND_PREPEND="cov-configure --comptype gcc --compiler gcc-8 --template && ./autogen.sh && ./configure CC=gcc-8"
+    - COVERITY_SCAN_BUILD_COMMAND_PREPEND="cov-configure --comptype gcc --compiler gcc-8 --template && ./autogen.sh && ./configure --enable-gpt CC=gcc-8"
     - COVERITY_SCAN_BUILD_COMMAND="make V=1"
 
 stages:
@@ -38,7 +38,7 @@ jobs:
         - docker exec -it rauc-ci gcc --version
 
         - docker exec -it rauc-ci ./autogen.sh
-        - docker exec -it rauc-ci ./configure --enable-code-coverage CFLAGS=-Werror
+        - docker exec -it rauc-ci ./configure --enable-code-coverage --enable-gpt CFLAGS=-Werror
         - docker exec -it rauc-ci make clean
         - docker exec -it rauc-ci make -j2
         - docker exec -it rauc-ci make doc SPHINXOPTS=-W
@@ -64,10 +64,10 @@ jobs:
       before_script:
         - docker exec -it cross uname -a
         - docker exec -it cross apt-get update
-        - docker exec -it cross apt-get install -y build-essential automake libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev
+        - docker exec -it cross apt-get install -y build-essential automake libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev libfdisk-dev
       script:
         - docker exec -it cross ./autogen.sh
-        - docker exec -it cross ./configure CFLAGS=-Werror
+        - docker exec -it cross ./configure --enable-gpt CFLAGS=-Werror
         - docker exec -it cross make
       after_script:
         - docker stop cross

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,9 @@ Release 1.4 (development)
   than 512MiB.
   This avoids the "ext4 filesystem being mounted at /foo supports timestamps
   until 2038" message on newer kernels.
+* Added new slot type ``boot-gpt-switch`` to support atomic updating of boot
+  partitions in the GPT.
+  See :ref:`here <sec-gpt-partition>` for details.
 
 .. rubric:: Bug fixes
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -148,6 +148,10 @@ if WANT_NETWORK
 check_PROGRAMS += test/network.test
 endif
 
+if WANT_JSON
+check_PROGRAMS += test/boot_switch.test
+endif
+
 noinst_PROGRAMS = test/fakerand
 
 test_fakerand_SOURCES = test/fakerand.c
@@ -186,6 +190,11 @@ TESTS = $(check_PROGRAMS) test/rauc.t
 
 test_bootchooser_test_SOURCES = test/bootchooser.c
 test_bootchooser_test_LDADD = librauctest.la
+
+test_boot_switch_test_CFLAGS = $(AM_CFLAGS) $(JSON_GLIB_CFLAGS)
+test_boot_switch_test_LDFLAGS = $(AM_LDFLAGS) $(JSON_GLIB_LDFLAGS)
+test_boot_switch_test_SOURCES = test/boot_switch.c
+test_boot_switch_test_LDADD = librauctest.la $(JSON_GLIB_LIBS)
 
 test_bundle_test_SOURCES = test/bundle.c
 test_bundle_test_LDADD = librauctest.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ librauc_la_SOURCES = \
 	include/config_file.h \
 	include/context.h \
 	include/emmc.h \
+	include/gpt.h \
 	include/install.h \
 	include/manifest.h \
 	include/mark.h \
@@ -75,11 +76,16 @@ endif
 if WANT_NETWORK
 librauc_la_SOURCES += src/network.c include/network.h
 endif
+
+if WANT_GPT
+librauc_la_SOURCES += src/gpt.c
+endif
+
 nodist_librauc_la_SOURCES = \
 	$(gdbus_installer_generated)
 librauc_la_CFLAGS = $(AM_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 librauc_la_LDFLAGS = $(AM_LDFLAGS) $(CODE_COVERAGE_LDFLAGS)
-librauc_la_LIBADD = $(GLIB_LIBS) $(CURL_LIBS) $(OPENSSL_LIBS)
+librauc_la_LIBADD = $(GLIB_LIBS) $(CURL_LIBS) $(OPENSSL_LIBS) $(FDISK_LIBS)
 
 bin_PROGRAMS = rauc
 
@@ -269,7 +275,8 @@ AM_DISTCHECK_CONFIGURE_FLAGS = \
     --with-systemdunitdir=$$dc_install_base/$(systemdunitdir) \
     --with-dbuspolicydir=$$dc_install_base/$(dbuspolicydir) \
     --with-dbussystemservicedir=$$dc_install_base/$(dbussystemservicedir) \
-    --with-dbusinterfacesdir=$$dc_install_base/$(dbusinterfacesdir)
+    --with-dbusinterfacesdir=$$dc_install_base/$(dbusinterfacesdir) \
+    --enable-gpt
 
 CLEANFILES = $(gdbus_installer_generated) \
 	     $(nodist_systemdunit_DATA) \

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,17 @@ AS_IF([test "x$enable_json" != "xno"], [
 
 PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.1.1])
 
+AC_ARG_ENABLE([gpt],
+       AS_HELP_STRING([--enable-gpt], [Enable GPT support])
+)
+AM_CONDITIONAL([WANT_GPT], [test x$enable_gpt = xyes])
+AS_IF([test "x$enable_gpt" = "xyes"], [
+       AC_DEFINE([ENABLE_GPT], [1], [Define to 1 to enable building with GPT support])
+       PKG_CHECK_MODULES([FDISK], [fdisk >= 2.29])
+], [
+       AC_DEFINE([ENABLE_GPT], [0])
+])
+
 AC_ARG_WITH([systemdunitdir],
         AC_HELP_STRING([--with-systemdunitdir=DIR], [path to systemd service directory]),
         [],

--- a/include/gpt.h
+++ b/include/gpt.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <glib.h>
+
+#include "update_handler.h"
+
+/**
+ * Get the address and size of the inactive boot partition
+ * if a partition exists in the defined region.
+ *
+ * @param device dev path (/dev/sdX)
+ * @param partition will contain the inactive boot partition (start & size)
+ * @param region_start start address of the region, where bootpartitions are
+ * are inside
+ * @param region_size size of the region, where bootpartitions are are inside
+ * @param error return location for a GError, or NULL
+ *
+ * @return True if succeeded, False if failed
+ */
+gboolean r_gpt_switch_get_inactive_partition(const gchar *device,
+		struct boot_switch_partition *partition,
+		guint64 region_start, guint64 region_size,
+		GError **error);
+
+/**
+ * Set the boot partition in the GPT to point to the partion at address and
+ * size in partition.
+ *
+ * @param device dev path (/dev/sdX)
+ * @param partition updated boot partition (start & size)
+ * @param error return location for a GError, or NULL
+ *
+ * @return True if succeeded, False if failed
+ */
+gboolean r_gpt_switch_set_boot_partition(const gchar *device,
+		const struct boot_switch_partition *partition,
+		GError **error);

--- a/include/mbr.h
+++ b/include/mbr.h
@@ -2,10 +2,7 @@
 
 #include <glib.h>
 
-struct mbr_switch_partition {
-	guint64 start;          /* address in bytes */
-	guint64 size;           /* size in bytes */
-};
+#include "update_handler.h"
 
 /**
  * Get the address and size of the inactive boot partition
@@ -21,21 +18,8 @@ struct mbr_switch_partition {
  * @return True if succeeded, False if failed
  */
 gboolean r_mbr_switch_get_inactive_partition(const gchar *device,
-		struct mbr_switch_partition *partition,
+		struct boot_switch_partition *partition,
 		guint64 region_start, guint64 region_size,
-		GError **error);
-
-/**
- * Clear the the memory area defined in dest_partition.
- *
- * @param device dev path (/dev/mmcblkX)
- * @param dest_partition partition to be cleared (start & size) *
- * @param error return location for a GError, or NULL
- *
- * @return True if succeeded, False if failed
- */
-gboolean r_mbr_switch_clear_partition(const gchar *device,
-		const struct mbr_switch_partition *dest_partition,
 		GError **error);
 
 /**
@@ -49,5 +33,5 @@ gboolean r_mbr_switch_clear_partition(const gchar *device,
  * @return True if succeeded, False if failed
  */
 gboolean r_mbr_switch_set_boot_partition(const gchar *device,
-		const struct mbr_switch_partition *partition,
+		const struct boot_switch_partition *partition,
 		GError **error);

--- a/include/update_handler.h
+++ b/include/update_handler.h
@@ -17,3 +17,8 @@ typedef enum {
 typedef gboolean (*img_to_slot_handler) (RaucImage *image, RaucSlot *dest_slot, const gchar *hook_name, GError **error);
 
 img_to_slot_handler get_update_handler(RaucImage *mfimage, RaucSlot  *dest_slot, GError **error);
+
+struct boot_switch_partition {
+	guint64 start;          /* address in bytes */
+	guint64 size;           /* size in bytes */
+};

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -441,11 +441,12 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 			}
 			g_key_file_remove_key(key_file, groups[i], "resize", NULL);
 
-			if (g_strcmp0(slot->type, "boot-mbr-switch") == 0) {
+			if (g_strcmp0(slot->type, "boot-mbr-switch") == 0 ||
+			    g_strcmp0(slot->type, "boot-gpt-switch") == 0) {
 				slot->region_start = key_file_consume_binary_suffixed_string(key_file, groups[i],
 						"region-start", &ierror);
 				if (ierror) {
-					g_propagate_prefixed_error(error, ierror, "mandatory for boot-mbr-switch: ");
+					g_propagate_prefixed_error(error, ierror, "mandatory for %s: ", slot->type);
 					res = FALSE;
 					goto free;
 				}
@@ -453,7 +454,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 				slot->region_size = key_file_consume_binary_suffixed_string(key_file, groups[i],
 						"region-size", &ierror);
 				if (ierror) {
-					g_propagate_prefixed_error(error, ierror, "mandatory for boot-mbr-switch: ");
+					g_propagate_prefixed_error(error, ierror, "mandatory for %s: ", slot->type);
 					res = FALSE;
 					goto free;
 				}

--- a/src/gpt.c
+++ b/src/gpt.c
@@ -1,0 +1,350 @@
+#include <glib/gstdio.h>
+#include <unistd.h>
+
+#include <libfdisk/libfdisk.h>
+
+#include "gpt.h"
+#include "update_handler.h"
+
+/* partition entry in GPT partition table, the system boots from */
+#define BOOT_PARTITION_ENTRY		0
+
+static int ask_cb(struct fdisk_context *cxt, struct fdisk_ask *ask, void *data)
+{
+	switch (fdisk_ask_get_type(ask)) {
+		case FDISK_ASKTYPE_INFO:
+			g_info("libfdisk: %s", fdisk_ask_print_get_mesg(ask));
+			break;
+		case FDISK_ASKTYPE_WARNX:
+			g_warning("libfdisk: %s", fdisk_ask_print_get_mesg(ask));
+			break;
+		case FDISK_ASKTYPE_WARN:
+			g_warning("libfdisk: %s: %s", fdisk_ask_print_get_mesg(ask), strerror(fdisk_ask_print_get_errno(ask)));
+			break;
+		default:
+			break;
+	}
+	return 0;
+}
+
+static struct fdisk_context *get_context(void)
+{
+	struct fdisk_context *cxt = NULL;
+
+	fdisk_init_debug(0);
+
+	cxt = fdisk_new_context();
+	if (!cxt)
+		g_error("%s: Failed to allocate libfdisk context\n", G_STRLOC);
+
+	fdisk_disable_dialogs(cxt, 1);
+	fdisk_set_ask(cxt, ask_cb, NULL);
+
+	return cxt;
+}
+
+static gboolean check_gpt(struct fdisk_context *cxt,
+		GError **error)
+{
+	gulong grain_size, sector_size;
+
+	g_return_val_if_fail(cxt, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	grain_size = fdisk_get_grain_size(cxt);
+	sector_size = fdisk_get_sector_size(cxt);
+
+	if (grain_size < sector_size)
+		g_error("%s: libfdisk reported grain size is less than sector size", G_STRLOC);
+
+	if (fdisk_get_collision(cxt)) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Partition table collision found: %s",
+				fdisk_get_collision(cxt));
+		return FALSE;
+	}
+	if (!fdisk_is_labeltype(cxt, FDISK_DISKLABEL_GPT)) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"GPT not found");
+		return FALSE;
+	}
+	if (fdisk_gpt_is_hybrid(cxt)) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Hybrid GPT is not supported, use a protective MBR instead");
+		return FALSE;
+	}
+	if (fdisk_get_alignment_offset(cxt) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Non-zero aligment offset (%ld) is not supported",
+				fdisk_get_alignment_offset(cxt));
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean check_region(struct fdisk_context *cxt,
+		guint64 region_start, guint64 region_size,
+		GError **error)
+{
+	gboolean res = FALSE, found = FALSE;
+	guint64 grain_size, sector_size;
+	struct fdisk_table *tb = NULL;
+	struct fdisk_iter *itr = NULL;
+	struct fdisk_partition *pa = NULL;
+	fdisk_sector_t number_of_sectors;
+	fdisk_sector_t region_start_sector, region_end_sector;
+
+	g_return_val_if_fail(cxt, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	grain_size = fdisk_get_grain_size(cxt);
+	sector_size = fdisk_get_sector_size(cxt);
+	number_of_sectors = fdisk_get_nsectors(cxt);
+
+	if (region_start < 34*512 || region_size == 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Region configuration is invalid");
+		goto out;
+	}
+
+	if ((region_start % grain_size) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Region start %"G_GINT64_MODIFIER "d is not aligned to grain-size %"G_GINT64_MODIFIER "d",
+				region_start, grain_size);
+		goto out;
+	}
+
+	if ((region_size % (2 * grain_size)) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Region size %"G_GINT64_MODIFIER "d is not aligned to the double grain-size %"G_GINT64_MODIFIER "d",
+				region_size, 2 * grain_size);
+		goto out;
+	}
+
+	if (region_start / sector_size >= number_of_sectors) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Region starts beyond end of block device");
+		goto out;
+	}
+
+	if ((region_start + region_size) / sector_size >= number_of_sectors) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Region ends beyond end of block device");
+		goto out;
+	}
+
+	region_start_sector = region_start / sector_size;
+	region_end_sector = region_start_sector + region_size / sector_size - 1;
+
+	if (fdisk_get_partitions(cxt, &tb)) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Failed to get partitions");
+		goto out;
+	}
+
+	itr = fdisk_new_iter(FDISK_ITER_FORWARD);
+	if (!itr)
+		g_error("%s: Failed to allocate libfdisk iter\n", G_STRLOC);
+	while (fdisk_table_next_partition(tb, itr, &pa) == 0) {
+		fdisk_sector_t p_start_sector, p_end_sector;
+		if (!fdisk_partition_has_start(pa) ||
+		    !fdisk_partition_has_end(pa) ||
+		    !fdisk_partition_has_partno(pa))
+			g_error("%s: Invalid partition entry\n", G_STRLOC);
+
+		/* skip boot partition entry */
+		if (fdisk_partition_get_partno(pa) == BOOT_PARTITION_ENTRY) {
+			found = TRUE;
+			continue;
+		}
+
+		p_start_sector = fdisk_partition_get_start(pa);
+		p_end_sector = fdisk_partition_get_end(pa);
+
+		if (region_start_sector <= p_end_sector && p_start_sector <= region_end_sector) {
+			g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+					"Region (sectors 0x%"G_GINT64_MODIFIER "x - 0x%"G_GINT64_MODIFIER "x) overlaps "
+					"with partition %zd (sectors 0x%"G_GINT64_MODIFIER "x - 0x%"G_GINT64_MODIFIER "x)",
+					region_start_sector, region_end_sector,
+					fdisk_partition_get_partno(pa),
+					p_start_sector, p_end_sector);
+			goto out_table;
+		}
+	}
+
+	if (!found) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"No boot partition found in entry %d",
+				BOOT_PARTITION_ENTRY);
+		goto out_table;
+	}
+
+	res = TRUE;
+
+out_table:
+	fdisk_free_iter(itr);
+	fdisk_unref_table(tb);
+out:
+
+	return res;
+}
+
+gboolean r_gpt_switch_get_inactive_partition(const gchar *device,
+		struct boot_switch_partition *partition,
+		guint64 region_start, guint64 region_size,
+		GError **error)
+{
+	gboolean res = FALSE;
+	GError *ierror = NULL;
+	gulong sector_size;
+	struct fdisk_context *cxt = NULL;
+	struct fdisk_partition *pa = NULL;
+
+	g_return_val_if_fail(device, FALSE);
+	g_return_val_if_fail(partition, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	cxt = get_context();
+
+	if (fdisk_assign_device(cxt, device, 1)) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Failed to open %s with libfdisk", device);
+		goto out_cxt;
+	}
+
+	if (!check_gpt(cxt, &ierror)) {
+		g_propagate_error(error, ierror);
+		goto out_deassign;
+	}
+
+	if (!check_region(cxt, region_start, region_size, &ierror)) {
+		g_propagate_error(error, ierror);
+		goto out_deassign;
+	}
+
+	if (fdisk_get_partition(cxt, BOOT_PARTITION_ENTRY, &pa) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"No boot partition found in entry %d",
+				BOOT_PARTITION_ENTRY);
+		goto out_deassign;
+	}
+
+	sector_size = fdisk_get_sector_size(cxt);
+	if ((region_start / sector_size) ==
+	    fdisk_partition_get_start(pa)) {
+		partition->start = region_start + region_size / 2;
+	} else if (((region_start + region_size / 2) / sector_size) ==
+	           fdisk_partition_get_start(pa)) {
+		partition->start = region_start;
+	} else {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Boot partition's start address does not match "
+				"region configuration");
+		goto out_unref_part;
+	}
+	partition->size = region_size / 2;
+
+	res = TRUE;
+
+out_unref_part:
+	fdisk_unref_partition(pa);
+out_deassign:
+	fdisk_deassign_device(cxt, 0);
+out_cxt:
+	fdisk_unref_context(cxt);
+
+	return res;
+}
+
+gboolean r_gpt_switch_set_boot_partition(const gchar *device,
+		const struct boot_switch_partition *partition,
+		GError **error)
+{
+	gboolean res = FALSE;
+	GError *ierror = NULL;
+	gulong sector_size;
+	struct fdisk_context *cxt = NULL;
+	struct fdisk_label *lb = NULL;
+	struct fdisk_partition *pa = NULL;
+
+	g_return_val_if_fail(device, FALSE);
+	g_return_val_if_fail(partition, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	cxt = get_context();
+
+	if (fdisk_assign_device(cxt, device, 0)) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Failed to open %s with libfdisk", device);
+		goto out_cxt;
+	}
+
+	if (!check_gpt(cxt, &ierror)) {
+		g_propagate_error(error, ierror);
+		goto out_deassign;
+	}
+
+	lb = fdisk_get_label(cxt, NULL);
+	if (!lb)
+		g_error("%s: Failed to get libfdisk label\n", G_STRLOC);
+
+	/* Make sure both GPT copies are consistent so the actual update below
+	 * is safe against crashes. */
+	if (fdisk_label_is_changed(lb) == 1) {
+		g_message("GPT is inconsistent, repairing...\n");
+		if (fdisk_write_disklabel(cxt) != 0) {
+			g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+					"Could not repair GPT");
+			goto out_deassign;
+		}
+		g_message("GPT repaired\n");
+	}
+	if (fdisk_verify_disklabel(cxt) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Old GPT failed to verify");
+		goto out_deassign;
+	}
+
+	if (fdisk_get_partition(cxt, BOOT_PARTITION_ENTRY, &pa) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"No boot partition found in entry %d",
+				BOOT_PARTITION_ENTRY);
+		goto out_deassign;
+	}
+
+	sector_size = fdisk_get_sector_size(cxt);
+	fdisk_reset_partition(pa); /* only change the location */
+	fdisk_partition_set_start(pa, partition->start / sector_size);
+	fdisk_partition_set_size(pa, partition->size / sector_size);
+
+	if (fdisk_set_partition(cxt, BOOT_PARTITION_ENTRY, pa) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Could not update boot partition");
+		goto out_unref_part;
+	}
+
+	if (fdisk_verify_disklabel(cxt) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"New GPT failed to verify");
+		goto out_unref_part;
+	}
+	/* As we made sure that we have two copies above, we are sure to always
+	 * have at least one valid copy at any point during the update. */
+	if (fdisk_write_disklabel(cxt) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Could not write new GPT");
+		goto out_unref_part;
+	}
+
+	res = TRUE;
+
+out_unref_part:
+	fdisk_unref_partition(pa);
+out_deassign:
+	fdisk_deassign_device(cxt, 0);
+out_cxt:
+	fdisk_unref_context(cxt);
+
+	return res;
+}

--- a/src/mbr.c
+++ b/src/mbr.c
@@ -100,10 +100,17 @@ static gboolean validate_region(gint fd, guint64 start, guint64 size,
 		goto out;
 	}
 
-	if ((start % (2 * sector_size)) != 0 || (size % (2 * sector_size)) != 0) {
+	if ((start % sector_size) != 0) {
 		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
-				"Region configuration is not aligned to the double"
-				"sector-size %d", 2 * sector_size);
+				"Region start %"G_GINT64_MODIFIER "d is not aligned to the sector-size %d",
+				start, sector_size);
+		goto out;
+	}
+
+	if ((size % (2 * sector_size)) != 0) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Region size %"G_GINT64_MODIFIER "d is not aligned to the double sector-size %d",
+				size, 2 * sector_size);
 		goto out;
 	}
 

--- a/src/mbr.c
+++ b/src/mbr.c
@@ -69,20 +69,22 @@ static gboolean get_number_of_sectors(gint fd, guint *sectors,
 	return TRUE;
 }
 
-static gboolean get_hd_geometry(gint fd, struct hd_geometry *geometry,
-		GError **error)
+static void get_hd_geometry(gint fd, guint8 *heads, guint8 *sectors)
 {
-	g_return_val_if_fail(geometry, FALSE);
-	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+	struct hd_geometry geometry;
 
-	if (ioctl(fd, HDIO_GETGEO, geometry) != 0) {
-		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
-				"ioctl command 0x%04x failed: %s",
-				HDIO_GETGEO, g_strerror(errno));
-		return FALSE;
+	g_return_if_fail(heads);
+	g_return_if_fail(sectors);
+
+	if (ioctl(fd, HDIO_GETGEO, &geometry) == 0) {
+		*heads = geometry.heads;
+		*sectors = geometry.sectors;
+	} else {
+		g_message("Failed to get disk geometry, using LBA addressing: %s",
+				g_strerror(errno));
+		*heads = 255;
+		*sectors = 63;
 	}
-
-	return TRUE;
 }
 
 static gboolean validate_region(gint fd, guint64 start, guint64 size,
@@ -205,17 +207,18 @@ static gboolean is_region_free(guint64 region_start, guint64 region_size,
  *   - lower 8 bits for CYLINDER
  */
 static void get_chs(struct mbr_chs_entry *chs, guint32 lba,
-		const struct hd_geometry *geometry)
+		guint8 heads, guint8 sectors)
 {
 	g_return_if_fail(chs);
-	g_return_if_fail(geometry);
+	g_return_if_fail(heads);
+	g_return_if_fail(sectors);
 
-	chs->sector = lba % geometry->sectors + 1;
+	chs->sector = lba % sectors + 1;
 
-	lba /= geometry->sectors;
-	chs->head = lba % geometry->heads;
+	lba /= sectors;
+	chs->head = lba % heads;
 
-	lba /= geometry->heads;
+	lba /= heads;
 	chs->cylinder = lba & 0xFF;
 
 	/* Move bit 8 & 9 of cylinder to bit 6 & 7 of sector */
@@ -229,8 +232,7 @@ static gboolean get_raw_partition_entry(gint fd,
 	gboolean res = FALSE;
 	guint32 start, size;
 	guint sector_size;
-	struct hd_geometry geometry;
-	GError *ierror = NULL;
+	guint8 heads, sectors;
 
 	g_return_val_if_fail(raw_entry, FALSE);
 	g_return_val_if_fail(partition, FALSE);
@@ -245,21 +247,19 @@ static gboolean get_raw_partition_entry(gint fd,
 		goto out;
 	}
 
-	res = get_hd_geometry(fd, &geometry, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
-	}
-
 	start = partition->start / sector_size;
 	size = partition->size / sector_size;
 
 	raw_entry->partition_start_le = GUINT32_TO_LE(start);
 	raw_entry->partition_size_le = GUINT32_TO_LE(size);
 
-	get_chs(&raw_entry->chs_start, start, &geometry);
+	get_hd_geometry(fd, &heads, &sectors);
 
-	get_chs(&raw_entry->chs_end, start + size - 1, &geometry);
+	get_chs(&raw_entry->chs_start, start, heads, sectors);
+
+	get_chs(&raw_entry->chs_end, start + size - 1, heads, sectors);
+
+	res = TRUE;
 out:
 	return res;
 }

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1270,7 +1270,7 @@ static gboolean img_to_boot_mbr_switch_handler(RaucImage *image, RaucSlot *dest_
 		goto out;
 	}
 
-	g_message("Setting MBR to switch boot partitions");
+	g_message("Setting MBR to switch boot partition");
 
 	res = r_mbr_switch_set_boot_partition(dest_slot->device, &dest_partition, &ierror);
 	if (!res) {

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1551,8 +1551,11 @@ RaucUpdatePair updatepairs[] = {
 	{"*.squashfs", "ubivol", img_to_ubivol_handler},
 #if ENABLE_EMMC_BOOT_SUPPORT == 1
 	{"*.img", "boot-emmc", img_to_boot_emmc_handler},
+	{"*", "boot-emmc", NULL},
 #endif
 	{"*.vfat", "boot-mbr-switch", img_to_boot_mbr_switch_handler},
+	{"*.img", "boot-mbr-switch", img_to_boot_mbr_switch_handler},
+	{"*", "boot-mbr-switch", NULL},
 	{"*.img", "*", img_to_raw_handler}, /* fallback */
 	{0}
 };
@@ -1570,7 +1573,7 @@ img_to_slot_handler get_update_handler(RaucImage *mfimage, RaucSlot *dest_slot, 
 
 	g_message("Checking image type for slot type: %s", dest);
 
-	for (RaucUpdatePair *updatepair = updatepairs; updatepair->handler != NULL; updatepair++) {
+	for (RaucUpdatePair *updatepair = updatepairs; updatepair->src != NULL; updatepair++) {
 		if (g_pattern_match_simple(updatepair->src, src) &&
 		    g_pattern_match_simple(updatepair->dest, dest)) {
 			g_message("Image detected as type: %s", updatepair->src);

--- a/test/boot_switch.c
+++ b/test/boot_switch.c
@@ -1,0 +1,523 @@
+#include <locale.h>
+#include <glib.h>
+#include <gio/gio.h>
+#include <glib/gstdio.h>
+#include <json-glib/json-glib.h>
+
+#include "update_handler.h"
+#include "manifest.h"
+#include "common.h"
+#include "context.h"
+#include "mount.h"
+
+typedef struct {
+	gchar *tmpdir;
+} BootSwitchFixture;
+
+#define BIT(nr) (1UL << (nr))
+typedef enum {
+	BOOT_SWITCH_DEFAULT       = 0,
+	BOOT_SWITCH_EXPECT_FAIL   = BIT(0),
+	BOOT_SWITCH_MBR           = BIT(1),
+	BOOT_SWITCH_GPT           = BIT(2),
+	BOOT_SWITCH_WRITE_FIRST   = BIT(3),
+	BOOT_SWITCH_WRITE_SECOND  = BIT(4),
+} BootSwitchTestParams;
+
+typedef struct {
+	// whether test is expected to be successful
+	BootSwitchTestParams params;
+	GQuark err_domain;
+	gint err_code;
+
+	// slot type to test
+	const gchar *slottype;
+
+	// sfdisk dump for setup
+	const gchar *sfdisk_setup;
+
+	// sfdisk json to check against
+	const gchar *sfdisk_expect;
+} BootSwitchData;
+
+#define IMAGE_SIZE (1*1024*1024)
+
+// from 1MiB to 7MiB (2*3MiB)
+#define REGION_START (1024*1024*1)
+#define REGION_SIZE (1024*1024*6)
+
+#define PART_SIZE (REGION_SIZE/2)
+#define PART_A_START (REGION_START)
+#define PART_B_START (REGION_START + PART_SIZE)
+
+static gchar *sfdisk_get(const gchar *device)
+{
+	GSubprocess *sub;
+	GError *error = NULL;
+	GBytes *stdout_buf = NULL;
+	gsize size;
+	gboolean res = FALSE;
+
+	sub = g_subprocess_new(
+			G_SUBPROCESS_FLAGS_STDOUT_PIPE,
+			&error,
+			"sfdisk",
+			"--json",
+			device,
+			NULL);
+	g_assert_no_error(error);
+	g_assert_nonnull(sub);
+
+	res = g_subprocess_communicate(sub, NULL, NULL, &stdout_buf, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	res = g_subprocess_wait_check(sub, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	return g_bytes_unref_to_data(stdout_buf, &size);
+}
+
+static void sfdisk_check(const gchar *device, const gchar *expected)
+{
+	g_autofree gchar *found = sfdisk_get(device);
+	g_autoptr(JsonNode) j_expected = NULL;
+	g_autoptr(JsonNode) j_found = NULL;
+	gboolean equal;
+	GError *error = NULL;
+	JsonObject *document, *partitiontable;
+	JsonArray *partitions;
+
+	j_expected = json_from_string(expected, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(j_expected);
+
+	j_found = json_from_string(found, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(j_found);
+
+	document = json_node_get_object(j_found);
+	g_assert_nonnull(document);
+	partitiontable = json_object_get_object_member(document, "partitiontable");
+	g_assert_nonnull(partitiontable);
+
+	/* versions of libfdisk/util-linux since 2.35 have a sectorsize member */
+	if (json_object_has_member(partitiontable, "sectorsize")) {
+		guint64 sectorsize = json_object_get_int_member(partitiontable, "sectorsize");
+		g_assert_cmpint(sectorsize, ==, 512);
+		json_object_remove_member(partitiontable, "sectorsize");
+	}
+
+	/* remove device names before comparison */
+	json_object_remove_member(partitiontable, "device");
+	partitions = json_object_get_array_member(partitiontable, "partitions");
+	g_assert_nonnull(partitions);
+	for (guint i = 0; i < json_array_get_length(partitions); i++) {
+		JsonObject *partition = json_array_get_object_element(partitions, i);
+		json_object_remove_member(partition, "node");
+	}
+
+	equal = json_node_equal(j_found, j_expected);
+	if (!equal) {
+		g_message("not equal:\nfound=%s\nexpected=%s",
+				json_to_string(j_found, TRUE),
+				json_to_string(j_expected, TRUE));
+	}
+	g_assert_true(equal);
+}
+
+static void sfdisk_set(const gchar *device, const gchar *dump)
+{
+	GSubprocess *sub;
+	GError *error = NULL;
+	g_autoptr(GBytes) stdin_buf = NULL;
+	gboolean res = FALSE;
+
+	stdin_buf = g_bytes_new(dump, strlen(dump));
+
+	sub = g_subprocess_new(
+			G_SUBPROCESS_FLAGS_STDIN_PIPE,
+			&error,
+			"sfdisk",
+			device,
+			NULL);
+	g_assert_no_error(error);
+	g_assert_nonnull(sub);
+
+	res = g_subprocess_communicate(sub, stdin_buf, NULL, NULL, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	res = g_subprocess_wait_check(sub, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+}
+
+static void swap_marker(const gchar *device, goffset offset, guint64 *marker)
+{
+	GError *error = NULL;
+	g_autoptr(GFile) file = NULL;
+	g_autoptr(GFileIOStream) stream = NULL;
+	guint64 old_marker;
+	gboolean res;
+
+	file = g_file_new_for_path(device);
+	stream = g_file_open_readwrite(file, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(stream);
+
+	res = g_seekable_seek(G_SEEKABLE(stream), offset, G_SEEK_SET, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	res = g_input_stream_read_all(
+			g_io_stream_get_input_stream(G_IO_STREAM(stream)),
+			&old_marker,
+			sizeof(old_marker), NULL, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	res = g_seekable_seek(G_SEEKABLE(stream), offset, G_SEEK_SET, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	res = g_output_stream_write_all(
+			g_io_stream_get_output_stream(G_IO_STREAM(stream)),
+			marker, sizeof(*marker), NULL, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	*marker = old_marker;
+}
+
+static guint64 get_marker(const gchar *device, goffset offset)
+{
+	GError *error = NULL;
+	g_autoptr(GFile) file = NULL;
+	g_autoptr(GFileIOStream) stream = NULL;
+	guint64 found_marker;
+	gboolean res;
+
+	file = g_file_new_for_path(device);
+	stream = g_file_open_readwrite(file, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(stream);
+
+	res = g_seekable_seek(G_SEEKABLE(stream), offset, G_SEEK_SET, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	res = g_input_stream_read_all(
+			g_io_stream_get_input_stream(G_IO_STREAM(stream)),
+			&found_marker,
+			sizeof(found_marker), NULL, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	return found_marker;
+}
+
+
+static void clear_device(const gchar *device)
+{
+	GError *error = NULL;
+	g_autoptr(GFile) file = NULL;
+	g_autoptr(GFileIOStream) stream = NULL;
+	gchar buf[4096] = {0};
+	guint64 size;
+	gboolean res;
+
+	file = g_file_new_for_path(device);
+	stream = g_file_open_readwrite(file, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(stream);
+
+	res = g_seekable_seek(G_SEEKABLE(stream), 0, G_SEEK_END, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+	size = g_seekable_tell(G_SEEKABLE(stream));
+	res = g_seekable_seek(G_SEEKABLE(stream), 0, G_SEEK_SET, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	while (size) {
+		gsize bytes_to_write = size < sizeof(buf) ? size : sizeof(buf);
+		gsize bytes_written;
+		res = g_output_stream_write_all(
+				g_io_stream_get_output_stream(G_IO_STREAM(stream)), buf,
+				bytes_to_write, &bytes_written, NULL, &error);
+		g_assert_no_error(error);
+		g_assert_true(res);
+
+		size -= bytes_written;
+	}
+}
+
+static void boot_switch_fixture_set_up(BootSwitchFixture *fixture,
+		gconstpointer user_data)
+{
+	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+	g_assert_nonnull(fixture->tmpdir);
+}
+
+static void boot_switch_fixture_tear_down(BootSwitchFixture *fixture,
+		gconstpointer user_data)
+{
+	if (!fixture->tmpdir)
+		return;
+
+	g_assert(test_rmdir(fixture->tmpdir, "") == 0);
+}
+
+static void test_boot_switch(BootSwitchFixture *fixture,
+		gconstpointer user_data)
+{
+	BootSwitchData *data = (BootSwitchData*) user_data;
+	gchar *slotpath, *imagename, *imagepath, *mountprefix, *hookpath = NULL;
+	RaucImage *image;
+	RaucSlot *targetslot;
+	img_to_slot_handler handler;
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+	guint64 marker;
+
+	enum {
+		M_IMAGE_START = 0x21d5c63ddf5203f3,
+		M_PART_A_START = 0x53ab9efa71294261,
+		M_PART_A_END = 0x182059db7361c8af,
+		M_PART_B_START = 0x242a93c66b47f053,
+		M_PART_B_END = 0x1fdc54fe25d81ac5,
+	};
+
+	/* needs to run as root */
+	if (!test_running_as_root())
+		return;
+
+	/* prepare image and slot information */
+	imagename = g_strdup("image.img");
+	slotpath = g_strdup(g_getenv("RAUC_TEST_BLOCK_LOOP"));
+	imagepath = g_build_filename(fixture->tmpdir, imagename, NULL);
+
+	if (!slotpath) {
+		g_test_message("no block device for testing found (define RAUC_TEST_BLOCK_LOOP)");
+		g_test_skip("RAUC_TEST_BLOCK_LOOP undefined");
+	}
+	clear_device(slotpath);
+
+	/* create source image */
+	image = g_new0(RaucImage, 1);
+	image->slotclass = g_strdup("rootfs");
+	image->filename = g_strdup(imagepath);
+	image->checksum.size = IMAGE_SIZE;
+	image->checksum.digest = g_strdup("0xdeadbeef");
+
+	g_assert(test_prepare_dummy_file(fixture->tmpdir, imagename,
+			IMAGE_SIZE, "/dev/zero") == 0);
+
+	/* create marker in source image */
+	marker = M_IMAGE_START;
+	swap_marker(imagepath, 0, &marker);
+	g_assert_cmphex(marker, ==, 0x0);
+
+	/* create target slot */
+	targetslot = g_new0(RaucSlot, 1);
+	targetslot->name = g_strdup("bootloader.0");
+	targetslot->sclass = g_strdup("bootloader");
+	targetslot->device = g_strdup(slotpath);
+	targetslot->type = g_strdup(data->slottype);
+	targetslot->region_start = REGION_START;
+	targetslot->region_size = REGION_SIZE;
+	targetslot->state = ST_INACTIVE;
+
+	/* Set mount path to current temp dir */
+	mountprefix = g_build_filename(fixture->tmpdir, "testmount", NULL);
+	g_assert_nonnull(mountprefix);
+	r_context_conf()->mountprefix = mountprefix;
+	r_context();
+	g_assert(g_mkdir(mountprefix, 0777) == 0);
+
+	/* prepare partitions */
+	sfdisk_set(slotpath, data->sfdisk_setup);
+
+	/* prepare marks in block device */
+	marker = M_PART_A_START;
+	swap_marker(slotpath, PART_A_START, &marker);
+	g_assert_cmphex(marker, ==, 0x0);
+	marker = M_PART_A_END;
+	swap_marker(slotpath, PART_A_START + PART_SIZE - 8, &marker);
+	g_assert_cmphex(marker, ==, 0x0);
+	marker = M_PART_B_START;
+	swap_marker(slotpath, PART_B_START, &marker);
+	g_assert_cmphex(marker, ==, 0x0);
+	marker = M_PART_B_END;
+	swap_marker(slotpath, PART_B_START + PART_SIZE - 8, &marker);
+	g_assert_cmphex(marker, ==, 0x0);
+
+	/* get handler for this */
+	handler = get_update_handler(image, targetslot, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_nonnull(handler);
+
+	/* Run to perform an update */
+	res = handler(image, targetslot, hookpath, &ierror);
+
+	if (data->params & BOOT_SWITCH_EXPECT_FAIL) {
+		g_assert_error(ierror, data->err_domain, data->err_code);
+		g_assert_false(res);
+		goto out;
+	} else {
+		g_assert_no_error(ierror);
+		g_assert_true(res);
+	}
+
+	/* check partitions */
+	sfdisk_check(slotpath, data->sfdisk_expect);
+
+	/* check marks */
+	if (data->params & BOOT_SWITCH_WRITE_FIRST) {
+		g_assert_cmphex(get_marker(slotpath, PART_A_START), ==, M_IMAGE_START); /* should contain the image */
+		g_assert_cmphex(get_marker(slotpath, PART_A_START + PART_SIZE - 8), ==, 0x0); /* should be cleared */
+		g_assert_cmphex(get_marker(slotpath, PART_B_START), ==, M_PART_B_START); /* should not be overwritten */
+		g_assert_cmphex(get_marker(slotpath, PART_B_START + PART_SIZE - 8), ==, M_PART_B_END); /* should not be overwritten */
+	} else if (data->params & BOOT_SWITCH_WRITE_SECOND) {
+		g_assert_cmphex(get_marker(slotpath, PART_A_START), ==, M_PART_A_START); /* should not be overwritten */
+		g_assert_cmphex(get_marker(slotpath, PART_A_START + PART_SIZE - 8), ==, M_PART_A_END); /* should not be overwritten */
+		g_assert_cmphex(get_marker(slotpath, PART_B_START), ==, M_IMAGE_START); /* should contain the image */
+		g_assert_cmphex(get_marker(slotpath, PART_B_START + PART_SIZE - 8), ==, 0x0); /* should be cleared */
+	}
+
+out:
+	/* clean up source image */
+	g_assert(g_remove(imagepath) == 0);
+
+	g_rmdir(mountprefix);
+
+	g_free(slotpath);
+	g_free(imagename);
+	g_free(imagepath);
+	g_clear_pointer(&hookpath, g_free);
+	g_free(mountprefix);
+	r_free_image(image);
+	r_slot_free(targetslot);
+}
+
+#define R_QUOTE(...) #__VA_ARGS__
+int main(int argc, char *argv[])
+{
+	BootSwitchData *data;
+
+	setlocale(LC_ALL, "C");
+
+	g_test_init(&argc, &argv, NULL);
+
+	data = &(BootSwitchData) {
+		.params = BOOT_SWITCH_MBR | BOOT_SWITCH_WRITE_SECOND,
+		.err_domain = 0, .err_code = 0,
+		.slottype = "boot-mbr-switch",
+		.sfdisk_setup =
+			"label: dos\n"
+			"label-id: 0x8b9e754a\n"
+			"unit: sectors\n"
+			"\n"
+			"start=        2048, size=        6144, type=ef, bootable\n"
+			"start=       14336, size=       65536, type=83\n"
+			"start=       79872, size=           1, type=5\n"
+			"start=       81920, size=       49152, type=82\n"
+		,
+		.sfdisk_expect = R_QUOTE({
+			/* *INDENT-OFF* */
+			"partitiontable" : {
+				"label" : "dos",
+				"id" : "0x8b9e754a",
+				"unit" : "sectors",
+				"partitions" : [
+				{
+					"start" : 8192,
+					"size" : 6144,
+					"type" : "ef",
+					"bootable" : true
+				},
+				{
+					"start" : 14336,
+					"size" : 65536,
+					"type" : "83"
+				},
+				{
+					"start" : 79872,
+					"size" : 1,
+					"type" : "5"
+				},
+				{
+					"start" : 81920,
+					"size" : 49152,
+					"type" : "82"
+				}
+				]
+			}
+			/* *INDENT-ON* */
+		}),
+	};
+	g_test_add("/boot_switch/mbr/active-first",
+			BootSwitchFixture,
+			data,
+			boot_switch_fixture_set_up,
+			test_boot_switch,
+			boot_switch_fixture_tear_down);
+
+	data = &(BootSwitchData) {
+		.params = BOOT_SWITCH_MBR | BOOT_SWITCH_WRITE_FIRST,
+		.err_domain = 0, .err_code = 0,
+		.slottype = "boot-mbr-switch",
+		.sfdisk_setup =
+			"label: dos\n"
+			"label-id: 0x8b9e754a\n"
+			"unit: sectors\n"
+			"\n"
+			"start=        8192, size=        6144, type=ef, bootable\n"
+			"start=       14336, size=       65536, type=83\n"
+			"start=       79872, size=           1, type=5\n"
+			"start=       81920, size=       49152, type=82\n"
+		,
+		.sfdisk_expect = R_QUOTE({
+			/* *INDENT-OFF* */
+			"partitiontable" : {
+				"label" : "dos",
+				"id" : "0x8b9e754a",
+				"unit" : "sectors",
+				"partitions" : [
+				{
+					"start" : 2048,
+					"size" : 6144,
+					"type" : "ef",
+					"bootable" : true
+				},
+				{
+					"start" : 14336,
+					"size" : 65536,
+					"type" : "83"
+				},
+				{
+					"start" : 79872,
+					"size" : 1,
+					"type" : "5"
+				},
+				{
+					"start" : 81920,
+					"size" : 49152,
+					"type" : "82"
+				}
+				]
+			}
+			/* *INDENT-ON* */
+		}),
+	};
+	g_test_add("/boot_switch/mbr/active-second",
+			BootSwitchFixture,
+			data,
+			boot_switch_fixture_set_up,
+			test_boot_switch,
+			boot_switch_fixture_tear_down);
+
+	return g_test_run();
+}

--- a/test/boot_switch.c
+++ b/test/boot_switch.c
@@ -519,5 +519,115 @@ int main(int argc, char *argv[])
 			test_boot_switch,
 			boot_switch_fixture_tear_down);
 
+#if ENABLE_GPT == 1
+	data = &(BootSwitchData) {
+		.params = BOOT_SWITCH_GPT | BOOT_SWITCH_WRITE_SECOND,
+		.err_domain = 0, .err_code = 0,
+		.slottype = "boot-gpt-switch",
+		.sfdisk_setup =
+			"label: gpt\n"
+			"label-id: 823CC890-4129-584D-9BD9-ED291FD87CDA\n"
+			"unit: sectors\n"
+			"first-lba: 2048\n"
+			"last-lba: 131038\n"
+			"\n"
+			"start=        2048, size=        6144, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, uuid=0C25253D-6578-2C47-8C3C-8E03EED3141B\n"
+			"start=       14336, size=       65536, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, uuid=3C97736F-F91A-F641-BF0D-A8C71DEBABBD\n"
+			"start=       79872, size=       32768, type=0657FD6D-A4AB-43C4-84E5-0933C84B4F4F, uuid=29836434-34FB-0744-AB30-9BD2F0D7C383\n"
+		,
+		.sfdisk_expect = R_QUOTE({
+			/* *INDENT-OFF* */
+			"partitiontable" : {
+				"label" : "gpt",
+				"id" : "823CC890-4129-584D-9BD9-ED291FD87CDA",
+				"unit" : "sectors",
+				"firstlba" : 2048,
+				"lastlba" : 131038,
+				"partitions" : [
+				{
+					"start" : 8192,
+					"size" : 6144,
+					"type" : "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+					"uuid" : "0C25253D-6578-2C47-8C3C-8E03EED3141B"
+				},
+				{
+					"start" : 14336,
+					"size" : 65536,
+					"type" : "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+					"uuid" : "3C97736F-F91A-F641-BF0D-A8C71DEBABBD"
+				},
+				{
+					"start" : 79872,
+					"size" : 32768,
+					"type" : "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F",
+					"uuid" : "29836434-34FB-0744-AB30-9BD2F0D7C383"
+				}
+				]
+			}
+			/* *INDENT-ON* */
+		}),
+	};
+	g_test_add("/boot_switch/gpt/active-first",
+			BootSwitchFixture,
+			data,
+			boot_switch_fixture_set_up,
+			test_boot_switch,
+			boot_switch_fixture_tear_down);
+
+	data = &(BootSwitchData) {
+		.params = BOOT_SWITCH_GPT | BOOT_SWITCH_WRITE_FIRST,
+		.err_domain = 0, .err_code = 0,
+		.slottype = "boot-gpt-switch",
+		.sfdisk_setup =
+			"label: gpt\n"
+			"label-id: 823CC890-4129-584D-9BD9-ED291FD87CDA\n"
+			"unit: sectors\n"
+			"first-lba: 2048\n"
+			"last-lba: 131038\n"
+			"\n"
+			"start=        8192, size=        6144, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, uuid=0C25253D-6578-2C47-8C3C-8E03EED3141B\n"
+			"start=       14336, size=       65536, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, uuid=3C97736F-F91A-F641-BF0D-A8C71DEBABBD\n"
+			"start=       79872, size=       32768, type=0657FD6D-A4AB-43C4-84E5-0933C84B4F4F, uuid=29836434-34FB-0744-AB30-9BD2F0D7C383\n"
+		,
+		.sfdisk_expect = R_QUOTE({
+			/* *INDENT-OFF* */
+			"partitiontable" : {
+				"label" : "gpt",
+				"id" : "823CC890-4129-584D-9BD9-ED291FD87CDA",
+				"unit" : "sectors",
+				"firstlba" : 2048,
+				"lastlba" : 131038,
+				"partitions" : [
+				{
+					"start" : 2048,
+					"size" : 6144,
+					"type" : "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+					"uuid" : "0C25253D-6578-2C47-8C3C-8E03EED3141B"
+				},
+				{
+					"start" : 14336,
+					"size" : 65536,
+					"type" : "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+					"uuid" : "3C97736F-F91A-F641-BF0D-A8C71DEBABBD"
+				},
+				{
+					"start" : 79872,
+					"size" : 32768,
+					"type" : "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F",
+					"uuid" : "29836434-34FB-0744-AB30-9BD2F0D7C383"
+				}
+				]
+			}
+			/* *INDENT-ON* */
+		}),
+	};
+	g_test_add("/boot_switch/gpt/active-second",
+			BootSwitchFixture,
+			data,
+			boot_switch_fixture_set_up,
+			test_boot_switch,
+			boot_switch_fixture_tear_down);
+#endif
+
 	return g_test_run();
 }


### PR DESCRIPTION
This adds support for atomic update of bootloaders in the first GPT partitions (such as the ESP), similar to what we already support for MBR (via boot-mbr-switch).

The PR also adds support for testing of both boot-switch methods in qemu on a loopback device.