### PR TITLE
Some Sanity Checks For Specifying Hooks in Bundle Manifest

### DIFF
--- a/include/manifest.h
+++ b/include/manifest.h
@@ -158,8 +158,8 @@ void free_manifest(RaucManifest *manifest);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucManifest, free_manifest);
 
 /**
- * Updates checksums for files and images listed in the manifest and found in
- * the bundle directory.
+ * Checks presence of image and hook files (defined in manifest) in bundle
+ * content directory and updates checksums.
  *
  * @param manifest pointer to the manifest
  * @param dir Directory with the bundle content
@@ -167,7 +167,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucManifest, free_manifest);
  *
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean update_manifest_checksums(RaucManifest *manifest, const gchar *dir, GError **error)
+gboolean sync_manifest_with_contentdir(RaucManifest *manifest, const gchar *dir, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -616,7 +616,7 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 		goto out;
 	}
 
-	res = update_manifest_checksums(manifest, contentdir, &ierror);
+	res = sync_manifest_with_contentdir(manifest, contentdir, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -361,8 +361,7 @@ gboolean check_manifest_internal(const RaucManifest *mf, GError **error)
 
 	r_context_begin_step("check_manifest", "Checking manifest contents", 0);
 
-	res = check_manifest_common(mf, &ierror);
-	if (!res) {
+	if (!check_manifest_common(mf, &ierror)) {
 		g_propagate_error(error, ierror);
 		goto out;
 	}
@@ -405,8 +404,7 @@ gboolean check_manifest_external(const RaucManifest *mf, GError **error)
 
 	r_context_begin_step("check_manifest", "Checking manifest contents", 0);
 
-	res = check_manifest_common(mf, &ierror);
-	if (!res) {
+	if (!check_manifest_common(mf, &ierror)) {
 		g_propagate_error(error, ierror);
 		goto out;
 	}

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -65,7 +65,7 @@ static gboolean parse_image(GKeyFile *key_file, const gchar *group, RaucImage **
 			iimage->hooks.post_install = TRUE;
 		} else {
 			g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
-					"hook key %s not supported", hooks[j]);
+					"slot hook type '%s' not supported", hooks[j]);
 			goto out;
 		}
 	}
@@ -173,7 +173,7 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 			raucm->hooks.install_check = TRUE;
 		} else {
 			g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
-					"hook key %s not supported", bundle_hooks[j]);
+					"install hook type '%s' not supported", bundle_hooks[j]);
 			goto free;
 		}
 	}

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -64,7 +64,9 @@ static gboolean parse_image(GKeyFile *key_file, const gchar *group, RaucImage **
 		} else if (g_strcmp0(hooks[j], "post-install") == 0) {
 			iimage->hooks.post_install = TRUE;
 		} else {
-			g_warning("hook key %s not supported", hooks[j]);
+			g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
+					"hook key %s not supported", hooks[j]);
+			goto out;
 		}
 	}
 	g_key_file_remove_key(key_file, group, "hooks", NULL);
@@ -170,7 +172,9 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 		if (g_strcmp0(bundle_hooks[j], "install-check") == 0) {
 			raucm->hooks.install_check = TRUE;
 		} else {
-			g_warning("hook key %s not supported", bundle_hooks[j]);
+			g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
+					"hook key %s not supported", bundle_hooks[j]);
+			goto free;
 		}
 	}
 	g_strfreev(bundle_hooks);

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -321,6 +321,35 @@ filename=rootfs-var2.ext4\n\
 	free_manifest(rm);
 }
 
+static void test_manifest_invalid_hook_name(void)
+{
+	g_autofree gchar *tmpdir;
+	g_autofree gchar *manifestpath = NULL;
+	g_autoptr(RaucManifest) rm = NULL;
+	gboolean res = FALSE;
+	g_autoptr(GError) error = NULL;
+	const gchar *mffile = "\
+[update]\n\
+compatible=FooCorp Super BarBazzer\n\
+version=2015.04-1\n\
+\n\
+[image.rootfs]\n\
+filename=rootfs-default.ext4\n\
+hooks=doesnotexist\n\
+";
+
+	tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+	g_assert_nonnull(tmpdir);
+
+	manifestpath = write_tmp_file(tmpdir, "manifest.raucm", mffile, NULL);
+	g_assert_nonnull(manifestpath);
+
+	res = load_manifest_file(manifestpath, &rm, &error);
+	g_assert_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE);
+	g_assert_false(res);
+	g_assert_null(rm);
+}
+
 
 /* Test manifest/invalid_data:
  *
@@ -423,6 +452,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/manifest/save/writefail", test_save_manifest_writefail);
 	g_test_add_func("/manifest/load_mem", test_load_manifest_mem);
 	g_test_add_func("/manifest/load_variants", test_manifest_load_variants);
+	g_test_add_func("/manifest/invalid_hook_name", test_manifest_invalid_hook_name);
 	g_test_add_func("/manifest/invalid_data", test_invalid_data);
 
 	return g_test_run();


### PR DESCRIPTION
This adds some sanity checks for parsing hook configuration during both bundle generation and bundle installation.

This should let misconfiguration fail faster and more explicitly and thus ease debugging hook handling issues (like https://github.com/rauc/meta-rauc/issues/185).

* Add checks for using valid hook types only
* Give more targeted error messages
* Add checks for specifying hook file when using hooks
* Add check for having hook file actually in bundle
* Fix broken error handling in manifest checking