### PR TITLE
Make uboot attempt settings configurable

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -93,6 +93,18 @@ Example configuration:
   key not exists, the bootchooser framework searches per default for ``/state``
   or ``/aliases/state``.
 
+``boot-attempts``
+  This configures the number of boot attempts to set when a slot is marked good
+  through the D-Bus API or via the command line tool.
+  This is currently only supported when ``bootloader`` is set to ``uboot`` and
+  defaults to 3 if not set.
+
+``boot-attempts-primary``
+  This configures the number of boot attempts to set when a slot is marked as
+  primary (ie, when an update was installed successfully).
+  This is currently only supported when ``bootloader`` is set to ``uboot`` and
+  defaults to 3 if not set.
+
 ``efi-use-bootnext``
   Only valid when ``bootloader`` is set to ``efi``.
   If set to ``false``, this disables using efi variable ``BootNext`` for

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -36,6 +36,8 @@ typedef struct {
 	gchar *system_variant;
 	gchar *system_bootloader;
 	gchar *system_bb_statename;
+	gint boot_default_attempts;
+	gint boot_attempts_primary;
 	gchar *grubenv_path;
 	gchar *custom_bootloader_backend;
 	gboolean efi_use_bootnext;

--- a/include/utils.h
+++ b/include/utils.h
@@ -139,6 +139,13 @@ gchar * key_file_consume_string(
 		GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
+gint key_file_consume_integer(
+		GKeyFile *key_file,
+		const gchar *group_name,
+		const gchar *key,
+		GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
 guint64 key_file_consume_binary_suffixed_string(GKeyFile *key_file,
 		const gchar *group_name,
 		const gchar *key,

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -252,6 +252,9 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		}
 	}
 
+	c->boot_default_attempts = key_file_consume_integer(key_file, "system", "boot-attempts", NULL);
+	c->boot_attempts_primary = key_file_consume_integer(key_file, "system", "boot-attempts-primary", NULL);
+
 	c->max_bundle_download_size = g_key_file_get_uint64(key_file, "system", "max-bundle-download-size", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
 		g_debug("No value for key \"max-bundle-download-size\" in [system] defined "

--- a/src/utils.c
+++ b/src/utils.c
@@ -211,6 +211,25 @@ gchar * key_file_consume_string(
 	return result;
 }
 
+/* get integer argument from key and remove key from key_file */
+gint key_file_consume_integer(
+		GKeyFile *key_file,
+		const gchar *group_name,
+		const gchar *key,
+		GError **error)
+{
+	gint result;
+	GError *ierror = NULL;
+
+	result = g_key_file_get_integer(key_file, group_name, key, &ierror);
+	if (ierror == NULL)
+		g_key_file_remove_key(key_file, group_name, key, NULL);
+	else
+		g_propagate_error(error, ierror);
+
+	return result;
+}
+
 guint64 key_file_consume_binary_suffixed_string(GKeyFile *key_file,
 		const gchar *group_name,
 		const gchar *key,


### PR DESCRIPTION
Make it possible to tweak the number of attempts that are set in the U-Boot environment when marking slots active or good.
    
This is helpful for systems that want to have different settings for first boots and consecutive ones.
