### PR TITLE
Makefile.am: Also ship test/minimal-test.conf in release tar ball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -174,6 +174,7 @@ EXTRA_DIST += tap-t \
 	      test/openssl-ca \
 	      $(wildcard test/*.raucb) \
 	      $(wildcard test/*.raucm) \
+	      test/minimal-test.conf \
 	      test/rauc.t \
 	      test/rootfs.raucs \
 	      test/sharness.sh \


### PR DESCRIPTION
I digged a bit around and just adding this file to the archive isn't enough to fix the failing tests, but these fail for me also with e.g.
```console
$ sudo make check
```
