### PR TITLE
improve testing of NAND and UBIFS slots

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,7 @@ Running the Test Suite
 
     sudo apt-get install qemu-system-x86 time squashfs-tools
     # Optional to run all tests:
-    # sudo apt-get install faketime casync grub-common softhsm2 opensc opensc-pkcs11 libengine-pkcs11-openssl
+    # sudo apt-get install faketime casync grub-common softhsm2 opensc opensc-pkcs11 libengine-pkcs11-openssl mtd-utils
     make check
     ./qemu-test
 

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -9,10 +9,14 @@ mount -t sysfs none /sys
 mount -t tmpfs none /mnt
 mount -t tmpfs none /tmp
 
+MAKE_TARGET="check"
+
 # parse cmdline
 for x in $(cat /proc/cmdline); do
   if [ "$x" = "shell" ]; then
     SHELL=1
+  elif [ "$x" = "coverage" ]; then
+    MAKE_TARGET="check-code-coverage"
   fi
 done
 
@@ -76,7 +80,7 @@ if [ -n "$SHELL" ]; then
   echo o > /proc/sysrq-trigger
 fi
 
-if make check; then
+if make $MAKE_TARGET; then
   touch qemu-test-ok
 else
   cat test-suite.log || true

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -64,13 +64,15 @@ if type losetup; then
   export RAUC_TEST_BLOCK_LOOP=/dev/loop0
 fi
 
-if [ -c /dev/mtd2 ]; then
+if [ -c /dev/mtd2 ] && type flash_erase; then
   export RAUC_TEST_MTD_NAND=/dev/mtd2
 fi
 
 if [ -c /dev/mtd3 ] && type ubiattach; then
   ubiattach -m 3 -d 0
+  ubimkvol /dev/ubi0 -s 12096KiB -N rauc-test
   export RAUC_TEST_MTD_UBI=/dev/ubi0
+  export RAUC_TEST_MTD_UBIVOL=/dev/ubi0_0
 fi
 
 echo "system ready"

--- a/uncrustify.sh
+++ b/uncrustify.sh
@@ -8,4 +8,4 @@ if [ ! -e .uncrustify/build/uncrustify ]; then
 	./build-uncrustify.sh
 fi
 
-.uncrustify/build/uncrustify -c .uncrustify.cfg -l C --replace src/*.c include/*.h test/*.[ch] contrib/cgi/src/*.[ch]
+.uncrustify/build/uncrustify -c .uncrustify.cfg -l C --replace --no-backup src/*.c include/*.h test/*.[ch] contrib/cgi/src/*.[ch]


### PR DESCRIPTION
With some additional setup in qemu, we can start testing these update_handlers.