### PR TITLE
Fix checking of remaining keys in system.conf

### DIFF
--- a/include/slot.h
+++ b/include/slot.h
@@ -56,6 +56,8 @@ typedef struct _RaucSlot {
 	SlotState state;
 	gboolean boot_good;
 	struct _RaucSlot *parent;
+	/** the name of the parent as parsed by config (parsing-internal use only) */
+	gchar *parent_name;
 	gchar *mount_point;
 	gchar *ext_mount_point;
 	RaucSlotStatus *status;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -461,6 +461,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 				res = FALSE;
 				goto free;
 			}
+			g_key_file_remove_key(key_file, groups[i], "allow-mounted", NULL);
 
 			slot->readonly = g_key_file_get_boolean(key_file, groups[i], "readonly", &ierror);
 			if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {

--- a/src/slot.c
+++ b/src/slot.c
@@ -11,6 +11,7 @@ void r_slot_free(gpointer value)
 	g_free(slot->type);
 	g_free(slot->bootname);
 	g_free(slot->extra_mount_opts);
+	g_free(slot->parent_name);
 	g_free(slot->mount_point);
 	g_free(slot->ext_mount_point);
 	g_clear_pointer(&slot->status, r_slot_free_status);


### PR DESCRIPTION
This applies two fixes to re-enable the checking of unknown keys in system.conf for all slots.

This eases writing working configuration and prevents unexpected behavior due to unhandled settings.