### PR TITLE
src/install: fix leaking gchar** with g_auto(GStrv)

### DIFF
--- a/include/slot.h
+++ b/include/slot.h
@@ -137,8 +137,7 @@ RaucSlot* r_slot_get_parent_root(RaucSlot *slot);
 /**
  * Gets all classes that do not have a parent
  *
- * @return newly allocated NULL-teminated string array. Free with g_strfreev
- *         [transfer full]
+ * @return NULL-teminated array of intern strings. Free with g_free().
  */
 gchar** r_slot_get_root_classes(GHashTable *slots);
 

--- a/include/slot.h
+++ b/include/slot.h
@@ -27,7 +27,7 @@ typedef struct {
 typedef struct _RaucSlot {
 	/** name of the slot. A glib intern string. */
 	const gchar *name;
-	/** user-friendly description of the slot. A glib intern string. */
+	/** user-friendly description of the slot. */
 	gchar *description;
 	/** slot class the slot belongs to. A glib intern string. */
 	const gchar *sclass;

--- a/src/install.c
+++ b/src/install.c
@@ -281,7 +281,7 @@ static RaucSlot *select_inactive_slot_class_member(const gchar *rootclass)
  */
 GHashTable* determine_target_install_group(void)
 {
-	gchar **rootclasses = NULL;
+	g_autofree gchar **rootclasses = NULL;
 	GHashTable *targetgroup = NULL;
 	GHashTableIter iter;
 	RaucSlot *iterslot = NULL;

--- a/src/install.c
+++ b/src/install.c
@@ -214,9 +214,9 @@ gboolean determine_boot_states(GError **error)
 	return TRUE;
 }
 
-/* Returns newly allocated NULL-teminated string array of all classes listed in
+/* Returns NULL-teminated intern string array of all classes listed in
  * given manifest.
- * Free with g_strfreev */
+ * Free with g_free */
 static gchar** get_all_manifest_slot_classes(const RaucManifest *manifest)
 {
 	GPtrArray *slotclasses = NULL;
@@ -330,7 +330,7 @@ GHashTable* determine_target_install_group(void)
 GList* get_install_images(const RaucManifest *manifest, GHashTable *target_group, GError **error)
 {
 	GList *install_images = NULL;
-	gchar **slotclasses = NULL;
+	g_autofree gchar **slotclasses = NULL;
 
 	g_return_val_if_fail(manifest != NULL, NULL);
 	g_return_val_if_fail(target_group != NULL, NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -1066,7 +1066,7 @@ static gchar* r_status_formatter_readable(RaucStatusPrint *status)
 {
 	GString *text = g_string_new(NULL);
 	RaucSlot *bootedfrom = NULL;
-	gchar **slotclasses = NULL;
+	g_autofree gchar **slotclasses = NULL;
 
 	g_return_val_if_fail(status, NULL);
 

--- a/test/boot_switch.c
+++ b/test/boot_switch.c
@@ -322,8 +322,8 @@ static void test_boot_switch(BootSwitchFixture *fixture,
 
 	/* create target slot */
 	targetslot = g_new0(RaucSlot, 1);
-	targetslot->name = g_strdup("bootloader.0");
-	targetslot->sclass = g_strdup("bootloader");
+	targetslot->name = g_intern_string("bootloader.0");
+	targetslot->sclass = g_intern_string("bootloader");
 	targetslot->device = g_strdup(slotpath);
 	targetslot->type = g_strdup(data->slottype);
 	targetslot->region_start = REGION_START;

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -56,8 +56,8 @@ static void test_get_update_handler(UpdateHandlerFixture *fixture, gconstpointer
 	image->filename = g_strconcat("rootfs.", test_pair->imagetype, NULL);
 
 	targetslot = g_new0(RaucSlot, 1);
-	targetslot->name = g_strdup("rootfs.0");
-	targetslot->sclass = g_strdup("rootfs");
+	targetslot->name = g_intern_string("rootfs.0");
+	targetslot->sclass = g_intern_string("rootfs");
 	targetslot->device = g_strdup("/dev/null");
 	targetslot->type = g_strdup(test_pair->slottype);
 
@@ -89,8 +89,8 @@ static void test_get_custom_update_handler(UpdateHandlerFixture *fixture, gconst
 	image->hooks.install = TRUE;
 
 	targetslot = g_new0(RaucSlot, 1);
-	targetslot->name = g_strdup("rootfs.0");
-	targetslot->sclass = g_strdup("rootfs");
+	targetslot->name = g_intern_string("rootfs.0");
+	targetslot->sclass = g_intern_string("rootfs");
 	targetslot->device = g_strdup("/dev/null");
 	targetslot->type = g_strdup("nand");
 
@@ -325,8 +325,8 @@ static void test_update_handler(UpdateHandlerFixture *fixture,
 no_image:
 	/* create target slot */
 	targetslot = g_new0(RaucSlot, 1);
-	targetslot->name = g_strdup("rootfs.0");
-	targetslot->sclass = g_strdup("rootfs");
+	targetslot->name = g_intern_string("rootfs.0");
+	targetslot->sclass = g_intern_string("rootfs");
 	targetslot->device = g_strdup(slotpath);
 	targetslot->type = g_strdup(test_pair->slottype);
 	targetslot->state = ST_INACTIVE;


### PR DESCRIPTION
We have to use a type name for freeing and GStrv is the standard glib
typedef prepared for this purpose.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>