### PR TITLE
Fix systemd D-Bus handling and RAUC error reporting

### DIFF
--- a/data/rauc.service.in
+++ b/data/rauc.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Rauc Update Service
 Documentation=https://rauc.readthedocs.io
+After=dbus.service
 
 [Service]
 Type=dbus

--- a/src/service.c
+++ b/src/service.c
@@ -521,7 +521,10 @@ static void r_on_name_lost(GDBusConnection *connection,
 	                             ? "session" : "system";
 
 	if (connection == NULL) {
-		g_printerr("Connection to the %s bus can't be made for %s\n", bus_type_name, name);
+		if (r_installer)
+			g_printerr("Lost connection to the %s bus\n", bus_type_name);
+		else
+			g_printerr("Connection to the %s bus can't be made for %s\n", bus_type_name, name);
 	} else {
 		g_printerr("Failed to obtain name %s on %s bus\n", name, bus_type_name);
 	}

--- a/src/service.c
+++ b/src/service.c
@@ -517,11 +517,13 @@ static void r_on_name_lost(GDBusConnection *connection,
 		gpointer user_data)
 {
 	gboolean *service_return = (gboolean*)user_data;
+	const gchar *bus_type_name = (!g_strcmp0(g_getenv("DBUS_STARTER_BUS_TYPE"), "session"))
+	                             ? "session" : "system";
 
 	if (connection == NULL) {
-		g_printerr("Connection to the bus can't be made for %s\n", name);
+		g_printerr("Connection to the %s bus can't be made for %s\n", bus_type_name, name);
 	} else {
-		g_printerr("Failed to obtain name %s\n", name);
+		g_printerr("Failed to obtain name %s on %s bus\n", name, bus_type_name);
 	}
 
 	/* Abort service with exit code */


### PR DESCRIPTION
When shutting down a system running RAUC, one can see RAUC failing regularly with an exit 1 code and a misleading error message:

``` 
rauc[197]: Connection to the bus can't be made for de.pengutronix.rauc
systemd[1]: Stopping D-Bus System Message Bus...
systemd[1]: Stopping Rauc Update Service...
[...]
systemd[1]: rauc.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: rauc.service: Failed with result 'exit-code'.
```

This PR aims to solve both the systemd behavior as well as the error message.