### PR TITLE
docs: integration: refer to PTXdist's new "Managing CA Keyrings" section

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -39,6 +39,8 @@ be useful as an example for creating your own PKI.
 In the following sections, general CA configuration, some use-cases and
 corresponding PKI setups are described.
 
+.. _sec-ca-configuration:
+
 CA Configuration
 ~~~~~~~~~~~~~~~~
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -1088,6 +1088,9 @@ RAUC package install it into the rootfs you build.
 
 .. note:: PTXdist versions since 2020.06.0 use their `code signing infrastructure
   <ptxdist-code-signing_>`_ for keyring creation.
+  See PTXdist's `Managing Certificate Authority Keyrings
+  <ptxdist-manage-ca-keyrings_>`_ for different scenarios (refer to RAUC's
+  :ref:`sec-ca-configuration`).
   Previous PTXdist versions expected the keyring in
   ``$(PTXDIST_PLATFORMCONFIGDIR)/projectroot/etc/rauc/ca.cert.pem``.
   The keyring is installed into the rootfs to ``/etc/rauc/ca.cert.pem``.
@@ -1102,6 +1105,7 @@ bootloader that is decremented before starting the system and reset by
 `rauc status mark-good` to indicate a successful system startup.
 
 .. _ptxdist-code-signing: https://www.ptxdist.org/doc/dev_code_signing.html
+.. _ptxdist-manage-ca-keyrings: https://www.ptxdist.org/doc/dev_code_signing.html#managing-certificate-authority-keyrings
 
 Create Update Bundles from your RootFS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This should help people migrating from a CA keyring file to the code signing infrastructure as well as people with simple and more complex PKI cases.

Note: to make the link work the [corresponding documentation patch](https://www.mail-archive.com/ptxdist@pengutronix.de/msg16496.html) has to be applied in PTXdist.

Improves #599.