### PR TITLE
src/manifest: fix NULL pointer dereference if update_manifest fails

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -292,6 +292,7 @@ out:
 gboolean save_manifest_file(const gchar *filename, RaucManifest *mf, GError **error)
 {
 	g_autoptr(GKeyFile) key_file = NULL;
+	GError *ierror = NULL;
 	gboolean res = FALSE;
 	GPtrArray *hooks = g_ptr_array_new_full(3, g_free);
 
@@ -391,9 +392,11 @@ gboolean save_manifest_file(const gchar *filename, RaucManifest *mf, GError **er
 			g_key_file_set_string(key_file, group, "filename", file->filename);
 	}
 
-	res = g_key_file_save_to_file(key_file, filename, NULL);
-	if (!res)
+	res = g_key_file_save_to_file(key_file, filename, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
 		goto free;
+	}
 
 free:
 	return res;

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -190,6 +190,23 @@ static void test_save_load_manifest(void)
 	free_manifest(rm);
 }
 
+/* Test manifest/save/writefail:
+ *
+ * Tests error handling for saving a manifest file
+ *
+ * Test cases:
+ * - try to save a manifest file to a non-existing directory
+ */
+static void test_save_manifest_writefail(void)
+{
+	GError *error = NULL;
+	gboolean res;
+	g_autoptr(RaucManifest) rm = g_new0(RaucManifest, 1);
+
+	res = save_manifest_file("test/nonexistingdir/savedmanifest.raucm", rm, &error);
+	g_assert_error(error, G_FILE_ERROR, G_FILE_ERROR_NOENT);
+	g_assert_false(res);
+}
 
 /* Test manifest/load_mem:
  *
@@ -376,6 +393,7 @@ int main(int argc, char *argv[])
 
 	g_test_add_func("/manifest/load", test_load_manifest);
 	g_test_add_func("/manifest/save_load", test_save_load_manifest);
+	g_test_add_func("/manifest/save/writefail", test_save_manifest_writefail);
 	g_test_add_func("/manifest/load_mem", test_load_manifest_mem);
 	g_test_add_func("/manifest/load_variants", test_manifest_load_variants);
 	g_test_add_func("/manifest/invalid_data", test_invalid_data);


### PR DESCRIPTION
In case we are unable to save the manifest file (e.g. insufficient
permissions), we should propagate the error. Otherwise the error
handling for update_manifest will cause a NULL pointer derefence.

Try to bundle with insufficient permission (before patch):
``` 
$ rauc bundle --keyring=keyring.crt --key=my.key --cert=my.crt RAUC my.img

(rauc:4825): GLib-CRITICAL **: 21:35:37.306: g_propagate_error: assertion 'src != NULL' failed
Speicherzugriffsfehler (Speicherabzug geschrieben)
```

Try to bundle with insufficient permission (after patch):
```
Failed to update manifest: Datei »RAUC/manifest.raucm.7B24S0« konnte nicht angelegt werden: Keine Berechtigung
```
