### PR TITLE
Include string.h to fix Compilation With Some Toolchains

### DIFF
--- a/src/dm.c
+++ b/src/dm.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include <linux/dm-ioctl.h>
 #include <errno.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/sysmacros.h>
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -7,6 +7,7 @@
 #include <openssl/crypto.h>
 #include <openssl/engine.h>
 #include <openssl/x509.h>
+#include <string.h>
 
 #include "context.h"
 #include "signature.h"


### PR DESCRIPTION
Some older toolchains do not provide (correct) built-in defintions of `strstr()` or `memset()` and thus emit compilation warnings or errors:

```
[..] warning: incompatible implicit declaration of built-in function 'strstr'
```
```
src/dm.c:15:2: error: implicit declaration of function 'memset' [-Werror=implicit-function-declaration]
  memset(header, 0, sizeof(*header));
```

Fix this by including `string.h` explicitly.

Tested on ubuntu-16.04.