### PR TITLE
src/mount.c: fix build with kernel < 4.14

### DIFF
--- a/src/mount.c
+++ b/src/mount.c
@@ -11,6 +11,10 @@
 #include "mount.h"
 #include "utils.h"
 
+#ifndef LOOP_SET_BLOCK_SIZE
+#define LOOP_SET_BLOCK_SIZE 0x4C09
+#endif
+
 gboolean r_mount_bundle(const gchar *source, const gchar *mountpoint, GError **error)
 {
 	const unsigned long flags = MS_NODEV | MS_NOSUID | MS_RDONLY;


### PR DESCRIPTION
Build with kernel headers < 4.14 fails since version 1.5.0 and https://github.com/rauc/rauc/commit/527bf2f7f746e0253f7843542e19cb0fa0c7c869:

```
src/mount.c: In function 'r_setup_loop':
src/mount.c:201:25: error: 'LOOP_SET_BLOCK_SIZE' undeclared (first use in this function)
  looprc = ioctl(loopfd, LOOP_SET_BLOCK_SIZE, 4096);
                         ^
```

Indeed, `LOOP_SET_BLOCK_SIZE` is only defined since https://github.com/torvalds/linux/commit/89e4fdecb51cf5535867026274bc97de9480ade5

Fixes:
 - http://autobuild.buildroot.org/results/829ae7ed66686c11a941ac99bd08a06f754affb4

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>