### PR TITLE
Add some testing enhancements and extend CLI testing

### DIFF
--- a/qemu-test
+++ b/qemu-test
@@ -1,4 +1,21 @@
 #!/bin/sh
+#
+# RAUC qemu test runner script
+#
+# Executes the RAUC test suite in a safe qemu environment with simulated root
+# privileges to emulate and test virtual devices such as block devices, NAND,
+# etc.
+#
+# Usage:
+#
+# ./qemu-test <argument>
+#
+# Optional arguments:
+#
+#   coverage    Run with coverage report generation enabled
+#   shell       Setup qemu test system and provide an interactive shell
+#
+# When no argument is given, the default test suite will be executed
 
 set -e
 

--- a/test/minimal-test.conf
+++ b/test/minimal-test.conf
@@ -1,0 +1,31 @@
+# testsuite system configuration
+
+[system]
+compatible=Test Config
+bootloader=grub
+grubenv=grubenv.test
+variant-name=Default Variant
+
+[keyring]
+path=openssl-ca/dev-ca.pem
+check-crl=true
+
+[slot.rootfs.0]
+device=images/rootfs-0
+type=raw
+bootname=system0
+
+[slot.rootfs.1]
+device=images/rootfs-1
+type=raw
+bootname=system1
+
+[slot.appfs.0]
+device=images/appfs-0
+type=raw
+parent=rootfs.0
+
+[slot.appfs.1]
+device=images/appfs-1
+type=raw
+parent=rootfs.1

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -667,6 +667,12 @@ test_expect_success ROOT,SERVICE "rauc install --progress" "
     install --progress $SHARNESS_TEST_DIRECTORY/good-bundle.raucb
 "
 
+test_expect_success ROOT,!SERVICE "rauc install (no service)" "
+  rauc \
+    --conf=${SHARNESS_TEST_DIRECTORY}/minimal-test.conf \
+    install $SHARNESS_TEST_DIRECTORY/good-bundle.raucb
+"
+
 rm -rf $TEST_TMPDIR
 
 test_done

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -6,6 +6,8 @@ test_description="rauc binary tests"
 
 export G_DEBUG="fatal-criticals"
 
+TEST_TMPDIR=$(mktemp -d)
+
 CA_DEV="${SHARNESS_TEST_DIRECTORY}/openssl-ca/dev"
 CA_REL="${SHARNESS_TEST_DIRECTORY}/openssl-ca/rel"
 if [ -e "/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so" ]; then
@@ -515,6 +517,19 @@ test_expect_success FAKETIME "rauc sign bundle with valid certificate" "
   test -f out.raucb
 "
 
+
+test_expect_success "rauc extract" "
+  rauc \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+    extract $SHARNESS_TEST_DIRECTORY/good-bundle.raucb $TEST_TMPDIR/bundle-extract &&
+  test -f $TEST_TMPDIR/bundle-extract/appfs.img &&
+  test -f $TEST_TMPDIR/bundle-extract/custom_handler.sh &&
+  test -f $TEST_TMPDIR/bundle-extract/hook.sh &&
+  test -f $TEST_TMPDIR/bundle-extract/manifest.raucm &&
+  test -f $TEST_TMPDIR/bundle-extract/rootfs.img &&
+  rm -rf $TEST_TMPDIR/bundle-extract
+"
+
 test_expect_success CASYNC "rauc convert" "
   rm -f casync.raucb &&
   rauc \
@@ -651,5 +666,7 @@ test_expect_success ROOT,SERVICE "rauc install --progress" "
   rauc \
     install --progress $SHARNESS_TEST_DIRECTORY/good-bundle.raucb
 "
+
+rm -rf $TEST_TMPDIR
 
 test_done

--- a/test/service.c
+++ b/test/service.c
@@ -193,8 +193,9 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 
 	installer = r_installer_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
 			G_DBUS_PROXY_FLAGS_GET_INVALIDATED_PROPERTIES,
-			"de.pengutronix.rauc", "/", NULL, NULL);
+			"de.pengutronix.rauc", "/", NULL, &error);
 
+	g_assert_no_error(error);
 	g_assert_nonnull(installer);
 
 	/* connect signals to test callbacks */
@@ -268,7 +269,9 @@ static void service_test_install_api(ServiceFixture *fixture, gconstpointer user
 
 	installer = r_installer_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
 			G_DBUS_PROXY_FLAGS_GET_INVALIDATED_PROPERTIES,
-			"de.pengutronix.rauc", "/", NULL, NULL);
+			"de.pengutronix.rauc", "/", NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(installer);
 
 	g_assert_cmpint(g_signal_connect(installer, "completed",
 			G_CALLBACK(on_installer_completed_failed), NULL), !=, 0);
@@ -342,7 +345,8 @@ static void service_test_info(ServiceFixture *fixture, gconstpointer user_data)
 			"de.pengutronix.rauc",
 			"/",
 			NULL,
-			NULL);
+			&error);
+	g_assert_no_error(error);
 
 	if (installer == NULL) {
 		g_error("failed to install proxy");
@@ -380,7 +384,8 @@ static void service_test_slot_status(ServiceFixture *fixture, gconstpointer user
 			"de.pengutronix.rauc",
 			"/",
 			NULL,
-			NULL);
+			&error);
+	g_assert_no_error(error);
 
 	if (installer == NULL) {
 		g_error("failed to install proxy");


### PR DESCRIPTION
Adds tests for "rauc extract" and "rauc install" to rauc.t, also for non-service case and adds minimal qemu-test documentation and error handling updates for service tests.