### PR TITLE
Fix and Improve Error Handling for resolve_loop_device()

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -57,7 +57,7 @@ static gchar *resolve_loop_device(const gchar *devicepath)
 
 	content = read_file_str(syspath, &ierror);
 	if (!content) {
-		g_message("%s", ierror->message);
+		g_message("Error getting loop backing_file for %s: %s", devicepath, ierror->message);
 		g_clear_error(&ierror);
 		return NULL;
 	}

--- a/src/install.c
+++ b/src/install.c
@@ -42,7 +42,7 @@ static void install_args_update(RaucInstallArgs *args, const gchar *msg)
 	g_main_context_invoke(NULL, args->notify, args);
 }
 
-static gchar *resolve_loop_device(const gchar *devicepath)
+static gchar *resolve_loop_device(const gchar *devicepath, GError **error)
 {
 	g_autofree gchar *devicename = NULL;
 	g_autofree gchar *syspath = NULL;
@@ -57,8 +57,10 @@ static gchar *resolve_loop_device(const gchar *devicepath)
 
 	content = read_file_str(syspath, &ierror);
 	if (!content) {
-		g_message("Error getting loop backing_file for %s: %s", devicepath, ierror->message);
-		g_clear_error(&ierror);
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Error getting loop backing_file for %s: ", devicepath);
 		return NULL;
 	}
 
@@ -74,6 +76,7 @@ gboolean determine_slot_states(GError **error)
 	GHashTableIter iter;
 	RaucSlot *slot;
 	gboolean res = FALSE;
+	GError *ierror = NULL;
 
 	g_assert_nonnull(r_context()->config);
 
@@ -98,8 +101,14 @@ gboolean determine_slot_states(GError **error)
 	mountlist = g_unix_mounts_get(NULL);
 	for (GList *l = mountlist; l != NULL; l = l->next) {
 		GUnixMountEntry *m = (GUnixMountEntry*)l->data;
-		g_autofree gchar *devicepath = resolve_loop_device(g_unix_mount_get_device_path(m));
-		RaucSlot *s = find_config_slot_by_device(r_context()->config,
+		g_autofree gchar *devicepath = NULL;
+		RaucSlot *s;
+		devicepath = resolve_loop_device(g_unix_mount_get_device_path(m), &ierror);
+		if (!devicepath) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+		s = find_config_slot_by_device(r_context()->config,
 				devicepath);
 		if (s) {
 			/* We might have multiple mount entries matching the same device and thus the same slot.

--- a/test/install.c
+++ b/test/install.c
@@ -341,6 +341,8 @@ static void test_install_determine_target_group_non_redundant(void)
 	g_autofree gchar *tmpdir = NULL;
 	g_autofree gchar *sysconfpath = NULL;
 	g_autoptr(GHashTable) tgrp = NULL;
+	g_autoptr(GError) error = NULL;
+	gboolean res;
 
 	const gchar *system_conf = "\
 [system]\n\
@@ -362,7 +364,9 @@ device=/dev/null\n\
 	r_context_conf()->bootslot = g_strdup("system0");
 	r_context();
 
-	g_assert_true(determine_slot_states(NULL));
+	res = determine_slot_states(&error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 
 	tgrp = determine_target_install_group();
 	g_assert_nonnull(tgrp);
@@ -378,6 +382,8 @@ static void test_install_target_group_async(void)
 	g_autofree gchar *tmpdir = NULL;
 	g_autofree gchar *sysconfpath = NULL;
 	g_autoptr(GHashTable) tgrp = NULL;
+	g_autoptr(GError) error = NULL;
+	gboolean res;
 
 	const gchar *system_conf = "\
 [system]\n\
@@ -411,7 +417,9 @@ device=/dev/null\n\
 	r_context_conf()->bootslot = g_strdup("rescue");
 	r_context();
 
-	g_assert_true(determine_slot_states(NULL));
+	res = determine_slot_states(&error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 
 	tgrp = determine_target_install_group();
 	g_assert_nonnull(tgrp);
@@ -431,6 +439,8 @@ static void test_install_target_group_sync(void)
 	g_autofree gchar *tmpdir = NULL;
 	g_autofree gchar *sysconfpath = NULL;
 	g_autoptr(GHashTable) tgrp = NULL;
+	g_autoptr(GError) error = NULL;
+	gboolean res;
 
 	const gchar *system_conf = "\
 [system]\n\
@@ -463,7 +473,9 @@ device=/dev/null\n\
 	r_context_conf()->bootslot = g_strdup("system1");
 	r_context();
 
-	g_assert_true(determine_slot_states(NULL));
+	res = determine_slot_states(&error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 
 	tgrp = determine_target_install_group();
 	g_assert_nonnull(tgrp);
@@ -483,6 +495,8 @@ static void test_install_target_group_loose(void)
 	g_autofree gchar *tmpdir = NULL;
 	g_autofree gchar *sysconfpath = NULL;
 	g_autoptr(GHashTable) tgrp = NULL;
+	g_autoptr(GError) error = NULL;
+	gboolean res;
 
 	const gchar *system_conf = "\
 [system]\n\
@@ -510,7 +524,9 @@ device=/dev/null\n\
 	r_context_conf()->bootslot = g_strdup("system0");
 	r_context();
 
-	g_assert_true(determine_slot_states(NULL));
+	res = determine_slot_states(&error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 
 	tgrp = determine_target_install_group();
 	g_assert_nonnull(tgrp);
@@ -530,6 +546,8 @@ static void test_install_target_group_n_redundant(void)
 	g_autofree gchar *tmpdir = NULL;
 	g_autofree gchar *sysconfpath = NULL;
 	g_autoptr(GHashTable) tgrp = NULL;
+	g_autoptr(GError) error = NULL;
+	gboolean res;
 
 	const gchar *system_conf = "\
 [system]\n\
@@ -558,7 +576,9 @@ device=/dev/null\n\
 	r_context_conf()->bootslot = g_strdup("system1");
 	r_context();
 
-	g_assert_true(determine_slot_states(NULL));
+	res = determine_slot_states(&error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 
 	tgrp = determine_target_install_group();
 	g_assert_nonnull(tgrp);


### PR DESCRIPTION
* Provides more helpful error message when resolving fails
* adds support for GError
* fixes missing return value check before passing to `find_config_slot_by_device()`
* Improves test debugability

Fallout from debugging behavior described in #631.