### PR TITLE
src/mbr: fix r_mbr_switch_set_boot_partition() error paths

### DIFF
--- a/src/mbr.c
+++ b/src/mbr.c
@@ -428,6 +428,7 @@ gboolean r_mbr_switch_set_boot_partition(const gchar *device,
 	if (lseek(fd, 0, SEEK_SET) != 0) {
 		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
 				"Failed to seek to position 0");
+		res = FALSE;
 		goto out;
 	}
 
@@ -435,6 +436,7 @@ gboolean r_mbr_switch_set_boot_partition(const gchar *device,
 		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
 				"Could not write new MBR: %s",
 				g_strerror(errno));
+		res = FALSE;
 		goto out;
 	}
 


### PR DESCRIPTION
res variable will be set to true by the previous call of
`get_raw_partition_entry()`. Thus only setting the error and going to
'out' will result in accidentally returning TRUE in case of failures of
`lseek()` or `write()` call.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>