### PR TITLE
src/context: support resolving PARTLABEL to real path

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -355,11 +355,12 @@ Giving the plain device name is supported, of course.
 
 ::
 
+  root=PARTLABEL=abcde
   root=PARTUUID=01234
   root=UUID=01234
 
-Parsing the ``PARTUUID`` and ``UUID`` is supported, which allows referring to a
-special partition / file system without having to know the
+Parsing the ``PARTLABEL, ``PARTUUID`` and ``UUID`` is supported, which allows
+referring to a special partition / file system without having to know the
 enumeration-dependent `sdX` name.
 
 RAUC converts the value to the corresponding ``/dev/disk/by-*`` symlink name

--- a/src/context.c
+++ b/src/context.c
@@ -56,6 +56,17 @@ static const gchar* get_cmdline_bootname(void)
 	if (!bootname)
 		return NULL;
 
+	if (strncmp(bootname, "PARTLABEL=", 10) == 0) {
+		gchar *partlabelpath = g_build_filename(
+				"/dev/disk/by-partlabel/",
+				&bootname[10],
+				NULL);
+		if (partlabelpath) {
+			g_free((gchar*) bootname);
+			bootname = partlabelpath;
+		}
+	}
+
 	if (strncmp(bootname, "PARTUUID=", 9) == 0) {
 		gchar *partuuidpath = g_build_filename(
 				"/dev/disk/by-partuuid/",


### PR DESCRIPTION
Hi folks,

This is basically the same commit as c6730a6d90acd319072f633f35249134a6a1d34e buf for `PARTLABEL`.

Regards,
Gaël