### PR TITLE
src/install: remove checksum verification for files in bundle

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -853,15 +853,6 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 		mfimage = l->data;
 		dest_slot = g_hash_table_lookup(target_group, mfimage->slotclass);
 
-		/* Verify image checksum (for non-casync images) */
-		if (!g_str_has_suffix(mfimage->filename, ".caibx") && !g_str_has_suffix(mfimage->filename, ".caidx")) {
-			res = verify_checksum(&mfimage->checksum, mfimage->filename, &ierror);
-			if (!res) {
-				g_propagate_prefixed_error(error, ierror, "Failed verifying checksum: ");
-				goto out;
-			}
-		}
-
 		/* determine whether update image type is compatible with destination slot type */
 		update_handler = get_update_handler(mfimage, dest_slot, &ierror);
 		if (update_handler == NULL) {


### PR DESCRIPTION
The RAUC bundle is already verified at this point, so there is no need
to verify the checksum of each file individually. This saves time during
the installation.