### PR TITLE
src/bootchooser: fix leaking gchar in grub_get_primary()

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -573,6 +573,7 @@ static RaucSlot* grub_get_primary(GError **error)
 				g_propagate_error(error, ierror);
 				return NULL;
 			}
+			g_free(key);
 			key = g_strdup_printf("%s_TRY", slot->bootname);
 			if (!grub_env_get(key, &slot_try, &ierror)) {
 				g_propagate_error(error, ierror);


### PR DESCRIPTION
Note that we have the same in `grub_get_state()` already but missed to add it here, too.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>