### PR TITLE
src/update_handler: Allow overriding the configured casync store path

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -764,6 +764,8 @@ IN a{sv} *args*:
         installation of bundles on platforms that a compatible not matching the one
         of the bundle to be installed
 
+    :STRING 'store-path', VARIANT 's': Override the configured casync store path
+
 .. _gdbus-method-de-pengutronix-rauc-Installer.Install:
 
 The Install() Method

--- a/include/context.h
+++ b/include/context.h
@@ -14,6 +14,7 @@ typedef void (*progress_callback) (gint percentage, const gchar *message,
 typedef struct {
 	/* The bundle currently mounted by RAUC */
 	RaucBundle *mounted_bundle;
+	gchar *store_path;
 } RContextInstallationInfo;
 
 typedef struct {

--- a/include/install.h
+++ b/include/install.h
@@ -31,6 +31,7 @@ typedef struct {
 	gint status_result;
 	/* install options */
 	gboolean ignore_compatible;
+	gchar *store_path;
 } RaucInstallArgs;
 
 /**

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -754,7 +754,9 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, gboolean ver
 	}
 
 	/* Determine store path for casync, defaults to bundle */
-	if (r_context()->config->store_path) {
+	if (r_context()->install_info->store_path) {
+		ibundle->storepath = r_context()->install_info->store_path;
+	} else if (r_context()->config->store_path) {
 		ibundle->storepath = r_context()->config->store_path;
 	} else {
 		gchar *path = ibundle->origpath ?: ibundle->path;

--- a/src/context.c
+++ b/src/context.c
@@ -565,6 +565,7 @@ void r_context_install_info_free(RContextInstallationInfo *info)
 {
 	/* contains only reference to existing bundle instance */
 	info->mounted_bundle = NULL;
+	info->store_path = NULL;
 	g_free(info);
 }
 

--- a/src/install.c
+++ b/src/install.c
@@ -1006,6 +1006,11 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	g_assert_nonnull(bundlefile);
 	g_assert_null(r_context()->install_info->mounted_bundle);
 
+	if (args->store_path) {
+		g_debug("Using casync store path: %s", args->store_path);
+		r_context()->install_info->store_path = args->store_path;
+	}
+
 	r_context_begin_step("do_install_bundle", "Installing", 5);
 
 	r_context_begin_step("determine_slot_states", "Determining slot states", 0);
@@ -1156,6 +1161,7 @@ RaucInstallArgs *install_args_new(void)
 void install_args_free(RaucInstallArgs *args)
 {
 	g_free(args->name);
+	g_free(args->store_path);
 	g_mutex_clear(&args->status_mutex);
 	g_assert_cmpint(args->status_result, >=, 0);
 	g_assert_true(g_queue_is_empty(&args->status_messages));

--- a/src/main.c
+++ b/src/main.c
@@ -35,6 +35,7 @@ gchar *output_format = NULL;
 gchar *signing_keyring = NULL;
 gchar *mksquashfs_args = NULL;
 gchar *casync_args = NULL;
+gchar *install_store_path = NULL;
 gboolean utf8_supported = FALSE;
 
 static gchar* make_progress_line(gint percentage)
@@ -232,12 +233,15 @@ static gboolean install_start(int argc, char **argv)
 	args->status_result = 2;
 
 	args->ignore_compatible = install_ignore_compatible;
+	args->store_path = g_steal_pointer(&install_store_path);
 
 	r_loop = g_main_loop_new(NULL, FALSE);
 	if (ENABLE_SERVICE) {
 		g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
 
 		g_variant_dict_insert(&dict, "ignore-compatible", "b", args->ignore_compatible);
+		if (args->store_path)
+			g_variant_dict_insert(&dict, "store-path", "s", args->store_path);
 
 		installer = r_installer_proxy_new_for_bus_sync(bus_type,
 				G_DBUS_PROXY_FLAGS_GET_INVALIDATED_PROPERTIES,
@@ -1714,6 +1718,7 @@ static GOptionEntry entries_install[] = {
 #if ENABLE_SERVICE == 1
 	{"progress", '\0', 0, G_OPTION_ARG_NONE, &install_progressbar, "show progress bar", NULL},
 #endif
+	{"store-path", '\0', 0, G_OPTION_ARG_STRING, &install_store_path, "override configured casync store path", "STOREPATH"},
 	{0}
 };
 

--- a/src/service.c
+++ b/src/service.c
@@ -79,6 +79,8 @@ static gboolean r_on_handle_install_bundle(
 
 	if (g_variant_dict_lookup(&dict, "ignore-compatible", "b", &args->ignore_compatible))
 		g_variant_dict_remove(&dict, "ignore-compatible");
+	if (g_variant_dict_lookup(&dict, "store-path", "s", &args->store_path))
+		g_variant_dict_remove(&dict, "store-path");
 
 	/* Check for unhandled keys */
 	g_variant_iter_init(&iter, g_variant_dict_end(&dict));


### PR DESCRIPTION
This commit adds a command-line argument `--store-path` to the install
command and the `InstallBundle()` D-Bus method.

The argument overrides the casync store path that is configured (or the
default based on the bundle filename if not configured).

Fixes #606 

Signed-off-by: Kevin O'Rourke <dev@caboose.org.uk>