### PR TITLE
More usage-friendly and explicitly-handled error and info printouts for 'rauc status' (subcommands)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ EXTRA_DIST += src/de.pengutronix.rauc.Installer.xml
 $(gdbus_installer_generated): src/de.pengutronix.rauc.Installer.xml
 	$(AM_V_GEN) gdbus-codegen \
 		--generate-c-code rauc-installer-generated \
+		--c-generate-autocleanup all \
 		--c-namespace R \
 		--interface-prefix de.pengutronix.rauc. \
 		$<

--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AS_IF([test "x$enable_create" != "xno"], [
 ])
 
 # Checks for libraries.
-PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.49.3 gio-2.0 gio-unix-2.0])
+PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.50 gio-2.0 gio-unix-2.0])
 # Sanity checks to not use new glib methods unintentionally.
 # package check, minimum and maximum required version must be updated
 # explicitly when using newer glib APIs

--- a/src/main.c
+++ b/src/main.c
@@ -1729,6 +1729,8 @@ static gboolean status_start(int argc, char **argv)
 				G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
 				"de.pengutronix.rauc", "/", NULL, &ierror);
 		if (proxy == NULL) {
+			if (g_dbus_error_is_remote_error(ierror))
+				g_dbus_error_strip_remote_error(ierror);
 			g_printerr("rauc mark: error creating proxy: %s\n", ierror->message);
 			g_error_free(ierror);
 			r_exit_status = 1;
@@ -1737,6 +1739,8 @@ static gboolean status_start(int argc, char **argv)
 		g_debug("Trying to contact rauc service");
 		if (!r_installer_call_mark_sync(proxy, state, slot_identifier,
 				&slot_name, &message, NULL, &ierror)) {
+			if (g_dbus_error_is_remote_error(ierror))
+				g_dbus_error_strip_remote_error(ierror);
 			g_printerr("rauc mark: %s\n", ierror->message);
 			g_error_free(ierror);
 			r_exit_status = 1;

--- a/src/main.c
+++ b/src/main.c
@@ -1707,7 +1707,7 @@ static gboolean status_start(int argc, char **argv)
 	} else if (argc == 4) {
 		slot_identifier = argv[3];
 	} else { /* argc > 4 */
-		g_warning("Too many arguments");
+		g_printerr("Too many arguments\n");
 		r_exit_status = 1;
 		goto out;
 	}
@@ -1719,7 +1719,7 @@ static gboolean status_start(int argc, char **argv)
 	} else if (g_strcmp0(argv[2], "mark-active") == 0) {
 		state = "active";
 	} else {
-		g_message("unknown subcommand %s", argv[2]);
+		g_printerr("unknown subcommand %s\n", argv[2]);
 		r_exit_status = 1;
 		goto out;
 	}
@@ -1749,7 +1749,7 @@ static gboolean status_start(int argc, char **argv)
 
 out:
 	if (message)
-		g_message("rauc status: %s", message);
+		g_print("rauc status: %s\n", message);
 	g_clear_object(&proxy);
 
 	return TRUE;

--- a/src/main.c
+++ b/src/main.c
@@ -1688,8 +1688,7 @@ static gboolean status_start(int argc, char **argv)
 		status_print->slots = r_context()->config->slots;
 	} else {
 		if (!retrieve_status_via_dbus(&status_print, &ierror)) {
-			message = g_strdup_printf(
-					"error retrieving slot status via D-Bus: %s",
+			g_printerr("Error retrieving slot status via D-Bus: %s\n",
 					ierror->message);
 			g_error_free(ierror);
 			r_exit_status = 1;
@@ -1729,8 +1728,7 @@ static gboolean status_start(int argc, char **argv)
 				G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
 				"de.pengutronix.rauc", "/", NULL, &ierror);
 		if (proxy == NULL) {
-			message = g_strdup_printf("rauc mark: error creating proxy: %s",
-					ierror->message);
+			g_printerr("rauc mark: error creating proxy: %s\n", ierror->message);
 			g_error_free(ierror);
 			r_exit_status = 1;
 			goto out;
@@ -1738,7 +1736,7 @@ static gboolean status_start(int argc, char **argv)
 		g_debug("Trying to contact rauc service");
 		if (!r_installer_call_mark_sync(proxy, state, slot_identifier,
 				&slot_name, &message, NULL, &ierror)) {
-			message = g_strdup(ierror->message);
+			g_printerr("rauc mark: %s\n", ierror->message);
 			g_error_free(ierror);
 			r_exit_status = 1;
 			goto out;

--- a/src/main.c
+++ b/src/main.c
@@ -1644,7 +1644,6 @@ static gboolean status_start(int argc, char **argv)
 	const gchar *slot_identifier = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
-	RInstaller *proxy = NULL;
 	g_autoptr(RaucStatusPrint) status_print = NULL;
 
 	g_debug("status start");
@@ -1724,6 +1723,8 @@ static gboolean status_start(int argc, char **argv)
 	}
 
 	if (ENABLE_SERVICE) {
+		g_autoptr(RInstaller) proxy = NULL;
+
 		proxy = r_installer_proxy_new_for_bus_sync(bus_type,
 				G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
 				"de.pengutronix.rauc", "/", NULL, &ierror);
@@ -1748,7 +1749,6 @@ static gboolean status_start(int argc, char **argv)
 out:
 	if (message)
 		g_print("rauc status: %s\n", message);
-	g_clear_object(&proxy);
 
 	return TRUE;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1655,7 +1655,7 @@ static gboolean status_start(int argc, char **argv)
 			g_printerr("Failed to determine slot states: %s\n", ierror->message);
 			g_clear_error(&ierror);
 			r_exit_status = 1;
-			goto out;
+			return TRUE;
 		}
 
 		res = determine_boot_states(&ierror);
@@ -1691,7 +1691,7 @@ static gboolean status_start(int argc, char **argv)
 					ierror->message);
 			g_error_free(ierror);
 			r_exit_status = 1;
-			goto out;
+			return TRUE;
 		}
 	}
 
@@ -1699,7 +1699,7 @@ static gboolean status_start(int argc, char **argv)
 		if (!print_status(status_print)) {
 			r_exit_status = 1;
 		}
-		goto out;
+		return TRUE;
 	} else if (argc == 3) {
 		slot_identifier = "booted";
 	} else if (argc == 4) {
@@ -1707,7 +1707,7 @@ static gboolean status_start(int argc, char **argv)
 	} else { /* argc > 4 */
 		g_printerr("Too many arguments\n");
 		r_exit_status = 1;
-		goto out;
+		return TRUE;
 	}
 
 	if (g_strcmp0(argv[2], "mark-good") == 0) {
@@ -1719,7 +1719,7 @@ static gboolean status_start(int argc, char **argv)
 	} else {
 		g_printerr("unknown subcommand %s\n", argv[2]);
 		r_exit_status = 1;
-		goto out;
+		return TRUE;
 	}
 
 	if (ENABLE_SERVICE) {
@@ -1734,7 +1734,7 @@ static gboolean status_start(int argc, char **argv)
 			g_printerr("rauc mark: error creating proxy: %s\n", ierror->message);
 			g_error_free(ierror);
 			r_exit_status = 1;
-			goto out;
+			return TRUE;
 		}
 		g_debug("Trying to contact rauc service");
 		if (!r_installer_call_mark_sync(proxy, state, slot_identifier,
@@ -1744,13 +1744,15 @@ static gboolean status_start(int argc, char **argv)
 			g_printerr("rauc mark: %s\n", ierror->message);
 			g_error_free(ierror);
 			r_exit_status = 1;
-			goto out;
+			return TRUE;
 		}
 	} else {
 		r_exit_status = mark_run(state, slot_identifier, NULL, &message) ? 0 : 1;
+		if (r_exit_status)
+			g_printerr("rauc mark: %s\n", message);
+		return TRUE;
 	}
 
-out:
 	if (message)
 		g_print("rauc status: %s\n", message);
 


### PR DESCRIPTION
Calling 'rauc status' from the command line still produced some noise and used logging methods instead of `g_print()`/`g_printerr()` as we otherwise use halfway consistently in the CLI frontend.

We also do not need to call the boot selection backend when only invoking `mark-*` subcommands.