### PR TITLE
docs: integration: Extend description of how to set up U-Boot for RAUC

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -783,6 +783,72 @@ See the corresponding
 section from the U-Boot documentation for more details on how to set up the
 environment config file for your device.
 
+Example: Setting up U-Boot Environment on eMMC/SD Card
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this example we assume a simple redundancy boot partition layout with a
+bootloader partition and two rootfs partitions.
+
+Another additional partition we use exclusively for storing the environment.
+
+.. note:: It is not strictly required to have the env on an actual MBR/GPT
+   partition, but we use this here as it better protects against accidentially
+   overwriting relevant data of other partitions.
+
+Parition table (excerpt with partition offsets):
+
+.. code-block:: text
+
+   /dev/mmcblk0p1 StartLBA:   8192 -> u-boot etc.
+   /dev/mmcblk0p2 StartLBA: 114688 -> u-boot environment
+   /dev/mmcblk0p3 StartLBA: 139264 -> rootfs A
+   /dev/mmcblk0p4 StartLBA: 475136 -> rootfs B
+
+We enable redundant environment and storage in MMC (not in vfat/ext4 partition)
+in the u-boot config:
+
+.. code-block:: cfg
+
+   CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+   CONFIG_ENV_IS_IN_MMC=y
+
+The default should be to use mmc device 0 and HW partition 0.
+Since U-Boot 2020.10.0 we can set this also explicitly if required:
+
+.. code-block:: cfg
+
+   CONFIG_SYS_MMC_ENV_DEV=0
+   CONFIG_SYS_MMC_ENV_PART=0
+
+.. important:: With ``CONFIG_SYS_MMC_ENV_PART`` we can specify a eMMC HW
+   partition only, not an MBR/GPT partition!
+   HW partitions are e.g. 0=user data area, 1=boot partition.
+
+Then we must specify the env storage size and its offset relative to the
+currently used device.
+Here the device is the eMMC user data area (or SD Card).
+For placing the content in partition 2 now, we must calculate the offset as
+``offset=hex(n sector * 512 bytes/sector)``.
+With ``n=114688`` (start of /dev/mmcblk0p2 according to above partition table)
+we get an offset of ``0x3800000``.
+As size we pick ``0x4000`` (16kB) here. The offset of the redundant copy must
+be the offset of the first copy + size of first copy. This results in:
+
+.. code-block:: cfg
+
+   CONFIG_ENV_SIZE=0x4000
+   CONFIG_ENV_OFFSET=0x3800000
+   CONFIG_ENV_OFFSET_REDUND=0x3804000
+
+Finally, we need to configure userspace to access the same location.
+This can be referenced directly by its partition device name (/dev/mmcblk0p2)
+in the ``/etc/fw_env.config``:
+
+.. code-block:: text
+
+   /dev/mmcblk0p2 0x0000 0x4000
+   /dev/mmcblk0p2 0x4000 0x4000
+
 GRUB
 ~~~~
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -668,11 +668,14 @@ U-Boot
 To enable handling of redundant booting in U-Boot, manual scripting is
 required.
 U-Boot allows storing and modifying variables in its *Environment*.
-Properly configured it can be accessed both from U-Boot itself as
+Properly configured, the environment can be accessed both from U-Boot itself as
 well as from Linux userspace.
+U-Boot also supports setting up the environment redundantly for atomic
+modifications.
 
-The RAUC U-Boot boot selection implementation uses a custom U-Boot script
-together with the environment for managing and persisting slot selection.
+The default RAUC U-Boot boot selection implementation requires a U-Boot
+boot script using specific set of variables that are persisted to the
+environment as stateful slot selection information.
 
 To enable U-Boot support in RAUC, select it in your system.conf:
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -737,18 +737,35 @@ The ``BOOT_ORDER`` variable will contain ``A B`` if ``A`` is the primary slot or
    the ``uboot_set_state()`` and ``uboot_set_primary()``
    functions in ``src/bootchooser.c`` of RAUC.
 
-Support for Fail-Safe Environment Update
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Setting up the (Fail-Safe) U-Boot Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For atomic updates of environment, U-Boot can use redundant environment
-storages that allow to write one copy while using the other as fallback if
-writing fails, e.g. due to sudden power cut.
+The U-Boot environment is used to store stateful boot selection information and
+serves as the interface between userspace and bootloader.
+The information stored in the environment needs to be preserved, even if the
+bootloader should be updated.
+Thus the environment should be placed outside the bootloader partition!
 
-In order to enable redundant environment storage, you have to set in your U-Boot
-config::
+The storage location for the environment can be controlled with
+``CONFIG_ENV_IS_IN_*`` U-Boot Kconfig options like ``CONFIG_ENV_IS_IN_FAT`` or
+``CONFIG_ENV_IS_IN_MMC``.
+You may either select a different storage than your bootloader, or a different
+location/partition/volume on the same storage.
 
-  CONFIG_ENV_OFFSET_REDUND=y
-  CONFIG_ENV_ADDR_REDUND=xxx
+For fail-safe (atomic) updates of the environment, U-Boot can use redundant
+environments that allow to write to one copy while keeping the other as
+fallback if writing fails, e.g. due to sudden power cut.
+
+In order to enable redundant environment storage, you have to additionally set in your U-Boot config:
+
+.. code-block:: cfg
+
+  CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+  CONFIG_ENV_SIZE=<size-of-env>
+  CONFIG_ENV_OFFSET=<offset-in-device>
+  CONFIG_ENV_OFFSET_REDUND=<copy-offset-in-device>
+
+.. note:: Above switches refer to U-Boot >= v2020.01.
 
 Refer to U-Boot source code and README for more details on this.
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -713,20 +713,6 @@ The ``BOOT_ORDER`` variable will contain ``A B`` if ``A`` is the primary slot or
    might need to modify the ``uboot_set_state()`` and ``uboot_set_primary()``
    functions in ``src/bootchooser.c``.
 
-Enable Accessing U-Boot Environment from Userspace
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To enable reading and writing of the U-Boot environment from Linux userspace,
-you need to have:
-
-* U-Boot target tools ``fw_printenv`` and ``fw_setenv`` available on your devices rootfs.
-* Environment configuration file ``/etc/fw_env.config`` in your target root filesystem.
-
-See the corresponding
-`HowTo <https://www.denx.de/wiki/DULG/HowCanIAccessUBootEnvironmentVariablesInLinux>`_
-section from the U-Boot documentation for more details on how to set up the
-environment config file for your device.
-
 Support for Fail-Safe Environment Update
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -741,6 +727,20 @@ config::
   CONFIG_ENV_ADDR_REDUND=xxx
 
 Refer to U-Boot source code and README for more details on this.
+
+Enable Accessing U-Boot Environment from Userspace
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To enable reading and writing of the U-Boot environment from Linux userspace,
+you need to have:
+
+* U-Boot target tools ``fw_printenv`` and ``fw_setenv`` available on your devices rootfs.
+* Environment configuration file ``/etc/fw_env.config`` in your target root filesystem.
+
+See the corresponding
+`HowTo <https://www.denx.de/wiki/DULG/HowCanIAccessUBootEnvironmentVariablesInLinux>`_
+section from the U-Boot documentation for more details on how to set up the
+environment config file for your device.
 
 GRUB
 ~~~~


### PR DESCRIPTION
The description for U-Boot lacked some useful details and omitted some steps or described them misleading.

The aim of this PR is to clarify these things and extend the documentation concerning U-Boot integration.