### PR TITLE
various cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,8 @@ config.h.in
 config.status
 configure
 libtool
-rauc
-rauc.map
+/rauc
+/rauc.map
 stamp-h1
 .deps
 .dirstamp

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -48,7 +48,7 @@ static GUnixOutputStream* open_slot_device(RaucSlot *slot, int *fd, GError **err
 		return NULL;
 	}
 
-	outstream = (GUnixOutputStream *) g_unix_output_stream_new(fd_out, TRUE);
+	outstream = G_UNIX_OUTPUT_STREAM(g_unix_output_stream_new(fd_out, TRUE));
 	if (outstream == NULL) {
 		g_propagate_prefixed_error(error, ierror,
 				"Failed to open file for writing: ");
@@ -69,7 +69,7 @@ static gboolean clear_slot(RaucSlot *slot, GError **error)
 	g_autoptr(GOutputStream) outstream = NULL;
 	gint write_count = 0;
 
-	outstream = (GOutputStream *) open_slot_device(slot, NULL, &ierror);
+	outstream = G_OUTPUT_STREAM(open_slot_device(slot, NULL, &ierror));
 	if (outstream == NULL) {
 		g_propagate_error(error, ierror);
 		return FALSE;
@@ -189,7 +189,7 @@ static gboolean copy_raw_image(RaucImage *image, GUnixOutputStream *outstream, G
 	g_autoptr(GFile) srcimagefile = g_file_new_for_path(image->filename);
 	int out_fd = g_unix_output_stream_get_fd(outstream);
 
-	g_autoptr(GInputStream) instream = (GInputStream*)g_file_read(srcimagefile, NULL, &ierror);
+	g_autoptr(GInputStream) instream = G_INPUT_STREAM(g_file_read(srcimagefile, NULL, &ierror));
 	if (instream == NULL) {
 		g_propagate_prefixed_error(error, ierror,
 				"Failed to open file for reading: ");
@@ -199,7 +199,7 @@ static gboolean copy_raw_image(RaucImage *image, GUnixOutputStream *outstream, G
 	/* Do not close fd automatically to give us the chance to call fsync() on it before closing */
 	g_unix_output_stream_set_close_fd(outstream, FALSE);
 
-	size = g_output_stream_splice((GOutputStream *) outstream, instream,
+	size = g_output_stream_splice(G_OUTPUT_STREAM(outstream), instream,
 			G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET,
 			NULL,
 			&ierror);
@@ -209,7 +209,7 @@ static gboolean copy_raw_image(RaucImage *image, GUnixOutputStream *outstream, G
 		return FALSE;
 	}
 
-	seeksize = g_seekable_tell((GSeekable*) instream);
+	seeksize = g_seekable_tell(G_SEEKABLE(instream));
 
 	if (seeksize != (goffset)image->checksum.size) {
 		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
@@ -1324,7 +1324,7 @@ static gboolean img_to_boot_mbr_switch_handler(RaucImage *image, RaucSlot *dest_
 		goto out;
 	}
 
-	outstream = (GUnixOutputStream *)g_unix_output_stream_new(out_fd, FALSE);
+	outstream = G_UNIX_OUTPUT_STREAM(g_unix_output_stream_new(out_fd, FALSE));
 	if (outstream == NULL) {
 		g_propagate_prefixed_error(error, ierror,
 				"Failed to open file for writing: ");
@@ -1439,7 +1439,7 @@ static gboolean img_to_boot_gpt_switch_handler(RaucImage *image, RaucSlot *dest_
 		goto out;
 	}
 
-	outstream = (GUnixOutputStream *)g_unix_output_stream_new(out_fd, FALSE);
+	outstream = G_UNIX_OUTPUT_STREAM(g_unix_output_stream_new(out_fd, FALSE));
 	if (outstream == NULL) {
 		g_propagate_prefixed_error(error, ierror,
 				"Failed to open file for writing: ");

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -98,9 +98,9 @@ static void bundle_fixture_tear_down_autobuilder2(BundleFixture *fixture,
 static void test_check_empty_bundle(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	gchar *bundlename;
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autofree gchar *bundlename = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
 	bundlename = write_random_file(fixture->tmpdir, "bundle.raucb", 0, 1234);
@@ -110,16 +110,14 @@ static void test_check_empty_bundle(BundleFixture *fixture,
 	g_assert_false(res);
 	g_assert_error(ierror, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT);
 	g_assert_null(bundle);
-
-	g_free(bundlename);
 }
 
 static void test_check_invalid_bundle(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	gchar *bundlename;
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autofree gchar *bundlename = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
 	bundlename = write_random_file(fixture->tmpdir, "bundle.raucb", 1024, 1234);
@@ -129,16 +127,14 @@ static void test_check_invalid_bundle(BundleFixture *fixture,
 	g_assert_false(res);
 	g_assert_error(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_IDENTIFIER);
 	g_assert_null(bundle);
-
-	g_free(bundlename);
 }
 
 static void bundle_test_create_extract(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	gchar *outputdir;
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autofree gchar *outputdir = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
 	outputdir = g_build_filename(fixture->tmpdir, "output", NULL);
@@ -152,15 +148,13 @@ static void bundle_test_create_extract(BundleFixture *fixture,
 	res = extract_bundle(bundle, outputdir, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
-
-	free_bundle(bundle);
 }
 
 static void bundle_test_create_mount_extract(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
 	/* mount needs to run as root */
@@ -179,16 +173,15 @@ static void bundle_test_create_mount_extract(BundleFixture *fixture,
 	res = umount_bundle(bundle, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
-
-	free_bundle(bundle);
 }
 
 static void bundle_test_extract_manifest(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	gchar *outputdir, *manifestpath;
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autofree gchar *outputdir = NULL;
+	g_autofree gchar *manifestpath = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
 	outputdir = g_build_filename(fixture->tmpdir, "output", NULL);
@@ -206,8 +199,6 @@ static void bundle_test_extract_manifest(BundleFixture *fixture,
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_true(g_file_test(manifestpath, G_FILE_TEST_EXISTS));
-
-	free_bundle(bundle);
 }
 
 // Hack to pull-in context for testing modification
@@ -216,9 +207,9 @@ extern RaucContext *context;
 static void bundle_test_resign(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	gchar *resignbundle;
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autofree gchar *resignbundle = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
 	resignbundle = g_build_filename(fixture->tmpdir, "resigned-bundle.raucb", NULL);
@@ -274,14 +265,13 @@ static void bundle_test_resign(BundleFixture *fixture,
 
 	// hacky restore of original signing_keyringpath
 	context->signing_keyringpath = NULL;
-	g_clear_pointer(&bundle, free_bundle);
 }
 
 static void bundle_test_wrong_capath(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 	r_context()->config->keyring_path = g_strdup("does/not/exist.pem");
 
 	g_assert_false(check_bundle(fixture->bundlename, &bundle, TRUE, &ierror));
@@ -297,8 +287,8 @@ static void bundle_test_wrong_capath(BundleFixture *fixture,
 static void bundle_test_verify_no_crl_warn(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
 	r_context()->config->keyring_check_crl = FALSE;
@@ -311,8 +301,6 @@ static void bundle_test_verify_no_crl_warn(BundleFixture *fixture,
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
-
-	free_bundle(bundle);
 }
 
 /* Test that verification of a bundle signed with a revoked key actually fails
@@ -320,8 +308,8 @@ static void bundle_test_verify_no_crl_warn(BundleFixture *fixture,
 static void bundle_test_verify_revoked(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 
 	g_assert_false(check_bundle(fixture->bundlename, &bundle, TRUE, &ierror));
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
@@ -331,8 +319,8 @@ static void bundle_test_verify_revoked(BundleFixture *fixture,
 static void bundle_test_purpose_default(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
 	/* When the cert specifies no purpose, everything except 'codesign' is allowed */
@@ -374,8 +362,8 @@ static void bundle_test_purpose_default(BundleFixture *fixture,
 static void bundle_test_purpose_email(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
 	/* When the cert specifies the 'smimesign' usage, only default and that is allowed */
@@ -418,8 +406,8 @@ static void bundle_test_purpose_email(BundleFixture *fixture,
 static void bundle_test_purpose_codesign(BundleFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucBundle *bundle = NULL;
-	GError *ierror = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
 	/* When the cert specifies the 'codesign' usage, only that is allowed */

--- a/test/install-fixtures.c
+++ b/test/install-fixtures.c
@@ -9,10 +9,10 @@
 void fixture_helper_fixture_set_up_system_user(gchar *tmpdir,
 		const gchar *configname)
 {
-	gchar *configpath;
-	gchar *certpath;
-	gchar *keypath;
-	gchar *capath;
+	g_autofree gchar *configpath = NULL;
+	g_autofree gchar *certpath = NULL;
+	g_autofree gchar *keypath = NULL;
+	g_autofree gchar *capath = NULL;
 
 	g_assert_nonnull(tmpdir);
 	g_print("bundle tmpdir: %s\n", tmpdir);
@@ -78,11 +78,6 @@ void fixture_helper_fixture_set_up_system_user(gchar *tmpdir,
 
 	/* Set dummy bootname provider */
 	r_context_conf()->bootslot = g_strdup("system0");
-
-	g_free(configpath);
-	g_free(certpath);
-	g_free(keypath);
-	g_free(capath);
 }
 
 void fixture_helper_set_up_system(gchar *tmpdir,
@@ -124,10 +119,10 @@ void fixture_helper_set_up_bundle(gchar *tmpdir,
 		gboolean handler,
 		gboolean hook)
 {
-	gchar *contentdir;
-	gchar *bundlepath;
-	gchar *mountdir;
-	gchar *testfilepath;
+	g_autofree gchar *contentdir = NULL;
+	g_autofree gchar *bundlepath = NULL;
+	g_autofree gchar *mountdir = NULL;
+	g_autofree gchar *testfilepath = NULL;
 
 	/* needs to run as root */
 	if (!test_running_as_root())
@@ -185,9 +180,4 @@ void fixture_helper_set_up_bundle(gchar *tmpdir,
 
 	/* Create bundle */
 	g_assert_true(create_bundle(bundlepath, contentdir, NULL));
-
-	g_free(bundlepath);
-	g_free(contentdir);
-	g_free(mountdir);
-	g_free(testfilepath);
 }

--- a/test/install-fixtures.c
+++ b/test/install-fixtures.c
@@ -123,6 +123,8 @@ void fixture_helper_set_up_bundle(gchar *tmpdir,
 	g_autofree gchar *bundlepath = NULL;
 	g_autofree gchar *mountdir = NULL;
 	g_autofree gchar *testfilepath = NULL;
+	g_autoptr(GError) error = NULL;
+	gboolean res = FALSE;
 
 	/* needs to run as root */
 	if (!test_running_as_root())
@@ -179,5 +181,7 @@ void fixture_helper_set_up_bundle(gchar *tmpdir,
 	g_assert_true(update_manifest(contentdir, NULL));
 
 	/* Create bundle */
-	g_assert_true(create_bundle(bundlepath, contentdir, NULL));
+	res = create_bundle(bundlepath, contentdir, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 }

--- a/test/install.c
+++ b/test/install.c
@@ -151,7 +151,7 @@ hooks=post-install";
 static void install_fixture_set_up_system_conf(InstallFixture *fixture,
 		gconstpointer user_data)
 {
-	gchar* pathname = NULL;
+	g_autofree gchar* pathname = NULL;
 	const gchar *cfg_file = "\
 [system]\n\
 compatible=FooCorp Super BarBazzer\n\
@@ -218,8 +218,6 @@ device=/path/to/prebootloader";
 	pathname = write_tmp_file(fixture->tmpdir, "system.conf", cfg_file, NULL);
 	g_assert_nonnull(pathname);
 	r_context_conf()->configpath = g_strdup(pathname);
-
-	g_free(pathname);
 }
 
 static void install_fixture_tear_down(InstallFixture *fixture,
@@ -242,10 +240,10 @@ static void install_test_bootname(InstallFixture *fixture,
 static void install_test_target(InstallFixture *fixture,
 		gconstpointer user_data)
 {
-	RaucManifest *rm = NULL;
-	GHashTable *tgrp;
+	g_autoptr(RaucManifest) rm = NULL;
+	g_autoptr(GHashTable) tgrp = NULL;
 	GList *selected_images = NULL;
-	GError *error = NULL;
+	g_autoptr(GError) error = NULL;
 	gboolean result;
 
 
@@ -334,16 +332,14 @@ filename=bootloader.img";
 	g_assert_cmpstr(((RaucImage*)g_list_nth_data(selected_images, 1))->filename, ==, "appfs.ext4");
 	g_assert_cmpstr(((RaucImage*)g_list_nth_data(selected_images, 2))->filename, ==, "demofs.ext4");
 	g_assert_cmpstr(((RaucImage*)g_list_nth_data(selected_images, 3))->filename, ==, "bootloader.img");
-
-	g_hash_table_unref(tgrp);
 }
 
 /* Test with image for non-redundant active target slot. */
 static void test_install_determine_target_group_non_redundant(void)
 {
-	gchar *tmpdir = NULL;
-	gchar* sysconfpath = NULL;
-	GHashTable *tgrp = NULL;
+	g_autofree gchar *tmpdir = NULL;
+	g_autofree gchar *sysconfpath = NULL;
+	g_autoptr(GHashTable) tgrp = NULL;
 
 	const gchar *system_conf = "\
 [system]\n\
@@ -359,7 +355,6 @@ device=/dev/null\n\
 
 	sysconfpath = write_tmp_file(tmpdir, "test.conf", system_conf, NULL);
 	g_assert_nonnull(sysconfpath);
-	g_free(tmpdir);
 
 	/* Set up context */
 	r_context_conf()->configpath = sysconfpath;
@@ -373,17 +368,15 @@ device=/dev/null\n\
 
 	/* We must not have any updatable slot detected */
 	g_assert_cmpint(g_hash_table_size(tgrp), ==, 0);
-
-	g_hash_table_unref(tgrp);
 }
 
 /* Test a typical asynchronous slot setup (rootfs + rescuefs) with additional
  * childs */
 static void test_install_target_group_async(void)
 {
-	gchar *tmpdir = NULL;
-	gchar* sysconfpath = NULL;
-	GHashTable *tgrp = NULL;
+	g_autofree gchar *tmpdir = NULL;
+	g_autofree gchar *sysconfpath = NULL;
+	g_autoptr(GHashTable) tgrp = NULL;
 
 	const gchar *system_conf = "\
 [system]\n\
@@ -411,7 +404,6 @@ device=/dev/null\n\
 
 	sysconfpath = write_tmp_file(tmpdir, "test.conf", system_conf, NULL);
 	g_assert_nonnull(sysconfpath);
-	g_free(tmpdir);
 
 	/* Set up context */
 	r_context_conf()->configpath = sysconfpath;
@@ -430,16 +422,14 @@ device=/dev/null\n\
 
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rootfs"))->name, ==, "rootfs.0");
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "appfs"))->name, ==, "appfs.0");
-
-	g_hash_table_unref(tgrp);
 }
 
 /* Test a typical synchronous slot setup (rootfs a + b) with appfs childs */
 static void test_install_target_group_sync(void)
 {
-	gchar *tmpdir = NULL;
-	gchar* sysconfpath = NULL;
-	GHashTable *tgrp = NULL;
+	g_autofree gchar *tmpdir = NULL;
+	g_autofree gchar *sysconfpath = NULL;
+	g_autoptr(GHashTable) tgrp = NULL;
 
 	const gchar *system_conf = "\
 [system]\n\
@@ -484,16 +474,14 @@ device=/dev/null\n\
 
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rootfs"))->name, ==, "rootfs.0");
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "appfs"))->name, ==, "appfs.0");
-
-	g_hash_table_unref(tgrp);
 }
 
 /* Test with extra loose (non-booted) groups in parent child relation */
 static void test_install_target_group_loose(void)
 {
-	gchar *tmpdir = NULL;
-	gchar* sysconfpath = NULL;
-	GHashTable *tgrp = NULL;
+	g_autofree gchar *tmpdir = NULL;
+	g_autofree gchar *sysconfpath = NULL;
+	g_autoptr(GHashTable) tgrp = NULL;
 
 	const gchar *system_conf = "\
 [system]\n\
@@ -533,16 +521,14 @@ device=/dev/null\n\
 
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "xloader"))->name, ==, "xloader.0");
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "bootloader"))->name, ==, "bootloader.0");
-
-	g_hash_table_unref(tgrp);
 }
 
 /* Test with 3 redundant slots */
 static void test_install_target_group_n_redundant(void)
 {
-	gchar *tmpdir = NULL;
-	gchar* sysconfpath = NULL;
-	GHashTable *tgrp = NULL;
+	g_autofree gchar *tmpdir = NULL;
+	g_autofree gchar *sysconfpath = NULL;
+	g_autoptr(GHashTable) tgrp = NULL;
 
 	const gchar *system_conf = "\
 [system]\n\
@@ -581,19 +567,17 @@ device=/dev/null\n\
 	g_assert_true(g_hash_table_contains(tgrp, "rootfs"));
 
 	g_assert_cmpstr(((RaucSlot*)g_hash_table_lookup(tgrp, "rootfs"))->name, ==, "rootfs.0");
-
-	g_hash_table_unref(tgrp);
 }
 
 /* Test image selection, default redundancy setup */
 static void test_install_image_selection(void)
 {
-	gchar *tmpdir = NULL;
-	gchar* sysconfpath = NULL;
-	GBytes *data = NULL;
-	RaucManifest *rm = NULL;
-	GHashTable *tgrp = NULL;
-	GError *error = NULL;
+	g_autofree gchar *tmpdir = NULL;
+	g_autofree gchar *sysconfpath = NULL;
+	g_autoptr(GBytes) data = NULL;
+	g_autoptr(RaucManifest) rm = NULL;
+	g_autoptr(GHashTable) tgrp = NULL;
+	g_autoptr(GError) error = NULL;
 	GList *selected_images = NULL;
 	RaucImage *image = NULL;
 	gboolean res;
@@ -668,18 +652,16 @@ device=/dev/null\n\
 	image = (RaucImage*) g_list_nth_data(selected_images, 1);
 	g_assert_nonnull(image);
 	g_assert_cmpstr(image->filename, ==, "appfs.img");
-
-	g_hash_table_unref(tgrp);
 }
 
 static void test_install_image_selection_no_matching_slot(void)
 {
-	gchar *tmpdir = NULL;
-	gchar* sysconfpath = NULL;
-	GBytes *data = NULL;
-	RaucManifest *rm = NULL;
-	GHashTable *tgrp = NULL;
-	GError *error = NULL;
+	g_autofree gchar *tmpdir = NULL;
+	g_autofree gchar *sysconfpath = NULL;
+	g_autoptr(GBytes) data = NULL;
+	g_autoptr(RaucManifest) rm = NULL;
+	g_autoptr(GHashTable) tgrp = NULL;
+	g_autoptr(GError) error = NULL;
 	GList *selected_images = NULL;
 	gboolean res;
 
@@ -734,18 +716,16 @@ device=/dev/null\n\
 	selected_images = get_install_images(rm, tgrp, &error);
 	g_assert_null(selected_images);
 	g_assert_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_FAILED);
-
-	g_hash_table_unref(tgrp);
 }
 
 static void test_install_image_readonly(void)
 {
-	gchar *tmpdir = NULL;
-	gchar* sysconfpath = NULL;
-	GBytes *data = NULL;
-	RaucManifest *rm = NULL;
-	GHashTable *tgrp = NULL;
-	GError *error = NULL;
+	g_autofree gchar *tmpdir = NULL;
+	g_autofree gchar *sysconfpath = NULL;
+	g_autoptr(GBytes) data = NULL;
+	g_autoptr(RaucManifest) rm = NULL;
+	g_autoptr(GHashTable) tgrp = NULL;
+	g_autoptr(GError) error = NULL;
 	GList *selected_images = NULL;
 	gboolean res;
 
@@ -797,21 +777,19 @@ readonly=true\n\
 	selected_images = get_install_images(rm, tgrp, &error);
 	g_assert_null(selected_images);
 	g_assert_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_FAILED);
-
-	g_hash_table_unref(tgrp);
 }
 
 
 static void test_install_image_variants(void)
 {
-	gchar *tmpdir = NULL;
-	gchar* sysconfpath = NULL;
-	GBytes *data = NULL;
-	RaucManifest *rm = NULL;
-	GHashTable *tgrp = NULL;
+	g_autofree gchar *tmpdir = NULL;
+	g_autofree gchar *sysconfpath = NULL;
+	g_autoptr(GBytes) data = NULL;
+	g_autoptr(RaucManifest) rm = NULL;
+	g_autoptr(GHashTable) tgrp = NULL;
 	GList *install_images = NULL;
 	RaucImage *test_img = NULL;
-	GError *error = NULL;
+	g_autoptr(GError) error = NULL;
 	gboolean res;
 
 #define MANIFEST_VARIANT "\
@@ -891,6 +869,7 @@ device=/dev/null\n\
 	g_assert_cmpstr(test_img->variant, ==, "variant-1");
 
 	g_clear_pointer(&rm, free_manifest);
+	g_clear_pointer(&data, g_bytes_unref);
 
 	/* Test with manifest containing only default variant */
 	data = g_bytes_new_static(MANIFEST_DEFAULT_VARIANT, sizeof(MANIFEST_DEFAULT_VARIANT));
@@ -910,6 +889,7 @@ device=/dev/null\n\
 	g_assert_null(test_img->variant);
 
 	g_clear_pointer(&rm, free_manifest);
+	g_clear_pointer(&data, g_bytes_unref);
 
 	/* Test with manifest containing only non-matching specific variant (must fail) */
 	data = g_bytes_new_static(MANIFEST_OTHER_VARIANT, sizeof(MANIFEST_OTHER_VARIANT));
@@ -921,10 +901,6 @@ device=/dev/null\n\
 	install_images = get_install_images(rm, tgrp, &error);
 	g_assert_null(install_images);
 	g_assert_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_FAILED);
-
-	g_hash_table_unref(tgrp);
-
-	g_clear_pointer(&rm, free_manifest);
 }
 
 static gboolean r_quit(gpointer data)
@@ -980,7 +956,7 @@ static void install_test_bundle(InstallFixture *fixture,
 	g_autofree gchar *testfilepath = NULL;
 	g_autofree gchar *mountdir = NULL;
 	RaucInstallArgs *args;
-	GError *ierror = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res;
 
 	/* needs to run as root */
@@ -1027,7 +1003,8 @@ static void install_test_bundle_thread(InstallFixture *fixture,
 		gconstpointer user_data)
 {
 	RaucInstallArgs *args = install_args_new();
-	gchar *bundlepath, *mountdir;
+	g_autofree gchar *bundlepath = NULL;
+	g_autofree gchar *mountdir = NULL;
 
 	/* needs to run as root */
 	if (!test_running_as_root())
@@ -1050,16 +1027,15 @@ static void install_test_bundle_thread(InstallFixture *fixture,
 	g_assert_true(install_run(args));
 	g_main_loop_run(r_loop);
 	g_clear_pointer(&r_loop, g_main_loop_unref);
-
-	g_free(bundlepath);
 }
 
 static void install_test_bundle_hook_install_check(InstallFixture *fixture,
 		gconstpointer user_data)
 {
-	gchar *bundlepath, *mountdir;
+	g_autofree gchar *bundlepath = NULL;
+	g_autofree gchar *mountdir = NULL;
 	RaucInstallArgs *args;
-	GError *ierror = NULL;
+	g_autoptr(GError) ierror = NULL;
 
 	/* needs to run as root */
 	if (!test_running_as_root())
@@ -1082,17 +1058,18 @@ static void install_test_bundle_hook_install_check(InstallFixture *fixture,
 	g_assert_cmpstr(ierror->message, ==, "Installation error: Bundle rejected: Hook returned: No, I won't install this!");
 
 	args->status_result = 0;
-
-	g_free(bundlepath);
-	g_free(mountdir);
 }
 
 static void install_test_bundle_hook_install(InstallFixture *fixture,
 		gconstpointer user_data)
 {
-	gchar *bundlepath, *mountdir, *slotfile, *stamppath, *hookfilepath;
+	g_autofree gchar *bundlepath = NULL;
+	g_autofree gchar *mountdir = NULL;
+	g_autofree gchar *slotfile = NULL;
+	g_autofree gchar *stamppath = NULL;
+	g_autofree gchar *hookfilepath = NULL;
 	RaucInstallArgs *args;
-	GError *ierror = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
 	/* needs to run as root */
@@ -1123,27 +1100,26 @@ static void install_test_bundle_hook_install(InstallFixture *fixture,
 	g_assert_true(g_file_test(hookfilepath, G_FILE_TEST_IS_REGULAR));
 	g_assert_false(g_file_test(stamppath, G_FILE_TEST_IS_REGULAR));
 	g_assert(test_umount(fixture->tmpdir, "mount"));
-	g_free(hookfilepath);
-	g_free(stamppath);
-	g_free(slotfile);
 
+	g_free(slotfile);
 	slotfile = g_build_filename(fixture->tmpdir, "images/appfs-1", NULL);
+	g_free(stamppath);
 	stamppath = g_build_filename(mountdir, "hook-stamp", NULL);
 	g_assert(test_mount(slotfile, mountdir));
 	g_assert_false(g_file_test(stamppath, G_FILE_TEST_IS_REGULAR));
 	g_assert(test_umount(fixture->tmpdir, "mount"));
-	g_free(stamppath);
-	g_free(slotfile);
 
 	args->status_result = 0;
-
-	g_free(bundlepath);
 }
 
 static void install_test_bundle_hook_post_install(InstallFixture *fixture,
 		gconstpointer user_data)
 {
-	gchar *bundlepath, *mountdir, *slotfile, *testfilepath, *stamppath;
+	g_autofree gchar *bundlepath = NULL;
+	g_autofree gchar *mountdir = NULL;
+	g_autofree gchar *slotfile = NULL;
+	g_autofree gchar *testfilepath = NULL;
+	g_autofree gchar *stamppath = NULL;
 	RaucInstallArgs *args;
 
 	/* needs to run as root */
@@ -1172,30 +1148,27 @@ static void install_test_bundle_hook_post_install(InstallFixture *fixture,
 	g_assert(g_file_test(testfilepath, G_FILE_TEST_IS_REGULAR));
 	g_assert(g_file_test(stamppath, G_FILE_TEST_IS_REGULAR));
 	g_assert(test_umount(fixture->tmpdir, "mount"));
-	g_free(stamppath);
-	g_free(slotfile);
-	g_free(testfilepath);
 
+	g_free(slotfile);
 	slotfile = g_build_filename(fixture->tmpdir, "images/appfs-1", NULL);
+	g_free(stamppath);
 	stamppath = g_build_filename(mountdir, "hook-stamp", NULL);
 	g_assert(test_mount(slotfile, mountdir));
 	g_assert(!g_file_test(stamppath, G_FILE_TEST_IS_REGULAR));
 	g_assert(test_umount(fixture->tmpdir, "mount"));
-	g_free(stamppath);
-	g_free(slotfile);
 
 	args->status_result = 0;
-
-	g_free(bundlepath);
 }
 
 /* Test with already mounted slot */
 static void install_test_already_mounted(InstallFixture *fixture,
 		gconstpointer user_data)
 {
-	gchar *bundlepath, *mountprefix, *hookfilepath;
+	g_autofree gchar *bundlepath = NULL;
+	g_autofree gchar *mountprefix = NULL;
+	g_autofree gchar *hookfilepath = NULL;
 	RaucInstallArgs *args;
-	GError *ierror = NULL;
+	g_autoptr(GError) ierror = NULL;
 	gboolean res;
 
 	/* needs to run as root */
@@ -1226,8 +1199,6 @@ static void install_test_already_mounted(InstallFixture *fixture,
 	g_assert_true(g_file_test(hookfilepath, G_FILE_TEST_IS_REGULAR));
 
 	args->status_result = 0;
-
-	g_free(bundlepath);
 }
 
 static void install_fixture_set_up_system_user(InstallFixture *fixture,
@@ -1241,12 +1212,11 @@ static void install_fixture_set_up_system_user(InstallFixture *fixture,
 int main(int argc, char *argv[])
 {
 	InstallData *install_data;
-	gchar *path;
+	g_autofree gchar *path = NULL;
 	setlocale(LC_ALL, "C");
 
 	path = g_strdup_printf("%s:%s", g_getenv("PATH"), "test/bin");
 	g_setenv("PATH", path, TRUE);
-	g_free(path);
 
 	g_test_init(&argc, &argv, NULL);
 

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -160,7 +160,7 @@ static gsize get_file_size(gchar* filename, GError **error)
 		goto out;
 	}
 
-	size = g_seekable_tell((GSeekable *)filestream);
+	size = g_seekable_tell(G_SEEKABLE(filestream));
 
 out:
 	g_clear_object(&filestream);


### PR DESCRIPTION
This increases g_autofree and g_autoptr usage in tests to make actual leaks easier to find. Also we add some more runtime checks and print the signer name after signature verification.