### PR TITLE
src/update_handler: use 256 byte inodes for ext4 by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,12 @@ Release 1.4 (development)
 
 .. rubric:: Enhancements
 
+* Changed ext4 filesystem creation options to always use 256 byte inodes.
+  Without it, mkfs.ext4 will default to 128 byte inodes on filesystems smaller
+  than 512MiB.
+  This avoids the "ext4 filesystem being mounted at /foo supports timestamps
+  until 2038" message on newer kernels.
+
 .. rubric:: Bug fixes
 
 .. rubric:: Testing

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -454,6 +454,7 @@ static gboolean ext4_format_slot(RaucSlot *dest_slot, GError **error)
 		g_ptr_array_add(args, g_strdup("-L"));
 		g_ptr_array_add(args, g_strdup(dest_slot->name));
 	}
+	g_ptr_array_add(args, g_strdup("-I256"));
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 

--- a/test/common.c
+++ b/test/common.c
@@ -217,6 +217,7 @@ gboolean test_make_filesystem(const gchar *dirname, const gchar *filename)
 			&error,
 			"/sbin/mkfs.ext4",
 			"-F",
+			"-I256",
 			path,
 			NULL);
 


### PR DESCRIPTION
By default, mkfs.ext4 will use 128 byte inodes on filesystems < 512MB. As those don't have enough space for longer timestamps, newer kernels complain with "ext4 filesystem being mounted at /foo supports timestamps until 2038".

Avoid this by specifying 256 bytes, which is already the default for larger filesystems. Also adjust the mkfs.ext4 call in the test suite. This option is supported since e2fsprogs v1.40 (released in 2007) and busybox 1.16.0 (released in 2010).