### PR TITLE
Fixes and open points for custom bootloader interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,10 @@ Release 1.4 (development)
 
 .. rubric:: Enhancements
 
+* Added support for custom boot selection scripts/binaries
+  This allows handling special cases where none of the standard bootloaders
+  is available for switching the redundant slots (by Christian Bräuner
+  Sørensen, Andreas Schmidt (docs))
 * Changed ext4 filesystem creation options to always use 256 byte inodes.
   Without it, mkfs.ext4 will default to 128 byte inodes on filesystems smaller
   than 512MiB.

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ Features
   * `barebox <http://barebox.org/>`_
   * `u-boot <http://www.denx.de/wiki/U-Boot>`_
   * `EFI <https://de.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface>`_
+  * Custom implementation
 * Storage support:
 
   * ext4 filesystem
@@ -95,6 +96,7 @@ Target Requirements
   * Barebox: State partition on EEPROM/FRAM/MRAM or NAND flash
   * U-Boot: environment variable
   * EFI: EFI variables
+  * Custom: depends on implementation
 * Boot target selection support in the bootloader
 * Enough mass storage for two symmetric/asymmetric/custom slots
 * For normal bundle mode:

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -890,27 +890,29 @@ RAUC to trigger the following actions:
 * set the boot state
 
 To get the primary slot, the handler is called with the argument ``get-primary``.
-The handler must output the current primary slot on the `stdout`,
+The handler must output the current primary slot's bootname on the `stdout`,
 and return ``0`` on exit, if no error occurred.
 In case of failure, the handler must return with non-zero value.
 Accordingly, in order to set the primary slot,
-the custom bootloader handler is called with argument ``set-primary <slot.name>``.
-The ``<slot.name>`` must match one of the slots defined in your `system.conf`.
+the custom bootloader handler is called with argument ``set-primary <slot.bootname>``
+where ``<slot.bootname>`` matches the ``bootname=`` key defined for the
+respective slot in your `system.conf`.
 If the set was successful, the handler must also return with a ``0``,
-otherwise the return value must non-zero.
+otherwise the return value must be non-zero.
 
 In addition to the primary slot,
 RAUC must also be able to determine the boot state of a specific slot.
 RAUC determines the necessary boot state by calling the custom bootloader
-handler with the argument ``get-state <slot.name>``. 
+handler with the argument ``get-state <slot.bootname>``.
 Whereupon the handler has to output the state ``good`` or ``bad`` to `stdout`
 and exit with the return value ``0``.
 If the state cannot be determined or another error occurs,
 the custom bootloader handler must exit with non-zero return value.
 To set the boot state to the desire slot,
-the handler is called with argument ``set-state <slot.name> <state>``.
+the handler is called with argument ``set-state <slot.bootname> <state>``.
 As already mentioned in the paragraph above,
-the ``<slot.name>`` must match one of the slots defined in your `system.conf`.
+the ``<slot.bootname>`` matches the ``bootname=`` key defined for the
+respective slot in your `system.conf`.
 The ``<state>`` argument corresponds to one of the following values:
 
 * ``good`` if the last start of the slot was successful or

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -876,7 +876,7 @@ To register the custom bootloader backend handler, assign your handler to the
 
   [handlers]
   ...
-  bootloader-custom-backed=custom-bootloader-script
+  bootloader-custom-backend=custom-bootloader-script
 
 Custom bootloader backend interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1408,7 +1408,7 @@ static gboolean custom_backend_get(const gchar *cmd, const gchar *bootname, gcha
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"Failed to start: %s", backend_name);
+				"Failed to start %s: ", backend_name);
 		return FALSE;
 	}
 
@@ -1416,7 +1416,7 @@ static gboolean custom_backend_get(const gchar *cmd, const gchar *bootname, gcha
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"Failed to run: %s", backend_name);
+				"Failed to run %s: ", backend_name);
 		return FALSE;
 	}
 	data = g_bytes_get_data(stdout_buf, &size);
@@ -1469,7 +1469,7 @@ static gboolean custom_backend_set(const gchar *cmd, const gchar *bootname, cons
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"Failed to start: %s", backend_name);
+				"Failed to start %s: ", backend_name);
 		return FALSE;
 	}
 
@@ -1477,7 +1477,7 @@ static gboolean custom_backend_set(const gchar *cmd, const gchar *bootname, cons
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"Failed to run: %s", backend_name);
+				"Failed to run %s: ", backend_name);
 		return FALSE;
 	}
 

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1555,7 +1555,7 @@ static gboolean custom_get_state(RaucSlot *slot, gboolean *good, GError **error)
 				error,
 				R_BOOTCHOOSER_ERROR,
 				R_BOOTCHOOSER_ERROR_FAILED,
-				"Invalid string obtained from custom bootloader backend");
+				"Invalid string obtained from custom bootloader backend: '%s'", ret_str);
 		return FALSE;
 	}
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -107,7 +107,8 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		}
 		g_key_file_remove_key(key_file, "system", "efi-use-bootnext", NULL);
 	} else if (g_strcmp0(c->system_bootloader, "custom") == 0) {
-		c->custom_bootloader_backend = key_file_consume_string(key_file, "handlers", "bootloader-custom-backend", NULL);
+		c->custom_bootloader_backend = resolve_path(filename,
+				key_file_consume_string(key_file, "handlers", "bootloader-custom-backend", NULL));
 		if (!c->custom_bootloader_backend) {
 			g_set_error(
 					error,

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -877,6 +877,7 @@ static void bootchooser_custom(BootchooserFixture *fixture,
 	RaucSlot *primary = NULL;
 	gboolean good;
 	GError *error = NULL;
+	gboolean res;
 
 	const gchar *cfg_file = "\
 [system]\n\
@@ -924,16 +925,28 @@ PRIMARY=A\n\
 STATE_A=good\n\
 STATE_B=good\n\
 ");
-	g_assert_true(r_boot_get_state(rootfs0, &good, NULL));
+	res = r_boot_get_state(rootfs0, &good, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 	g_assert_true(good);
-	g_assert_true(r_boot_get_state(rootfs1, &good, NULL));
+	res = r_boot_get_state(rootfs1, &good, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 	g_assert_true(good);
 
-	g_assert_true(r_boot_set_state(rootfs0, FALSE, NULL));
-	g_assert_true(r_boot_get_state(rootfs0, &good, NULL));
+	res = r_boot_set_state(rootfs0, FALSE, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+	res = r_boot_get_state(rootfs0, &good, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 	g_assert_false(good);
-	g_assert_true(r_boot_set_state(rootfs1, FALSE, NULL));
-	g_assert_true(r_boot_get_state(rootfs1, &good, NULL));
+	res = r_boot_set_state(rootfs1, FALSE, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+	res = r_boot_get_state(rootfs1, &good, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 	g_assert_false(good);
 	g_assert_true(test_custom_post_state("\
 PRIMARY=A\n\
@@ -947,15 +960,23 @@ PRIMARY=A\n\
 STATE_A=bad\n\
 STATE_B=bad\n\
 ");
-	g_assert_true(r_boot_get_state(rootfs0, &good, NULL));
+	res = r_boot_get_state(rootfs0, &good, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 	g_assert_false(good);
-	g_assert_true(r_boot_get_state(rootfs1, &good, NULL));
+	res = r_boot_get_state(rootfs1, &good, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 	g_assert_false(good);
-	g_assert_true(r_boot_set_state(rootfs0, TRUE, NULL));
-	g_assert_true(r_boot_get_state(rootfs0, &good, NULL));
+	res = r_boot_set_state(rootfs0, TRUE, &error);
+	res = r_boot_get_state(rootfs0, &good, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 	g_assert_true(good);
-	g_assert_true(r_boot_set_state(rootfs1, TRUE, NULL));
-	g_assert_true(r_boot_get_state(rootfs1, &good, NULL));
+	res = r_boot_set_state(rootfs1, TRUE, &error);
+	res = r_boot_get_state(rootfs1, &good, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 	g_assert_true(good);
 	g_assert_true(test_custom_post_state("\
 PRIMARY=A\n\
@@ -969,13 +990,17 @@ PRIMARY=A\n\
 STATE_A=good\n\
 STATE_B=good\n\
 ");
-	primary = r_boot_get_primary(NULL);
+	primary = r_boot_get_primary(&error);
+	g_assert_no_error(error);
 	g_assert_nonnull(primary);
 	g_assert(primary == rootfs0);
 	g_assert(primary != rootfs1);
 
-	g_assert_true(r_boot_set_primary(rootfs1, NULL));
-	primary = r_boot_get_primary(NULL);
+	res = r_boot_set_primary(rootfs1, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+	primary = r_boot_get_primary(&error);
+	g_assert_no_error(error);
 	g_assert_nonnull(primary);
 	g_assert(primary != rootfs0);
 	g_assert(primary == rootfs1);
@@ -991,13 +1016,17 @@ PRIMARY=B\n\
 STATE_A=good\n\
 STATE_B=good\n\
 ");
-	primary = r_boot_get_primary(NULL);
+	primary = r_boot_get_primary(&error);
+	g_assert_no_error(error);
 	g_assert_nonnull(primary);
 	g_assert(primary != rootfs0);
 	g_assert(primary == rootfs1);
 
-	g_assert_true(r_boot_set_primary(rootfs0, NULL));
-	primary = r_boot_get_primary(NULL);
+	res = r_boot_set_primary(rootfs0, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+	primary = r_boot_get_primary(&error);
+	g_assert_no_error(error);
 	g_assert_nonnull(primary);
 	g_assert(primary == rootfs0);
 	g_assert(primary != rootfs1);

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -19,6 +19,15 @@ static void bootchooser_fixture_set_up(BootchooserFixture *fixture,
 	g_assert_nonnull(fixture->tmpdir);
 }
 
+static void custom_bootchooser_fixture_set_up(BootchooserFixture *fixture,
+		gconstpointer user_data)
+{
+	bootchooser_fixture_set_up(fixture, user_data);
+
+	g_assert_true(test_copy_file("test/bin/custom-bootloader-script", NULL,
+			fixture->tmpdir, "custom-bootloader-script"));
+}
+
 static void bootchooser_fixture_tear_down(BootchooserFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1046,7 +1055,7 @@ int main(int argc, char *argv[])
 			bootchooser_fixture_tear_down);
 
 	g_test_add("/bootchooser/custom", BootchooserFixture, NULL,
-			bootchooser_fixture_set_up, bootchooser_custom,
+			custom_bootchooser_fixture_set_up, bootchooser_custom,
 			bootchooser_fixture_tear_down);
 
 	return g_test_run();


### PR DESCRIPTION
As I missed to review #541 and #600, my minor adaptions and concerns come now as a separate PR.

I think the most gets clear by the individual commits. One major discussion point I see is on how to provide the custom bootloader implementation script/binary.

By now, this is implemented as a 'handler' which is a bit confusing as we set the bootloader and all bootloader parameters in the `[system]` section normally.
But also if we could agree on understanding this as a handler in the same sense of the other handlers, then this would require resolving the handler's name relative to the system configuration file as we do for the others too.
This, in turn, makes the current testing fail (as Travis will show) because the tests expect the bootloader implementation to be script or binary in PATH. This is also a valid assumption but breaks with the concept of a handler in RAUC.

Thus, If we now decide to keep the 'handler' way of doing it, it would either require to support script/binary in PATH only by providing absolute paths or we add another key to the `[system]` section that allows us to specify a bootloader implementation name to be looked up as we do for e.g `barebox-state`, `grub-editenv`, etc.
