### PR TITLE
test/get-coverity: fix error handling

### DIFF
--- a/test/get-coverity.sh
+++ b/test/get-coverity.sh
@@ -34,7 +34,10 @@ if [ ! -d $TOOL_BASE ]; then
   echo -e "\033[33;1mExtracting Coverity Scan Analysis Tool...\033[0m"
   mkdir -p $TOOL_BASE
   pushd $TOOL_BASE
-  tar xzf $TOOL_ARCHIVE || rm -r $TOOL_BASE && exit 1
+  if ! tar xzf $TOOL_ARCHIVE; then
+    rm -r $TOOL_BASE
+    exit 1
+  fi
   popd
 fi
 


### PR DESCRIPTION
A || B && C runs C if either A or B succeeds, which happens always in this case.

This fixes aa4676cacbf23e32905b0b7a66662a816f253d0f.