### PR TITLE
src/service: return D-Bus error if slot states cannot be determined

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -179,11 +179,11 @@ gboolean determine_slot_states(GError **error)
 			goto out;
 		}
 
-		g_set_error_literal(
+		g_set_error(
 				error,
 				R_SLOT_ERROR,
 				R_SLOT_ERROR_NO_SLOT_WITH_STATE_BOOTED,
-				"Did not find booted slot");
+				"Did not find booted slot (matching '%s')", r_context()->bootslot);
 		goto out;
 	}
 

--- a/src/install.c
+++ b/src/install.c
@@ -200,12 +200,12 @@ gboolean determine_boot_states(GError **error)
 {
 	GHashTableIter iter;
 	RaucSlot *slot;
-	gchar *name;
-	GError *ierror = NULL;
 
 	/* get boot state */
 	g_hash_table_iter_init(&iter, r_context()->config->slots);
-	while (g_hash_table_iter_next(&iter, (gpointer*) &name, (gpointer*) &slot)) {
+	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
+		GError *ierror = NULL;
+
 		if (slot->bootname && !r_boot_get_state(slot, &slot->boot_good, &ierror)) {
 			g_propagate_error(error, ierror);
 			return FALSE;

--- a/src/service.c
+++ b/src/service.c
@@ -282,7 +282,7 @@ static GVariant* convert_slot_status_to_dict(RaucSlot *slot)
 /*
  * Makes slot status information available via DBUS.
  */
-static GVariant* create_slotstatus_array(void)
+static GVariant* create_slotstatus_array(GError **error)
 {
 	gint slot_number = g_hash_table_size(r_context()->config->slots);
 	GVariant **slot_status_tuples;
@@ -293,21 +293,26 @@ static GVariant* create_slotstatus_array(void)
 	GHashTableIter iter;
 	RaucSlot *slot;
 
-	g_return_val_if_fail(r_installer, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
-	slot_status_tuples = g_new(GVariant*, slot_number);
+	g_assert_nonnull(r_installer);
 
 	res = determine_slot_states(&ierror);
 	if (!res) {
-		g_debug("Failed to determine slot states: %s\n", ierror->message);
-		g_clear_error(&ierror);
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to determine slot states: ");
+		return NULL;
 	}
 
 	res = determine_boot_states(&ierror);
 	if (!res) {
-		g_debug("Failed to determine boot states: %s\n", ierror->message);
+		g_message("Failed to determine boot states: %s", ierror->message);
 		g_clear_error(&ierror);
 	}
+
+	slot_status_tuples = g_new(GVariant*, slot_number);
 
 	g_hash_table_iter_init(&iter, r_context()->config->slots);
 	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
@@ -330,18 +335,27 @@ static GVariant* create_slotstatus_array(void)
 static gboolean r_on_handle_get_slot_status(RInstaller *interface,
 		GDBusMethodInvocation  *invocation)
 {
+	GVariant *slotstatus;
+	GError *ierror = NULL;
 	gboolean res;
 
 	res = !r_context_get_busy();
 
-	if (res) {
-		r_installer_complete_get_slot_status(interface, invocation, create_slotstatus_array());
-	} else {
+	if (!res) {
 		g_dbus_method_invocation_return_error(invocation,
 				G_IO_ERROR,
 				G_IO_ERROR_FAILED_HANDLED,
 				"already processing a different method");
+		return TRUE;
 	}
+
+	slotstatus = create_slotstatus_array(&ierror);
+	if (!slotstatus) {
+		g_dbus_method_invocation_return_gerror(invocation, ierror);
+		return TRUE;
+	}
+
+	r_installer_complete_get_slot_status(interface, invocation, slotstatus);
 
 	return TRUE;
 }

--- a/test/install.c
+++ b/test/install.c
@@ -718,6 +718,79 @@ device=/dev/null\n\
 	g_assert_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_FAILED);
 }
 
+/* Test that get_install_images() returns non-NULL if there is no booted slot
+ * but the boot was marked as 'external' explicitly */
+static void test_install_image_selection_boot_external(void)
+{
+	g_autofree gchar *tmpdir = NULL;
+	g_autofree gchar *sysconfpath = NULL;
+	g_autoptr(GBytes) data = NULL;
+	g_autoptr(RaucManifest) rm = NULL;
+	g_autoptr(GHashTable) tgrp = NULL;
+	g_autoptr(GError) error = NULL;
+	GList *selected_images = NULL;
+	RaucImage *image = NULL;
+	gboolean res;
+
+#define MANIFEST3 "\
+[update]\n\
+compatible=foo\n\
+\n\
+[image.rootfs]\n\
+filename=rootfs.img\n\
+"
+
+	const gchar *system_conf = "\
+[system]\n\
+compatible=foo\n\
+bootloader=barebox\n\
+\n\
+[slot.rootfs.0]\n\
+bootname=system0\n\
+device=/dev/null\n\
+\n\
+[slot.rootfs.1]\n\
+bootname=system1\n\
+device=/dev/null\n\
+";
+	tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+
+	sysconfpath = write_tmp_file(tmpdir, "test.conf", system_conf, NULL);
+	g_assert_nonnull(sysconfpath);
+
+	/* Set up context */
+	r_context_conf()->configpath = sysconfpath;
+	r_context_conf()->bootslot = g_strdup("_external_"); /* mark as external */
+	r_context();
+
+	g_message("Bootname is: %s", r_context()->bootslot);
+
+	data = g_bytes_new_static(MANIFEST3, sizeof(MANIFEST3));
+	res = load_manifest_mem(data, &rm, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	res = determine_slot_states(&error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	tgrp = determine_target_install_group();
+	g_assert_nonnull(tgrp);
+
+	/* we expect the image mapping to fail as there is no slot candidate
+	 * for image.appfs */
+	selected_images = get_install_images(rm, tgrp, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(selected_images);
+
+	/* We expect a single rootfs slot to match */
+	g_assert_cmpint(g_list_length(selected_images), ==, 1);
+
+	image = (RaucImage*) g_list_nth_data(selected_images, 0);
+	g_assert_nonnull(image);
+	g_assert_cmpstr(image->filename, ==, "rootfs.img");
+}
+
 static void test_install_image_readonly(void)
 {
 	g_autofree gchar *tmpdir = NULL;
@@ -1236,6 +1309,8 @@ int main(int argc, char *argv[])
 	g_test_add_func("/install/image-selection/redundant", test_install_image_selection);
 
 	g_test_add_func("/install/image-selection/non-matching", test_install_image_selection_no_matching_slot);
+
+	g_test_add_func("/install/image-selection/boot-external", test_install_image_selection_boot_external);
 
 	g_test_add_func("/install/image-selection/readonly", test_install_image_readonly);
 

--- a/test/service.c
+++ b/test/service.c
@@ -53,7 +53,7 @@ static void service_info_fixture_set_up(ServiceFixture *fixture, gconstpointer u
 	write_tmp_file(fixture->tmpdir, "de.pengutronix.rauc.service", "\
 [D-BUS Service]\n\
 Name=de.pengutronix.rauc\n\
-Exec="TEST_SERVICES "/rauc -c test/test.conf service\n", NULL);
+Exec="TEST_SERVICES "/rauc -c test/test.conf --override-boot-slot=system0 service\n", NULL);
 
 	fixture->dbus = g_test_dbus_new(G_TEST_DBUS_NONE);
 	g_test_dbus_add_service_dir(fixture->dbus, fixture->tmpdir);


### PR DESCRIPTION
For now the service silently ignored if it could not determine slot
states. This led to a D-Bus response with a status message that
did not have the slots "state" member set to a proper value.

The CLI trying to interpret this then ends up in the undefined state of
`r_slot_slotstate_to_str()` that emits a `g_error()`

> (rauc:1523868): rauc-ERROR **: 12:32:50.829: invalid slot status 0

Fix this by not ignoring the error but forwarding it through D-Bus so
that the CLI or other frontends do not try to interpret broken data.

For this we equip `create_slotstatus_array()` with proper `GError` handling
and slightly adapt the flow in `r_on_handle_get_slot_status()` in order to
properly handle this and forward the error as a D-Bus error using
`g_dbus_method_invocation_return_gerror()`.
