### PR TITLE
gitignore: add precompiled Python files and some generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,13 @@
 /data/de.pengutronix.rauc.service
 /data/rauc-service.sh
 /data/rauc.service
+/test/*.dat
 /test/*.test
 /test/*.map
+/test/*.rauc*
 /test/fakerand
 /test/services/de.pengutronix.rauc.service
+/test/test-results
 /*-generated.[ch]
 /.qemu_bash_history
 Makefile
@@ -38,6 +41,7 @@ stamp-h1
 *.lo
 *.log
 *.o
+*.pyc
 *.so*
 *.tar*
 *.trs


### PR DESCRIPTION
This covers some file in e.g. docs/extensions/lexer
and also ignores some files generated during tests.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>