### PR TITLE
src/bundle: remove duplicate signature on casync bundle

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -715,12 +715,6 @@ gboolean create_casync_bundle(RaucBundle *bundle, const gchar *outbundle, GError
 		goto out;
 	}
 
-	res = sign_bundle(outbundle, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
-	}
-
 	res = TRUE;
 out:
 	/* Remove output file on error */


### PR DESCRIPTION
As convert_to_casync_bundle() already calls sign_bundle() via create_bundle(),
this call is redundant. Remove it.
