### PR TITLE
Add support for systemd.verity_root_data= in the kernel cmdline

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -391,6 +391,14 @@ There is no extra slot configuration needed for this as RAUC assumes it is safe
 to update all available slots in case the currently running system comes from
 NFS.
 
+.. rubric:: ``systemd.verity_root_data=``
+
+RAUC handles the ``systemd.verity_root_data=`` parameter the same as ``root=``
+above.
+See the `systemd-veritysetup-generator documentation
+<https://www.freedesktop.org/software/systemd/man/systemd-veritysetup-generator.html#systemd.verity_root_data=>`_
+for details.
+
 Barebox
 ~~~~~~~
 

--- a/src/context.c
+++ b/src/context.c
@@ -54,6 +54,9 @@ static const gchar* get_cmdline_bootname(void)
 
 	bootname = regex_match("root=(\\S+)", contents);
 	if (!bootname)
+		bootname = regex_match("systemd\\.verity_root_data=(\\S+)", contents);
+
+	if (!bootname)
 		return NULL;
 
 	if (strncmp(bootname, "PARTLABEL=", 10) == 0) {


### PR DESCRIPTION
Both [systemd][1] and [systemd-veritysetup-generator][2] define and use the specific systemd kernel parameter `systemd.verity_root_data=` to setup the integrity protected for the root file-system.

This looks for the kernel parameter `systemd.verity_root_data=` to guess the booted slot name if `root=` is not unset.

[1]: https://www.freedesktop.org/software/systemd/man/kernel-command-line.html#roothash=
[2]: https://www.freedesktop.org/software/systemd/man/systemd-veritysetup-generator.html#systemd.verity_root_data=