### PR TITLE
Rework parts of context and config handling for more targeted error handling.

### DIFF
--- a/include/config_file.h
+++ b/include/config_file.h
@@ -107,11 +107,8 @@ G_GNUC_WARN_UNUSED_RESULT;
  * Creates a default rauc system configuration.
  *
  * @param config a location to place the new config
- *
- * @return TRUE if the configuration was successfully created. FALSE if there were errors.
  */
-gboolean default_config(RaucConfig **config)
-G_GNUC_WARN_UNUSED_RESULT;
+void default_config(RaucConfig **config);
 
 /**
  * Finds a config slot given the device path.

--- a/include/context.h
+++ b/include/context.h
@@ -167,6 +167,26 @@ RaucContext *r_context_conf(void);
 const RaucContext *r_context(void);
 
 /**
+ * Sets up global context.
+ *
+ * Removes 'pending' flag from the context object.
+ *
+ * * Loads RAUC configuration file (system.conf)
+ * * Reads basic system information like variant, system info, etc. (if
+ *   configured)
+ * * Reads 'bootname' from kernel commandline
+ * * Overrides config file values by commandline argument values where required.
+ *
+ * Note: Must not be called when context is 'busy'.
+ *
+ * @param[out] error Return location for a GError, or NULL
+ *
+ * @return TRUE if context configuration succeeded, otherwise FALSE
+ */
+gboolean r_context_configure(GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
  * Cleans up provided RContextInstallationInfo.
  *
  * @param[in] info RContextInstallationInfo to free

--- a/include/context.h
+++ b/include/context.h
@@ -69,10 +69,6 @@ typedef struct {
 	gint last_explicit_percent;
 } RaucProgressStep;
 
-gboolean r_context_get_busy(void)
-G_GNUC_WARN_UNUSED_RESULT;
-void r_context_set_busy(gboolean busy);
-
 /**
  * Call at the beginning of a relevant code block. Provides progress
  * information via DBus when rauc service is running.
@@ -128,6 +124,10 @@ void r_context_free_progress_step(RaucProgressStep *step);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucProgressStep, r_context_free_progress_step);
 
 void r_context_register_progress_callback(progress_callback progress_cb);
+
+gboolean r_context_get_busy(void)
+G_GNUC_WARN_UNUSED_RESULT;
+void r_context_set_busy(gboolean busy);
 
 RaucContext *r_context_conf(void);
 const RaucContext *r_context(void);

--- a/include/context.h
+++ b/include/context.h
@@ -125,11 +125,57 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucProgressStep, r_context_free_progress_step);
 
 void r_context_register_progress_callback(progress_callback progress_cb);
 
+/**
+ * Return if context is marked 'busy'.
+ *
+ * @return TRUE if context is 'busy', otherwise FALSE.
+ */
 gboolean r_context_get_busy(void)
 G_GNUC_WARN_UNUSED_RESULT;
+
+/**
+ * Explicitly mark the context busy to prevent concurrent access on context
+ * during installation.
+ *
+ * Note this will fail if context is 'busy' already.
+ *
+ * @param[in] busy Whether to set 'busy' (TRUE) or 'not busy' (FALSE)
+ */
 void r_context_set_busy(gboolean busy);
 
+/**
+ * Returns a non-const instance of context object, to allow changing variables.
+ *
+ * Sets up context object if not existing, yet and initializes APIs.
+ *
+ * Leaves the context object with 'pending' flag set.
+ *
+ * @param (non-const) instance of context object
+ */
 RaucContext *r_context_conf(void);
+
+/**
+ * Returns read-only (const) reference to context object.
+ *
+ * Use this to access context information regularly.
+ *
+ * If the context has 'pending' flag set, this configures the context and
+ * removes the 'pending' flag from the context object.
+ *
+ * @return read-only (const) reference to global context object
+ */
 const RaucContext *r_context(void);
+
+/**
+ * Cleans up provided RContextInstallationInfo.
+ *
+ * @param[in] info RContextInstallationInfo to free
+ */
 void r_context_install_info_free(RContextInstallationInfo *info);
+
+/**
+ * Cleans up a global context created with r_context_conf().
+ *
+ * Will do nothing if context was not created.
+ */
 void r_context_clean(void);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -12,7 +12,7 @@ G_DEFINE_QUARK(r-slot-error-quark, r_slot_error)
 
 #define RAUC_SLOT_PREFIX	"slot"
 
-gboolean default_config(RaucConfig **config)
+void default_config(RaucConfig **config)
 {
 	RaucConfig *c = g_new0(RaucConfig, 1);
 
@@ -26,7 +26,6 @@ gboolean default_config(RaucConfig **config)
 		        1 << R_MANIFEST_FORMAT_VERITY;
 
 	*config = c;
-	return TRUE;
 }
 
 static gboolean fix_grandparent_links(GHashTable *slots, GError **error)

--- a/src/context.c
+++ b/src/context.c
@@ -206,7 +206,7 @@ static gchar* get_variant_from_file(const gchar* filename, GError **error)
 }
 
 
-static gboolean r_context_configure(GError **error)
+gboolean r_context_configure(GError **error)
 {
 	gboolean res = TRUE;
 	GError *ierror = NULL;

--- a/src/context.c
+++ b/src/context.c
@@ -219,11 +219,7 @@ static void r_context_configure(void)
 	if (!res && error->domain==g_file_error_quark()) {
 		g_debug("system config not found, using default values");
 		g_clear_error(&error);
-		res = default_config(&context->config);
-	}
-	if (!res) {
-		g_error("failed to initialize context: %s", error->message);
-		g_clear_error(&error);
+		default_config(&context->config);
 	}
 
 	if (context->config->system_variant_type == R_CONFIG_SYS_VARIANT_DTB) {

--- a/src/main.c
+++ b/src/main.c
@@ -210,6 +210,13 @@ static gboolean install_start(int argc, char **argv)
 
 	r_exit_status = 1;
 
+	if (!ENABLE_SERVICE) {
+		if (!r_context_conf()->configpath) {
+			g_debug("Using default system config path '/etc/rauc/system.conf'");
+			r_context_conf()->configpath = g_strdup("/etc/rauc/system.conf");
+		}
+	}
+
 	if (argc < 3) {
 		g_printerr("A bundle filename name must be provided\n");
 		goto out;
@@ -1558,6 +1565,13 @@ static gboolean status_start(int argc, char **argv)
 	r_exit_status = 0;
 
 	if (!ENABLE_SERVICE) {
+		if (!r_context_conf()->configpath) {
+			g_debug("Using default system config path '/etc/rauc/system.conf'");
+			r_context_conf()->configpath = g_strdup("/etc/rauc/system.conf");
+		}
+	}
+
+	if (!ENABLE_SERVICE) {
 		res = determine_slot_states(&ierror);
 		if (!res) {
 			g_printerr("Failed to determine slot states: %s\n", ierror->message);
@@ -1666,6 +1680,11 @@ G_GNUC_UNUSED
 static gboolean service_start(int argc, char **argv)
 {
 	g_debug("service start");
+
+	if (!r_context_conf()->configpath) {
+		g_debug("Using default system config path '/etc/rauc/system.conf'");
+		r_context_conf()->configpath = g_strdup("/etc/rauc/system.conf");
+	}
 
 	r_exit_status = r_service_run() ? 0 : 1;
 

--- a/src/service.c
+++ b/src/service.c
@@ -531,11 +531,16 @@ static gboolean r_on_signal(gpointer user_data)
 
 gboolean r_service_run(void)
 {
+	GError *ierror = NULL;
 	gboolean service_return = TRUE;
 	GBusType bus_type = (!g_strcmp0(g_getenv("DBUS_STARTER_BUS_TYPE"), "session"))
 	                    ? G_BUS_TYPE_SESSION : G_BUS_TYPE_SYSTEM;
 
-	r_context();
+	if (!r_context_configure(&ierror)) {
+		g_printerr("Failed to initialize context: %s", ierror->message);
+		g_clear_error(&ierror);
+		return FALSE;
+	}
 
 	service_loop = g_main_loop_new(NULL, FALSE);
 	g_unix_signal_add(SIGTERM, r_on_signal, NULL);

--- a/test/service.c
+++ b/test/service.c
@@ -269,6 +269,10 @@ static void service_test_install_api(ServiceFixture *fixture, gconstpointer user
 		return;
 	}
 
+	/* needs to run as root */
+	if (!test_running_as_root())
+		return;
+
 	testloop = g_main_loop_new(NULL, FALSE);
 
 	installer = r_installer_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,


### PR DESCRIPTION
The current set up of the context does not really allow handling errors gracefully. A configuration error will lead to a simple `g_error()` and core dump which is not optimal user experience.

Additionally, the context setup actually requires a configuration only in a few cases: Mainly for the service and for the install operations in a non-service build. The current handling does not enforce using a configuration but falls back to unusable defaults for these cases. This also prevents from printing more targeted error messages.

This PR aims to fix both at once.