### PR TITLE
Restore Compatibility With glib 2.50 API and add API Compatibility Checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,11 @@ AS_IF([test "x$enable_create" != "xno"], [
 
 # Checks for libraries.
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.49.3 gio-2.0 gio-unix-2.0])
+# Sanity checks to not use new glib methods unintentionally.
+# package check, minimum and maximum required version must be updated
+# explicitly when using newer glib APIs
+AC_DEFINE(GLIB_VERSION_MAX_ALLOWED, G_ENCODE_VERSION(2,52), [Prevent post-2.52 APIs])
+AC_DEFINE(GLIB_VERSION_MIN_REQUIRED, G_ENCODE_VERSION(2,50), [Set to minimum supported API version])
 
 AC_ARG_ENABLE([network],
        AS_HELP_STRING([--disable-network], [Disable network update mode])

--- a/src/dm.c
+++ b/src/dm.c
@@ -10,6 +10,47 @@
 
 #include "dm.h"
 
+#ifndef GLIB_VERSION_2_52
+/**
+ * g_uuid_string_random:
+ *
+ * Generates a random UUID (RFC 4122 version 4) as a string.
+ *
+ * Returns: (transfer full): A string that should be freed with g_free().
+ */
+static gchar *
+g_uuid_string_random(void)
+{
+	int i;
+	guint8 bytes[16];
+	guint32 *ints;
+
+	ints = (guint32 *) bytes;
+	for (i = 0; i < 4; i++)
+		ints[i] = g_random_int();
+
+	/*
+	 * Set the four most significant bits (bits 12 through 15) of the
+	 * time_hi_and_version field to the 4-bit version number from
+	 * Section 4.1.3.
+	 */
+	bytes[6] &= 0x0f;
+	bytes[6] |= 4 << 4;
+	/*
+	 * Set the two most significant bits (bits 6 and 7) of the
+	 * clock_seq_hi_and_reserved to zero and one, respectively.
+	 */
+	bytes[8] &= 0x3f;
+	bytes[8] |= 0x80;
+
+	return g_strdup_printf("%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x"
+			"-%02x%02x%02x%02x%02x%02x",
+			bytes[0], bytes[1], bytes[2], bytes[3],
+			bytes[4], bytes[5], bytes[6], bytes[7],
+			bytes[8], bytes[9], bytes[10], bytes[11],
+			bytes[12], bytes[13], bytes[14], bytes[15]);
+}
+#endif
 
 static void dm_set_header(struct dm_ioctl *header, size_t size, guint32 flags, const gchar *uuid)
 {

--- a/src/network.c
+++ b/src/network.c
@@ -1,4 +1,5 @@
 #include <curl/curl.h>
+#include <errno.h>
 #include <gio/gio.h>
 #include <glib/gstdio.h>
 #include <stdio.h>
@@ -164,6 +165,13 @@ gboolean download_file(const gchar *target, const gchar *url, goffset limit, GEr
 	}
 
 out:
-	g_clear_pointer(&xfer.dl, fclose);
+	if (xfer.dl) {
+		if (fclose(xfer.dl)) {
+			int err = errno;
+			g_debug("Failed to close download file '%s': %s", target, g_strerror(err));
+		}
+		xfer.dl = NULL;
+	}
+
 	return res;
 }


### PR DESCRIPTION
* Optionally define `g_uuid_string_random()` that required to move to glib 2.52 before
* Check for glib API versions required to prevent from unintentionally depending on newer API
* Fix fallout