### PR TITLE
src/update_handler: set RAUC_SLOT_BOOTNAME for child slots too

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -643,6 +643,10 @@ The following environment variables will be passed to the hook executable:
   ``RAUC_SLOT_BOOTNAME``
     For slots with a bootname (those that can be selected by the bootloader),
     the bootname of the currently installed slot, e.g. ``"system1"``
+    For slots with a parent, the parent's bootname is used.
+    Note that in many cases, it's better to use the explicit ``RAUC_SLOT_NAME``
+    to select different behaviour in the hook, than to rely indirectly on the
+    bootname.
 
   ``RAUC_SLOT_PARENT``
     If set, the parent of the currently installed slot, e.g. ``"rootfs.1"``

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -738,7 +738,11 @@ static gboolean run_slot_hook(const gchar *hook_name, const gchar *hook_cmd, Rau
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_CLASS", slot->sclass, TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_TYPE", slot->type, TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_DEVICE", slot->device, TRUE);
-	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_BOOTNAME", slot->bootname ?: "", TRUE);
+	if (slot->parent) {
+		g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_BOOTNAME", slot->parent->bootname ?: "", TRUE);
+	} else {
+		g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_BOOTNAME", slot->bootname ?: "", TRUE);
+	}
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_PARENT", slot->parent ? slot->parent->name : "", TRUE);
 	if (slot->mount_point) {
 		g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_MOUNT_POINT", slot->mount_point, TRUE);

--- a/test/install-content/hook.sh
+++ b/test/install-content/hook.sh
@@ -21,6 +21,7 @@ case "$1" in
 		test -n "$RAUC_SLOT_NAME" || die_error "missing RAUC_SLOT_NAME"
 		test -n "$RAUC_SLOT_CLASS" || die_error "missing RAUC_SLOT_CLASS"
 		test -n "$RAUC_SLOT_TYPE" || die_error "missing RAUC_SLOT_TYPE"
+		test -n "$RAUC_SLOT_BOOTNAME" || die_error "missing RAUC_SLOT_BOOTNAME"
 
 		# only rootfs needs to be handled
 		test "$RAUC_SLOT_CLASS" = "rootfs" || exit 0
@@ -34,6 +35,7 @@ case "$1" in
 		test -n "$RAUC_SLOT_NAME" || die_error "missing RAUC_SLOT_NAME"
 		test -n "$RAUC_SLOT_CLASS" || die_error "missing RAUC_SLOT_CLASS"
 		test -n "$RAUC_SLOT_TYPE" || die_error "missing RAUC_SLOT_TYPE"
+		test -n "$RAUC_SLOT_BOOTNAME" || die_error "missing RAUC_SLOT_BOOTNAME"
 
 		echo "RAUC_IMAGE_PATH: $RAUC_IMAGE_PATH"
 		echo "RAUC_SLOT_DEVICE: $RAUC_SLOT_DEVICE"


### PR DESCRIPTION
Otherwise it is tempting to try and set the bootname on the child slots too, as in #588.