### PR TITLE
test/get-coverity: let script detect and handle errors more reliably

### DIFF
--- a/test/get-coverity.sh
+++ b/test/get-coverity.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Based on systemd's travis-ci/tools/get-coverity.sh
 
 # Download and extract coverity tool
@@ -32,7 +34,7 @@ if [ ! -d $TOOL_BASE ]; then
   echo -e "\033[33;1mExtracting Coverity Scan Analysis Tool...\033[0m"
   mkdir -p $TOOL_BASE
   pushd $TOOL_BASE
-  tar xzf $TOOL_ARCHIVE
+  tar xzf $TOOL_ARCHIVE || rm -r $TOOL_BASE && exit 1
   popd
 fi
 


### PR DESCRIPTION
Note: coverity currently seems to provide a broken package.
Testing this revealed some drawbacks of the current script handling that should be fixed.

Commit message:

We add 'set -e' to abort on errors. This allows identifying issues in
the test flow earlier.

We remove the created $TOOL_BASE directory on extraction error as this
is used to check for skipping the download the next time the script
runs.