### PR TITLE
configure.ac: increase minimum glib version required (2.49.3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AS_IF([test "x$enable_create" != "xno"], [
 ])
 
 # Checks for libraries.
-PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.45.8 gio-2.0 gio-unix-2.0])
+PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.49.3 gio-2.0 gio-unix-2.0])
 
 AC_ARG_ENABLE([network],
        AS_HELP_STRING([--disable-network], [Disable network update mode])


### PR DESCRIPTION
Since we use `G_VARIANT_DICT_INIT` introduced by f2eda48dde10dded99310122d994d68ec2b5960e ("src/main.c: switch to use new client API") which was first defined in glib 2.49.3, this is now the minimum required glib version.

See: https://gitlab.gnome.org/GNOME/glib/-/blob/master/NEWS#L3180

This affects releases 1.5, 1.4, 1.3.