### PR TITLE
src/network,src/update_handler: Add Proxy Support

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -106,6 +106,10 @@ static gboolean transfer(RaucTransfer *xfer, GError **error)
 	/* decode all supported Accept-Encoding headers */
 	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
 
+	if (getenv("RAUC_CURLOPT_PROXY") != NULL) {
+		curl_easy_setopt(curl, CURLOPT_PROXY, getenv("RAUC_CURLOPT_PROXY"));
+	}
+
 	/* set error buffer empty before performing a request */
 	errbuf[0] = 0;
 

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -266,6 +266,10 @@ static gboolean casync_extract(RaucImage *image, gchar *dest, int out_fd, const 
 	if (tmpdir)
 		g_subprocess_launcher_setenv(launcher, "TMPDIR", tmpdir, TRUE);
 
+	if (getenv("RAUC_CURLOPT_PROXY") != NULL) {
+		g_subprocess_launcher_setenv(launcher, "CASYNC_CURLOPT_PROXY", getenv("RAUC_CURLOPT_PROXY"), TRUE);
+	}
+
 	sproc = r_subprocess_launcher_spawnv(launcher, args, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(


### PR DESCRIPTION
This PR adds support for RAUC_CURLOPT_PROXY environment to set the corresponding curl option, also it forwards the RAUC_CURLOPT_PROXY environment value to casync via CASYNC_CURLOPT_PROXY (https://github.com/systemd/casync/pull/241) environment. The proxy needs to secure an organization's internal network from external threats.

Example:
```
[Service]
Environment="RAUC_CURLOPT_PROXY=<[protocol://][user:password@]proxyhost[:port]>"
```