### PR TITLE
docs: include Kernel loop device patch

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -185,6 +185,12 @@ In kernel Kconfig you have to enable the following options:
   CONFIG_BLK_DEV_LOOP=y
   CONFIG_SQUASHFS=y
 
+.. note::
+   These drivers may also be loaded as modules. Kernel versions v5.0 to v5.7
+   will require the patch ``7e81f99afd91c937f0e66dc135e26c1c4f78b003``
+   backporting to fix a bug where the bundles cannot be mounted in a small
+   number of cases.
+
 .. _sec_ref_host_tools:
 
 Required Host Tools


### PR DESCRIPTION
There is a bug in Kernel version v5.0 until v5.7 when loop device
support is loaded as a module, in a small percentage of cases
mounting the bundle fails. Include information about the patch.

Resolves: #562
Resolves: #582

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>