### PR TITLE
fix bundle create/resign/convert error handling

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -449,7 +449,9 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 	res = TRUE;
 out:
 	/* Remove output file on error */
-	if (!res && g_file_test(bundlename, G_FILE_TEST_IS_REGULAR))
+	if (!res &&
+	    g_file_test(bundlename, G_FILE_TEST_IS_REGULAR) &&
+	    !g_error_matches(ierror, G_FILE_ERROR, G_FILE_ERROR_EXIST))
 		if (g_remove(bundlename) != 0)
 			g_warning("failed to remove %s", bundlename);
 	return res;
@@ -538,7 +540,9 @@ gboolean resign_bundle(RaucBundle *bundle, const gchar *outpath, GError **error)
 	res = TRUE;
 out:
 	/* Remove output file on error */
-	if (!res && g_file_test(outpath, G_FILE_TEST_IS_REGULAR))
+	if (!res &&
+	    g_file_test(outpath, G_FILE_TEST_IS_REGULAR) &&
+	    !g_error_matches(ierror, G_FILE_ERROR, G_FILE_ERROR_EXIST))
 		if (g_remove(outpath) != 0)
 			g_warning("failed to remove %s", outpath);
 	return res;

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -700,6 +700,12 @@ gboolean create_casync_bundle(RaucBundle *bundle, const gchar *outbundle, GError
 
 	res = TRUE;
 out:
+	/* Remove output file on error */
+	if (!res &&
+	    g_file_test(outbundle, G_FILE_TEST_IS_REGULAR) &&
+	    !g_error_matches(ierror, G_FILE_ERROR, G_FILE_ERROR_EXIST))
+		if (g_remove(outbundle) != 0)
+			g_warning("failed to remove %s", outbundle);
 	return res;
 }
 

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -506,6 +506,26 @@ test_expect_success CASYNC "rauc convert" "
   test -f casync.raucb
 "
 
+test_expect_success CASYNC "rauc convert (output exists)" "
+  touch casync.raucb &&
+  test_must_fail rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+    convert $SHARNESS_TEST_DIRECTORY/good-bundle.raucb casync.raucb &&
+  test -f casync.raucb
+"
+
+test_expect_success CASYNC "rauc convert (error)" "
+  rm -f casync.raucb &&
+  test_must_fail rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
+    convert $SHARNESS_TEST_DIRECTORY/good-bundle.raucb casync.raucb &&
+  test ! -f casync.raucb
+"
+
 test_expect_success CASYNC "rauc convert casync extra args" "
   rm -f casync-extra-args.raucb &&
   rauc \

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -528,6 +528,16 @@ test_expect_success "rauc resign" "
   test -f out.raucb
 "
 
+test_expect_success "rauc resign (output exists)" "
+  touch out.raucb &&
+  test_must_fail rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+    resign $SHARNESS_TEST_DIRECTORY/good-bundle.raucb out.raucb &&
+  test -f out.raucb
+"
+
 test_expect_success FAKETIME "rauc resign extend (not expired)" "
   rm -f out1.raucb out2.raucb &&
   faketime "2018-01-01" \


### PR DESCRIPTION
Commit 00cdb5e6b7bdeab0a3cafe28edcdeb8b2b1034a9 introduced a bug that lead to removing an existing output bundle instead of just aborting. This fixes that issue and also removes incomplete outputs for `rauc convert` (casync)