### PR TITLE
update_handler: support for nor flash devices using flashcp

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,8 @@ Features
   * vfat filesystem
   * UBI volumes
   * UBIFS
-  * raw NAND (using nandwrite)
+  * raw NAND flash (using nandwrite)
+  * raw NOR flash (using flashcp)
   * squashfs
   * MBR partition table
   * GPT partition table

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -145,7 +145,8 @@ Key Features of RAUC
   * vfat filesystem
   * UBI volumes
   * UBIFS
-  * raw NAND (using nandwrite)
+  * raw NAND flash (using nandwrite)
+  * raw NOR flash (using flashcp)
   * squashfs
 
 * Independent from update sources

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -114,7 +114,9 @@ A list of slot storage types currently supported by RAUC:
 +----------+-------------------------------------------------------------------+-------------+
 | ext4     | A block device holding an ext4 filesystem.                        |     x       |
 +----------+-------------------------------------------------------------------+-------------+
-| nand     | A raw NAND partition.                                             |             |
+| nand     | A raw NAND flash partition.                                       |             |
++----------+-------------------------------------------------------------------+-------------+
+| nor      | A raw NOR flash partition.                                        |             |
 +----------+-------------------------------------------------------------------+-------------+
 | ubivol   | An UBI partition in NAND.                                         |             |
 +----------+-------------------------------------------------------------------+-------------+
@@ -227,6 +229,8 @@ cannot fully know how you intend to use your system.
 
 :NAND Flash: flash_erase & nandwrite (from `mtd-utils
              <git://git.infradead.org/mtd-utils.git>`_)
+:NOR Flash: flash_erase & flashcp (from `mtd-utils
+            <git://git.infradead.org/mtd-utils.git>`_)
 :UBIFS: mkfs.ubifs (from `mtd-utils
                   <git://git.infradead.org/mtd-utils.git>`_)
 :TAR archives: You may either use `GNU tar <http://www.gnu.org/software/tar/>`_

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -297,7 +297,7 @@ hierarchical separator.
 
 ``type=<type>``
   The type describing the slot. Currently supported ``<type>`` values are ``raw``,
-  ``nand``, ``ubivol``, ``ubifs``, ``ext4``, ``vfat``.
+  ``nand``, ``nor``, ``ubivol``, ``ubifs``, ``ext4``, ``vfat``.
   See table :ref:`sec-slot-type` for a more detailed list of these different types.
   Defaults to ``raw`` if none given.
 

--- a/qemu-test
+++ b/qemu-test
@@ -70,6 +70,6 @@ qemu-system-x86_64 \
   -no-reboot \
   -virtfs local,id=rootfs,path=/,security_model=none,mount_tag=/dev/root \
   -nic user,model=virtio-net-pci \
-  -append "loglevel=6 console=ttyS0 nandsim.id_bytes=0x20,0xa2,0x00,0x15 nandsim.parts=0x100, root=/dev/root rootfstype=9p rw init=$(pwd)/qemu-test-init rauc.slot=system0 $*"
+  -append "loglevel=6 console=ttyS0 nandsim.id_bytes=0x20,0xa2,0x00,0x15 nandsim.parts=0x100, mtdram.total_size=32768 root=/dev/root rootfstype=9p rw init=$(pwd)/qemu-test-init rauc.slot=system0 $*"
 
 test -f qemu-test-ok

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -66,6 +66,12 @@ if type losetup; then
   export RAUC_TEST_BLOCK_LOOP=/dev/loop0
 fi
 
+cat /proc/mtd
+
+if [ -c /dev/mtd0 ] && type flashcp; then
+  export RAUC_TEST_MTD_NOR=/dev/mtd0
+fi
+
 if [ -c /dev/mtd2 ] && type flash_erase; then
   export RAUC_TEST_MTD_NAND=/dev/mtd2
 fi

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -584,7 +584,7 @@ out:
 	return res;
 }
 
-static gboolean nand_format_slot(const gchar *device, GError **error)
+static gboolean flash_format_slot(const gchar *device, GError **error)
 {
 	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
@@ -1185,7 +1185,7 @@ static gboolean img_to_nand_handler(RaucImage *image, RaucSlot *dest_slot, const
 
 	/* erase */
 	g_message("erasing slot device %s", dest_slot->device);
-	res = nand_format_slot(dest_slot->device, &ierror);
+	res = flash_format_slot(dest_slot->device, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -584,6 +584,40 @@ out:
 	return res;
 }
 
+static gboolean nor_write_slot(const gchar *image, const gchar *device, GError **error)
+{
+	g_autoptr(GSubprocess) sproc = NULL;
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+	g_autoptr(GPtrArray) args = g_ptr_array_new_full(5, g_free);
+
+	g_ptr_array_add(args, g_strdup("flashcp"));
+	g_ptr_array_add(args, g_strdup(image));
+	g_ptr_array_add(args, g_strdup(device));
+	g_ptr_array_add(args, NULL);
+
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
+	if (sproc == NULL) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed to start flashcp: ");
+		goto out;
+	}
+
+	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	if (!res) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed to run flashcp: ");
+		goto out;
+	}
+
+out:
+	return res;
+}
+
 static gboolean flash_format_slot(const gchar *device, GError **error)
 {
 	g_autoptr(GSubprocess) sproc = NULL;
@@ -1169,6 +1203,49 @@ out:
 	return res;
 }
 
+static gboolean img_to_nor_handler(RaucImage *image, RaucSlot *dest_slot, const gchar *hook_name, GError **error)
+{
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+
+	/* run slot pre install hook if enabled */
+	if (hook_name && image->hooks.pre_install) {
+		res = run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, NULL, dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+	}
+
+	/* erase */
+	g_message("erasing slot device %s", dest_slot->device);
+	res = flash_format_slot(dest_slot->device, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
+	/* write */
+	g_message("writing slot device %s", dest_slot->device);
+	res = nor_write_slot(image->filename, dest_slot->device, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
+	/* run slot post install hook if enabled */
+	if (hook_name && image->hooks.post_install) {
+		res = run_slot_hook(hook_name, R_SLOT_HOOK_POST_INSTALL, NULL, dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+	}
+
+out:
+	return res;
+}
+
 static gboolean img_to_nand_handler(RaucImage *image, RaucSlot *dest_slot, const gchar *hook_name, GError **error)
 {
 	GError *ierror = NULL;
@@ -1733,6 +1810,7 @@ RaucUpdatePair updatepairs[] = {
 	{"*.ubifs", "ubivol", img_to_ubivol_handler},
 	{"*.ubifs", "ubifs", img_to_ubifs_handler},
 	{"*.img", "ext4", img_to_fs_handler},
+	{"*.img", "nor", img_to_nor_handler},
 	{"*.img", "nand", img_to_nand_handler},
 	{"*.img", "ubifs", img_to_ubifs_handler},
 	{"*.img", "ubivol", img_to_ubivol_handler},

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -280,6 +280,13 @@ static void test_update_handler(UpdateHandlerFixture *fixture,
 			g_test_skip("RAUC_TEST_MTD_NAND undefined");
 			return;
 		}
+	} else if (g_strcmp0(test_pair->slottype, "nor") == 0) {
+		slotpath = g_strdup(g_getenv("RAUC_TEST_MTD_NOR"));
+		if (!slotpath) {
+			g_test_message("no MTD NOR device for testing found (define RAUC_TEST_MTD_NOR)");
+			g_test_skip("RAUC_TEST_MTD_NOR undefined");
+			return;
+		}
 	} else {
 		slotpath = g_build_filename(fixture->tmpdir, "rootfs-0", NULL);
 	}
@@ -478,6 +485,9 @@ int main(int argc, char *argv[])
 
 		/* nand tests */
 		{"nand", "img", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
+
+		/* nor tests */
+		{"nor", "img", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
 
 		{0}
 	};
@@ -835,6 +845,13 @@ int main(int argc, char *argv[])
 	g_test_add("/update_handler/update_handler/img_to_nand",
 			UpdateHandlerFixture,
 			&testpair_matrix[54],
+			update_handler_fixture_set_up,
+			test_update_handler,
+			update_handler_fixture_tear_down);
+	/* nor tests */
+	g_test_add("/update_handler/update_handler/img_to_nor",
+			UpdateHandlerFixture,
+			&testpair_matrix[55],
 			update_handler_fixture_set_up,
 			test_update_handler,
 			update_handler_fixture_tear_down);


### PR DESCRIPTION
Add a handler to write images using flashcp. Can be used to update the
bootloader or other images residing in a flash partition.

TODO:
- [x] adapt qemu tests
- [x] documentation for the "nor" type

Signed-off-by: Ladislav Michl <ladis at linux-mips.org>
[r.czerwinski@pengutronix.de: adapted for current code, added tests]
Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>