### PR TITLE
docs: add Upparat (client for AWS IoT Jobs)

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1075,3 +1075,16 @@ https://github.com/rauc/rauc-hawkbit
 It is also available via pypi:
 
 https://pypi.python.org/pypi/rauc-hawkbit/
+
+Upparat: Client for AWS IoT Jobs (python)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Upparat acts as a client for `AWS IoT Jobs <https://docs.aws.amazon.com/iot/latest/developerguide/iot-jobs.html>`_ that can be used together with RAUC.
+
+For more information visit it on GitHub:
+
+https://github.com/caruhome/upparat
+
+It is also available via pypi:
+
+https://pypi.org/project/upparat/


### PR DESCRIPTION
We recently open sourced [Upparat](https://github.com/caruhome/upparat) (a client for AWS IoT Jobs) that we use at [CARU](http://caruhome.com) in conjunction with RAUC to update our device fleet. Conceptually it's comparable to the RAUC hawkbit client but for [AWS IoT](https://aws.amazon.com/iot/) instead of hawkbit. 

If you don't mind I'd love to add a link in the docs. :)

Signed-off-by: Livio Bieri <livio@livio.li>