### PR TITLE
src/main: remove redundant "Failed getting primary slot:" error string

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1585,7 +1585,7 @@ static gboolean status_start(int argc, char **argv)
 
 		status_print->primary = r_boot_get_primary(&ierror);
 		if (!status_print->primary) {
-			g_printerr("Failed getting primary slot: %s\n", ierror->message);
+			g_printerr("%s\n", ierror->message);
 			g_clear_error(&ierror);
 		}
 


### PR DESCRIPTION
The same error string prefix is applied in `r_boot_get_primary()` already,
thus the resulting error messages all look like:

> Failed getting primary slot: Failed getting primary slot: Unable to obtain primary element

Thus simply remove the second prefix here.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>