### PR TITLE
.github: workflows: compile tests on ubuntu stable releases

### DIFF
--- a/.github/workflows/patches/16.04/0001-backport-to-OpenSSL-1.0.2.patch
+++ b/.github/workflows/patches/16.04/0001-backport-to-OpenSSL-1.0.2.patch
@@ -1,0 +1,298 @@
+From fffc9a1127687a93b9155ccfd4bd97978380987d Mon Sep 17 00:00:00 2001
+From: Jan Luebbe <jlu@pengutronix.de>
+Date: Tue, 1 Dec 2020 12:47:37 +0100
+Subject: [PATCH] backport to OpenSSL 1.0.2
+
+This is partially a revert of commit
+3c6470ba7c2adbf51e5eaf4601e4affbab0c15c5.
+
+Signed-off-by: Jan Luebbe <jlu@pengutronix.de>
+---
+ configure.ac           |   2 +-
+ m4/ax_check_openssl.m4 | 124 +++++++++++++++++++++++++++++++++++++++++
+ src/signature.c        |  36 ++++++++++--
+ src/verity_hash.c      |  10 ++++
+ 4 files changed, 167 insertions(+), 5 deletions(-)
+ create mode 100644 m4/ax_check_openssl.m4
+
+diff --git a/configure.ac b/configure.ac
+index 9f071a57..6d569864 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -89,7 +89,7 @@ AS_IF([test "x$enable_json" != "xno"], [
+        AC_DEFINE([ENABLE_JSON], [0])
+ ])
+ 
+-PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.1.1])
++AX_CHECK_OPENSSL([],[AC_MSG_ERROR([OpenSSL not found])])
+ 
+ AC_ARG_ENABLE([gpt],
+        AS_HELP_STRING([--enable-gpt], [Enable GPT support])
+diff --git a/m4/ax_check_openssl.m4 b/m4/ax_check_openssl.m4
+new file mode 100644
+index 00000000..a87c5a6b
+--- /dev/null
++++ b/m4/ax_check_openssl.m4
+@@ -0,0 +1,124 @@
++# ===========================================================================
++#     http://www.gnu.org/software/autoconf-archive/ax_check_openssl.html
++# ===========================================================================
++#
++# SYNOPSIS
++#
++#   AX_CHECK_OPENSSL([action-if-found[, action-if-not-found]])
++#
++# DESCRIPTION
++#
++#   Look for OpenSSL in a number of default spots, or in a user-selected
++#   spot (via --with-openssl).  Sets
++#
++#     OPENSSL_INCLUDES to the include directives required
++#     OPENSSL_LIBS to the -l directives required
++#     OPENSSL_LDFLAGS to the -L or -R flags required
++#
++#   and calls ACTION-IF-FOUND or ACTION-IF-NOT-FOUND appropriately
++#
++#   This macro sets OPENSSL_INCLUDES such that source files should use the
++#   openssl/ directory in include directives:
++#
++#     #include <openssl/hmac.h>
++#
++# LICENSE
++#
++#   Copyright (c) 2009,2010 Zmanda Inc. <http://www.zmanda.com/>
++#   Copyright (c) 2009,2010 Dustin J. Mitchell <dustin@zmanda.com>
++#
++#   Copying and distribution of this file, with or without modification, are
++#   permitted in any medium without royalty provided the copyright notice
++#   and this notice are preserved. This file is offered as-is, without any
++#   warranty.
++
++#serial 8
++
++AU_ALIAS([CHECK_SSL], [AX_CHECK_OPENSSL])
++AC_DEFUN([AX_CHECK_OPENSSL], [
++    found=false
++    AC_ARG_WITH([openssl],
++        [AS_HELP_STRING([--with-openssl=DIR],
++            [root of the OpenSSL directory])],
++        [
++            case "$withval" in
++            "" | y | ye | yes | n | no)
++            AC_MSG_ERROR([Invalid --with-openssl value])
++              ;;
++            *) ssldirs="$withval"
++              ;;
++            esac
++        ], [
++            # if pkg-config is installed and openssl has installed a .pc file,
++            # then use that information and don't search ssldirs
++            AC_PATH_PROG([PKG_CONFIG], [pkg-config])
++            if test x"$PKG_CONFIG" != x""; then
++                OPENSSL_LDFLAGS=`$PKG_CONFIG openssl --libs-only-L 2>/dev/null`
++                if test $? = 0; then
++                    OPENSSL_LIBS=`$PKG_CONFIG openssl --libs-only-l 2>/dev/null`
++                    OPENSSL_INCLUDES=`$PKG_CONFIG openssl --cflags-only-I 2>/dev/null`
++                    found=true
++                fi
++            fi
++
++            # no such luck; use some default ssldirs
++            if ! $found; then
++                ssldirs="/usr/local/ssl /usr/lib/ssl /usr/ssl /usr/pkg /usr/local /usr"
++            fi
++        ]
++        )
++
++
++    # note that we #include <openssl/foo.h>, so the OpenSSL headers have to be in
++    # an 'openssl' subdirectory
++
++    if ! $found; then
++        OPENSSL_INCLUDES=
++        for ssldir in $ssldirs; do
++            AC_MSG_CHECKING([for openssl/ssl.h in $ssldir])
++            if test -f "$ssldir/include/openssl/ssl.h"; then
++                OPENSSL_INCLUDES="-I$ssldir/include"
++                OPENSSL_LDFLAGS="-L$ssldir/lib"
++                OPENSSL_LIBS="-lssl -lcrypto"
++                found=true
++                AC_MSG_RESULT([yes])
++                break
++            else
++                AC_MSG_RESULT([no])
++            fi
++        done
++
++        # if the file wasn't found, well, go ahead and try the link anyway -- maybe
++        # it will just work!
++    fi
++
++    # try the preprocessor and linker with our new flags,
++    # being careful not to pollute the global LIBS, LDFLAGS, and CPPFLAGS
++
++    AC_MSG_CHECKING([whether compiling and linking against OpenSSL works])
++    echo "Trying link with OPENSSL_LDFLAGS=$OPENSSL_LDFLAGS;" \
++        "OPENSSL_LIBS=$OPENSSL_LIBS; OPENSSL_INCLUDES=$OPENSSL_INCLUDES" >&AS_MESSAGE_LOG_FD
++
++    save_LIBS="$LIBS"
++    save_LDFLAGS="$LDFLAGS"
++    save_CPPFLAGS="$CPPFLAGS"
++    LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
++    LIBS="$OPENSSL_LIBS $LIBS"
++    CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
++    AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM([#include <openssl/ssl.h>], [SSL_new(NULL)])],
++        [
++            AC_MSG_RESULT([yes])
++            $1
++        ], [
++            AC_MSG_RESULT([no])
++            $2
++        ])
++    CPPFLAGS="$save_CPPFLAGS"
++    LDFLAGS="$save_LDFLAGS"
++    LIBS="$save_LIBS"
++
++    AC_SUBST([OPENSSL_INCLUDES])
++    AC_SUBST([OPENSSL_LIBS])
++    AC_SUBST([OPENSSL_LDFLAGS])
++])
+diff --git a/src/signature.c b/src/signature.c
+index dace95e9..25d8c354 100644
+--- a/src/signature.c
++++ b/src/signature.c
+@@ -1,3 +1,5 @@
++#include <stdint.h>
++
+ #include <openssl/asn1.h>
+ #include <openssl/cms.h>
+ #include <openssl/conf.h>
+@@ -7,11 +9,20 @@
+ #include <openssl/crypto.h>
+ #include <openssl/engine.h>
+ #include <openssl/x509.h>
++#include <openssl/x509v3.h>
+ #include <string.h>
+ 
+ #include "context.h"
+ #include "signature.h"
+ 
++/* Define for OpenSSL 1.0.x backwards compatiblity.
++ * We use newer get0 names to be clear about memory ownership and to not use
++ * API deprecated in OpenSSL 1.1.x */
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
++#define X509_get0_notAfter X509_get_notAfter
++#define X509_get0_notBefore X509_get_notBefore
++#endif
++
+ GQuark r_signature_error_quark(void)
+ {
+ 	return g_quark_from_static_string("r_signature_error_quark");
+@@ -24,9 +35,15 @@ static int check_purpose_code_sign(const X509_PURPOSE *xp, const X509 *const_x,
+ 	 * the ex_ variables have already been calculated by other code when
+ 	 * we are in this callback. */
+ 	X509 *x = (X509 *)const_x;
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
++	uint32_t ex_flags = x->ex_flags;
++	uint32_t ex_kusage = (x->ex_flags & EXFLAG_KUSAGE) ? x->ex_kusage : UINT32_MAX;
++	uint32_t ex_xkusage = (x->ex_flags & EXFLAG_XKUSAGE) ? x->ex_xkusage : UINT32_MAX;
++#else
+ 	uint32_t ex_flags = X509_get_extension_flags(x);
+ 	uint32_t ex_kusage = X509_get_key_usage(x);
+ 	uint32_t ex_xkusage = X509_get_extended_key_usage(x);
++#endif
+ 
+ 	if (ca) {
+ 		/* If extended key usage is present, it must contain codeSigning for all
+@@ -57,7 +74,11 @@ static int check_purpose_code_sign(const X509_PURPOSE *xp, const X509 *const_x,
+ gboolean signature_init(GError **error)
+ {
+ 	int ret, id;
+-
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
++	OPENSSL_config(NULL);
++	OpenSSL_add_all_algorithms();
++	ERR_load_crypto_strings();
++#else
+ 	g_return_val_if_fail(error == FALSE || *error == NULL, FALSE);
+ 
+ 	ret = OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+@@ -75,6 +96,7 @@ gboolean signature_init(GError **error)
+ 				(flags & ERR_TXT_STRING) ? data : ERR_error_string(err, NULL));
+ 		return FALSE;
+ 	}
++#endif
+ 
+ 	id = X509_PURPOSE_get_count() + 1;
+ 	if (X509_PURPOSE_get_by_id(id) >= 0) {
+@@ -87,7 +109,9 @@ gboolean signature_init(GError **error)
+ 	}
+ 
+ 	/* X509_TRUST_OBJECT_SIGN maps to the Code Signing ID (via OpenSSL's NID_code_sign) */
+-	ret = X509_PURPOSE_add(id, X509_TRUST_OBJECT_SIGN, 0, check_purpose_code_sign, "Code signing", "codesign", NULL);
++	/* X509_PURPOSE_add calls BUF_strdup on the string arguments and they
++	 * are const in newer OpenSSL versions. */
++	ret = X509_PURPOSE_add(id, X509_TRUST_OBJECT_SIGN, 0, check_purpose_code_sign, (char *)"Code signing", (char *)"codesign", NULL);
+ 	if (!ret) {
+ 		unsigned long err;
+ 		const gchar *data;
+@@ -440,8 +464,12 @@ X509_STORE* setup_x509_store(const gchar *capath, const gchar *cadir, GError **e
+ 
+ 	/* Enable purpose checking if configured */
+ 	if (check_purpose) {
+-		const X509_PURPOSE *xp = X509_PURPOSE_get0(X509_PURPOSE_get_by_sname(check_purpose));
+-		if (!xp || !X509_STORE_set_purpose(store, X509_PURPOSE_get_id(xp))) {
++		/* X509_PURPOSE_get0 calls only strcmp on the string argument and
++		 * it is const in newer OpenSSL versions. */
++		const X509_PURPOSE *xp = X509_PURPOSE_get0(X509_PURPOSE_get_by_sname((char *)check_purpose));
++		/* X509_PURPOSE_get_id calls only returns an int field of the
++		 * X509_PURPOSE it is const in newer OpenSSL versions. */
++		if (!xp || !X509_STORE_set_purpose(store, X509_PURPOSE_get_id((X509_PURPOSE *)xp))) {
+ 			g_set_error(
+ 					error,
+ 					R_SIGNATURE_ERROR,
+diff --git a/src/verity_hash.c b/src/verity_hash.c
+index bc53e219..58493bc8 100644
+--- a/src/verity_hash.c
++++ b/src/verity_hash.c
+@@ -23,6 +23,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <stdint.h>
++#include <inttypes.h>
+ #include <glib.h>
+ 
+ #include <openssl/bio.h>
+@@ -80,11 +81,18 @@ static int verify_hash_block(
+ {
+ 	/* SHA256, version 1 only */
+ 	EVP_MD_CTX *mdctx;
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
++	EVP_MD_CTX mdctx_stack;
++#endif
+ 	uint8_t tmp[EVP_MAX_MD_SIZE];
+ 	unsigned int tmp_size = 0;
+ 	int r = 0;
+ 
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
++	mdctx = &mdctx_stack;
++#else
+ 	mdctx = EVP_MD_CTX_new();
++#endif
+ 	if (EVP_DigestInit(mdctx, EVP_sha256()) != 1) {
+ 		g_message("init failed");
+ 		r = -EINVAL;
+@@ -116,7 +124,9 @@ static int verify_hash_block(
+ out:
+ 	if (r)
+ 		ERR_print_errors_fp(stderr);
++#if !(OPENSSL_VERSION_NUMBER < 0x10100000L)
+ 	EVP_MD_CTX_free(mdctx);
++#endif
+ 	return r;
+ }
+ 
+-- 
+2.29.2
+

--- a/.github/workflows/patches/16.04/0001-src-replace-G_VARIANT_DICT_INIT-supported-not-before.patch
+++ b/.github/workflows/patches/16.04/0001-src-replace-G_VARIANT_DICT_INIT-supported-not-before.patch
@@ -1,0 +1,72 @@
+From f7ce3ce86e1f6c4d3ded26b1b850243a0b372bea Mon Sep 17 00:00:00 2001
+From: Enrico Joerns <ejo@pengutronix.de>
+Date: Wed, 23 Dec 2020 16:39:32 +0100
+Subject: [PATCH] src: replace G_VARIANT_DICT_INIT (supported not before
+ 2.49.3)
+
+Signed-off-by: Enrico Joerns <ejo@pengutronix.de>
+---
+ configure.ac  | 4 ++--
+ src/main.c    | 4 +++-
+ src/service.c | 4 +++-
+ 3 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 6d569864..4af3d286 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -59,12 +59,12 @@ AS_IF([test "x$enable_create" != "xno"], [
+ ])
+ 
+ # Checks for libraries.
+-PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.49.3 gio-2.0 gio-unix-2.0])
++PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.45.8 gio-2.0 gio-unix-2.0])
+ # Sanity checks to not use new glib methods unintentionally.
+ # package check, minimum and maximum required version must be updated
+ # explicitly when using newer glib APIs
+ AC_DEFINE(GLIB_VERSION_MAX_ALLOWED, G_ENCODE_VERSION(2,52), [Prevent post-2.52 APIs])
+-AC_DEFINE(GLIB_VERSION_MIN_REQUIRED, G_ENCODE_VERSION(2,50), [Set to minimum supported API version])
++AC_DEFINE(GLIB_VERSION_MIN_REQUIRED, G_ENCODE_VERSION(2,46), [Set to minimum supported API version])
+ 
+ AC_ARG_ENABLE([network],
+        AS_HELP_STRING([--disable-network], [Disable network update mode])
+diff --git a/src/main.c b/src/main.c
+index 3f0d480c..19dffbff 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -236,7 +236,9 @@ static gboolean install_start(int argc, char **argv)
+ 
+ 	r_loop = g_main_loop_new(NULL, FALSE);
+ 	if (ENABLE_SERVICE) {
+-		g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
++		GVariantDict dict;
++
++		g_variant_dict_init(&dict, NULL);
+ 
+ 		g_variant_dict_insert(&dict, "ignore-compatible", "b", args->ignore_compatible);
+ 
+diff --git a/src/service.c b/src/service.c
+index 7ca571f1..fdfe76fb 100644
+--- a/src/service.c
++++ b/src/service.c
+@@ -58,7 +58,7 @@ static gboolean r_on_handle_install_bundle(
+ 		GVariant *arg_args)
+ {
+ 	RaucInstallArgs *args = install_args_new();
+-	g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(arg_args);
++	GVariantDict dict;
+ 	GVariantIter iter;
+ 	gchar *key;
+ 	g_autofree gchar *message = NULL;
+@@ -66,6 +66,8 @@ static gboolean r_on_handle_install_bundle(
+ 
+ 	g_print("input bundle: %s\n", source);
+ 
++	g_variant_dict_init(&dict, arg_args);
++
+ 	res = !r_context_get_busy();
+ 	if (!res) {
+ 		message = g_strdup("Already processing a different method");
+-- 
+2.29.2
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,6 +115,54 @@ jobs:
         cat test-suite.log || true
         cat rauc-*/_build/sub/test-suite.log || true
 
+  stable:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release:
+        - 16.04
+        - 18.04
+        - 20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Prepare ubuntu ${{ matrix.release }} container
+      run: |
+        docker run --name stable -di -v "$PWD":/home -w /home ubuntu:${{ matrix.release }} bash
+        docker exec -i stable uname -a
+        docker exec -i stable apt-get update
+        docker exec -i stable apt-get install -qy build-essential automake libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev libfdisk-dev squashfs-tools
+
+    - name: Patch & prepare
+      run: |
+        docker exec -i stable whoami
+        docker exec -i stable uname -a
+        docker exec -i stable find .github/workflows/patches/${{ matrix.release}}/ -type f -name "*.patch" -print0 | sort -z | xargs -t -n 1 -r -0 patch -p1 -f -i
+        docker exec -i stable ./autogen.sh
+
+    - name: Configure (without GPT)
+      if: matrix.release == '16.04'
+      run: |
+        docker exec -i stable ./configure CFLAGS=-Werror
+
+    - name: Configure
+      if: matrix.release != '16.04'
+      run: |
+        docker exec -i stable ./configure --disable-gpt CFLAGS=-Werror
+
+    - name: Build
+      run: |
+        docker exec -i stable make
+        #docker exec -i stable make check
+
+    - name: Show logs
+      if: ${{ failure() }}
+      run: |
+        cat config.log || true
+        cat test/*.log || true
+        cat test-suite.log || true
+        cat rauc-*/_build/sub/test-suite.log || true
+
   uncrustify:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
         docker run --name cross -di -v "$PWD":/home -w /home multiarch/debian-debootstrap:${{ matrix.architecture }}-buster bash
         docker exec -i cross uname -a
         docker exec -i cross apt-get update
-        docker exec -i cross apt-get install -qy build-essential automake libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev libfdisk-dev squashfs-tools
+        docker exec -e DEBIAN_FRONTEND='noninteractive' -i cross apt-get install -qy build-essential automake libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev libfdisk-dev squashfs-tools
 
     - name: Build
       run: |
@@ -131,7 +131,7 @@ jobs:
         docker run --name stable -di -v "$PWD":/home -w /home ubuntu:${{ matrix.release }} bash
         docker exec -i stable uname -a
         docker exec -i stable apt-get update
-        docker exec -i stable apt-get install -qy build-essential automake libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev libfdisk-dev squashfs-tools
+        docker exec -e DEBIAN_FRONTEND='noninteractive' -i stable apt-get install -qy build-essential automake libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev libfdisk-dev squashfs-tools
 
     - name: Patch & prepare
       run: |


### PR DESCRIPTION
Note: This series bases on #677 which needs to be merged first.

In the past, we did not always notice when breaking RAUC compatibility with older toolchains and libraries.
While some incompatibilities cannot and will not be avoided (like dropping support for OpenSSL 1.0.x that is EOL since end of 2019) others are not strictly required and may happen unintentionally.

These added test should allow to be notified when breaking compatibility with old releases and making the decision explicit rather than implicit.

The tests currently run for ubuntu releases:
  - 16.04 (gcc 5.3.1, linux-libc-dev 4.4.0-197.229, glib 2.48.2, openssl 1.0.2g)
  - 18.04 (gcc 7.3.0, linux-libc-dev 4.15.0-20.21, glib 2.56.4, openssl 1.1.1)
  - 20.04 (gcc 9.3.0, linux-libc-dev 5.4.0-59.65, glib 2.64.3, openssl 1.1.1f)

Note that for now, they test only compilation. Not runtime behavior.

As it might happen, that support for a component is dropped intentionally, we add the ability to place specific non-mainline
backport patches for each ubuntu version.

Patches currently required for 16.04 are:

- Re-Add support for OpenSSL 1.0.2
- Do not use glib macro `G_VARIANT_DICT_INIT` which is not available in glib 2.48.2

Building against 16.04 also requires to disable GPT support as this needs fdisk at least in version 2.29, but only 2.27 is available.