### PR TITLE
Make boot slot hooks more versatile

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -817,6 +817,19 @@ The following environment variables will be passed to the hook executable:
   ``RAUC_MOUNT_PREFIX``
     The global RAUC mount prefix path, e.g. ``"/run/mount/rauc"``
 
+  ``RAUC_BOOT_PARTITION_ACTIVATING``
+    The to be activated boot partition (0 or 1).
+    ``boot-mbr-switch`` slot type only.
+
+  ``RAUC_BOOT_PARTITION_START``
+    The absolute partition offset of the to be activated boot partition in
+    bytes.
+    ``boot-mbr-switch`` slot type only.
+
+  ``RAUC_BOOT_PARTITION_SIZE``
+    The partition size of the to be activated boot partition in bytes.
+    ``boot-mbr-switch`` slot type only.
+
 .. _sec_ref_dbus-api:
 
 D-Bus API

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -819,7 +819,7 @@ The following environment variables will be passed to the hook executable:
 
   ``RAUC_BOOT_PARTITION_ACTIVATING``
     The to be activated boot partition (0 or 1).
-    ``boot-mbr-switch`` and ``boot-gpt-switch`` slot types only.
+    ``boot-mbr-switch``, ``boot-gpt-switch``, ``boot-emmc`` slot types only.
 
   ``RAUC_BOOT_PARTITION_START``
     The absolute partition offset of the to be activated boot partition in

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -819,16 +819,16 @@ The following environment variables will be passed to the hook executable:
 
   ``RAUC_BOOT_PARTITION_ACTIVATING``
     The to be activated boot partition (0 or 1).
-    ``boot-mbr-switch`` slot type only.
+    ``boot-mbr-switch`` and ``boot-gpt-switch`` slot types only.
 
   ``RAUC_BOOT_PARTITION_START``
     The absolute partition offset of the to be activated boot partition in
     bytes.
-    ``boot-mbr-switch`` slot type only.
+    ``boot-mbr-switch`` and ``boot-gpt-switch`` slot types only.
 
   ``RAUC_BOOT_PARTITION_SIZE``
     The partition size of the to be activated boot partition in bytes.
-    ``boot-mbr-switch`` slot type only.
+    ``boot-mbr-switch`` and ``boot-gpt-switch`` slot types only.
 
 .. _sec_ref_dbus-api:
 

--- a/src/gpt.c
+++ b/src/gpt.c
@@ -167,7 +167,7 @@ static gboolean check_region(struct fdisk_context *cxt,
 					"Region (sectors 0x%"G_GINT64_MODIFIER "x - 0x%"G_GINT64_MODIFIER "x) overlaps "
 					"with partition %zd (sectors 0x%"G_GINT64_MODIFIER "x - 0x%"G_GINT64_MODIFIER "x)",
 					region_start_sector, region_end_sector,
-					fdisk_partition_get_partno(pa),
+					fdisk_partition_get_partno(pa) + 1,
 					p_start_sector, p_end_sector);
 			goto out_table;
 		}

--- a/src/mbr.c
+++ b/src/mbr.c
@@ -176,7 +176,7 @@ static gboolean is_region_free(guint64 region_start, guint64 region_size,
 			g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
 					"Region start address 0x%"G_GINT64_MODIFIER "x is in area of "
 					"partition %d (0x%"G_GINT64_MODIFIER "x - 0x%"G_GINT64_MODIFIER "x)",
-					region_start, i, p_start, p_end);
+					region_start, i+1, p_start, p_end);
 			break;
 		}
 
@@ -185,7 +185,7 @@ static gboolean is_region_free(guint64 region_start, guint64 region_size,
 			g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
 					"Region end address 0x%"G_GINT64_MODIFIER "x is in area of "
 					"partition %d (0x%"G_GINT64_MODIFIER "x - 0x%"G_GINT64_MODIFIER "x)",
-					region_start + region_size - 1, i, p_start,
+					region_start + region_size - 1, i+1, p_start,
 					p_end);
 			break;
 		}

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1371,6 +1371,7 @@ static gboolean img_to_boot_mbr_switch_handler(RaucImage *image, RaucSlot *dest_
 	g_autoptr(GUnixOutputStream) outstream = NULL;
 	GError *ierror = NULL;
 	struct boot_switch_partition dest_partition;
+	g_autoptr(GHashTable) vars = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
 	res = r_mbr_switch_get_inactive_partition(dest_slot->device,
 			&dest_partition, dest_slot->region_start,
@@ -1396,10 +1397,17 @@ static gboolean img_to_boot_mbr_switch_handler(RaucImage *image, RaucSlot *dest_
 		goto out;
 	}
 
+	g_hash_table_insert(vars, g_strdup("RAUC_BOOT_PARTITION_ACTIVATING"),
+			g_strdup_printf("%d", inactive_part));
+	g_hash_table_insert(vars, g_strdup("RAUC_BOOT_PARTITION_START"),
+			g_strdup_printf("%"G_GUINT64_FORMAT, dest_partition.start));
+	g_hash_table_insert(vars, g_strdup("RAUC_BOOT_PARTITION_SIZE"),
+			g_strdup_printf("%"G_GUINT64_FORMAT, dest_partition.size));
+
 	/* run slot pre install hook if enabled */
 	if (hook_name && image->hooks.pre_install) {
-		res = run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, image,
-				dest_slot, &ierror);
+		res = run_slot_hook_extra_env(hook_name, R_SLOT_HOOK_PRE_INSTALL, image,
+				dest_slot, vars, &ierror);
 		if (!res) {
 			g_propagate_error(error, ierror);
 			goto out;
@@ -1456,8 +1464,8 @@ static gboolean img_to_boot_mbr_switch_handler(RaucImage *image, RaucSlot *dest_
 
 	/* run slot post install hook if enabled */
 	if (hook_name && image->hooks.post_install) {
-		res = run_slot_hook(hook_name, R_SLOT_HOOK_POST_INSTALL, image,
-				dest_slot, &ierror);
+		res = run_slot_hook_extra_env(hook_name, R_SLOT_HOOK_POST_INSTALL, image,
+				dest_slot, vars, &ierror);
 		if (!res) {
 			g_propagate_error(error, ierror);
 			goto out;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1459,16 +1459,6 @@ static gboolean img_to_boot_gpt_switch_handler(RaucImage *image, RaucSlot *dest_
 	GError *ierror = NULL;
 	struct boot_switch_partition dest_partition;
 
-	/* run slot pre install hook if enabled */
-	if (hook_name && image->hooks.pre_install) {
-		res = run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, image,
-				dest_slot, &ierror);
-		if (!res) {
-			g_propagate_error(error, ierror);
-			goto out;
-		}
-	}
-
 	res = r_gpt_switch_get_inactive_partition(dest_slot->device,
 			&dest_partition, dest_slot->region_start,
 			dest_slot->region_size, &ierror);
@@ -1491,6 +1481,16 @@ static gboolean img_to_boot_gpt_switch_handler(RaucImage *image, RaucSlot *dest_
 				image->checksum.size, dest_partition.size);
 		res = FALSE;
 		goto out;
+	}
+
+	/* run slot pre install hook if enabled */
+	if (hook_name && image->hooks.pre_install) {
+		res = run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, image,
+				dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
 	}
 
 	g_message("Clearing inactive boot partition %d on %s", inactive_part,

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1343,16 +1343,6 @@ static gboolean img_to_boot_mbr_switch_handler(RaucImage *image, RaucSlot *dest_
 	GError *ierror = NULL;
 	struct boot_switch_partition dest_partition;
 
-	/* run slot pre install hook if enabled */
-	if (hook_name && image->hooks.pre_install) {
-		res = run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, image,
-				dest_slot, &ierror);
-		if (!res) {
-			g_propagate_error(error, ierror);
-			goto out;
-		}
-	}
-
 	res = r_mbr_switch_get_inactive_partition(dest_slot->device,
 			&dest_partition, dest_slot->region_start,
 			dest_slot->region_size, &ierror);
@@ -1375,6 +1365,16 @@ static gboolean img_to_boot_mbr_switch_handler(RaucImage *image, RaucSlot *dest_
 				image->checksum.size, dest_partition.size);
 		res = FALSE;
 		goto out;
+	}
+
+	/* run slot pre install hook if enabled */
+	if (hook_name && image->hooks.pre_install) {
+		res = run_slot_hook(hook_name, R_SLOT_HOOK_PRE_INSTALL, image,
+				dest_slot, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
 	}
 
 	g_message("Clearing inactive boot partition %d on %s", inactive_part,

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1578,20 +1578,6 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 	GError *ierror = NULL;
 	g_autoptr(RaucSlot) part_slot = NULL;
 
-	/* run slot pre install hook if enabled */
-	if (hook_name && image->hooks.pre_install) {
-		res = run_slot_hook(
-				hook_name,
-				R_SLOT_HOOK_PRE_INSTALL,
-				image,
-				dest_slot,
-				&ierror);
-		if (!res) {
-			g_propagate_error(error, ierror);
-			goto out;
-		}
-	}
-
 	realdev = r_realpath(dest_slot->device);
 	if (!realdev) {
 		g_set_error(error,
@@ -1636,6 +1622,20 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;
+	}
+
+	/* run slot pre install hook if enabled */
+	if (hook_name && image->hooks.pre_install) {
+		res = run_slot_hook(
+				hook_name,
+				R_SLOT_HOOK_PRE_INSTALL,
+				image,
+				dest_slot,
+				&ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
 	}
 
 	/* clear block device partition */

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1425,14 +1425,6 @@ static gboolean img_to_boot_mbr_switch_handler(RaucImage *image, RaucSlot *dest_
 		goto out;
 	}
 
-	g_message("Setting MBR to switch boot partition");
-
-	res = r_mbr_switch_set_boot_partition(dest_slot->device, &dest_partition, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
-	}
-
 	/* run slot post install hook if enabled */
 	if (hook_name && image->hooks.post_install) {
 		res = run_slot_hook(hook_name, R_SLOT_HOOK_POST_INSTALL, image,
@@ -1442,6 +1434,15 @@ static gboolean img_to_boot_mbr_switch_handler(RaucImage *image, RaucSlot *dest_
 			goto out;
 		}
 	}
+
+	g_message("Setting MBR to switch boot partition");
+
+	res = r_mbr_switch_set_boot_partition(dest_slot->device, &dest_partition, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
 out:
 	if (out_fd >= 0)
 		close(out_fd);

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1664,6 +1664,20 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 		goto out;
 	}
 
+	/* run slot post install hook if enabled */
+	if (hook_name && image->hooks.post_install) {
+		res = run_slot_hook(
+				hook_name,
+				R_SLOT_HOOK_POST_INSTALL,
+				image,
+				dest_slot,
+				&ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+	}
+
 	/* re-enable read-only on determined eMMC boot partition */
 	g_debug("Reenabling read-only mode of slot device partition %s",
 			part_slot->device);
@@ -1708,20 +1722,6 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 	}
 
 	g_message("Boot partition %s is now active", part_slot->device);
-
-	/* run slot post install hook if enabled */
-	if (hook_name && image->hooks.post_install) {
-		res = run_slot_hook(
-				hook_name,
-				R_SLOT_HOOK_POST_INSTALL,
-				image,
-				dest_slot,
-				&ierror);
-		if (!res) {
-			g_propagate_error(error, ierror);
-			goto out;
-		}
-	}
 
 out:
 	/* ensure that the eMMC boot partition is read-only afterwards */

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1541,14 +1541,6 @@ static gboolean img_to_boot_gpt_switch_handler(RaucImage *image, RaucSlot *dest_
 		goto out;
 	}
 
-	g_message("Setting GPT to switch boot partition");
-
-	res = r_gpt_switch_set_boot_partition(dest_slot->device, &dest_partition, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
-	}
-
 	/* run slot post install hook if enabled */
 	if (hook_name && image->hooks.post_install) {
 		res = run_slot_hook(hook_name, R_SLOT_HOOK_POST_INSTALL, image,
@@ -1557,6 +1549,14 @@ static gboolean img_to_boot_gpt_switch_handler(RaucImage *image, RaucSlot *dest_
 			g_propagate_error(error, ierror);
 			goto out;
 		}
+	}
+
+	g_message("Setting GPT to switch boot partition");
+
+	res = r_gpt_switch_set_boot_partition(dest_slot->device, &dest_partition, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
+		goto out;
 	}
 out:
 	if (out_fd >= 0)


### PR DESCRIPTION
The i.MX28's ROM code expects an absolute offset to the raw device instead of an offset to a partition in the bootloader's header residing in a partition with a certain type. This is problematic when used in conjunction with `boot-mbr-switch`, because depending on which partition is active, the offset varies.

In order to allow such cases, run the pre install hook after the partition is determined and pass information required to manipulate the partition to the hook. Do the same for the post install hook, but run it prior to the actual atomic MBR switch.

To keep things consistent, apply these changes also to `boot-gpt-switch` and `boot-emmc`.

Please note that I only tested the `boot-mbr-switch` case, everything else is just compile-tested.