### PR TITLE
src/network: make the use of .netrc optional

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -105,6 +105,7 @@ static gboolean transfer(RaucTransfer *xfer, GError **error)
 	curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE, xfer->limit);
 	/* decode all supported Accept-Encoding headers */
 	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+	curl_easy_setopt(curl, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
 
 	/* set error buffer empty before performing a request */
 	errbuf[0] = 0;


### PR DESCRIPTION
Hi Maintainers,

libcurl ignores the `~/.netrc` file by default.

This makes the use of the `~/.netrc` file optional; the information in the URL is preferred.

With this patch, it is possible to hide the login/passwd in the file `~/.netrc` and enables the HTTP Basic Authentication.

This is a minimalist integration; there is no option given to the command line, nor environment variable, nor attribute in the configuration that may enable or disable the use of `~/.netrc`. I can do it if this is wanted.

Regards,
Gaël