### PR TITLE
qemu-test: also distribute qemu test scripts in a release tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,6 +157,7 @@ check_LTLIBRARIES = librauctest.la
 EXTRA_DIST += tap-t \
 	      tap-test \
 	      uml-test uml-test-init \
+	      qemu-test qemu-test-init \
 	      test/Dockerfile \
 	      test/bin \
 	      test/install-content \


### PR DESCRIPTION
The test script is useful also for users getting rauc via a tarball, so
ship qemu-test similar to the uml-test script.