### PR TITLE
src: allow passing separate devicetree file to barebox-state

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -93,6 +93,17 @@ Example configuration:
   key not exists, the bootchooser framework searches per default for ``/state``
   or ``/aliases/state``.
 
+``barebox-dtbpath``
+  Only valid when ``bootloader`` is set to ``barebox``.
+  Allows to set a path to a separate devicetree (dtb) file to be used for
+  reading `barebox state <https://www.barebox.org/doc/latest/user/state.html>`_
+  definition from.
+  This is mainly useful for systems that do not use devicetrees by default,
+  like x86 systems.
+
+  .. note:: Requires to have at least `dt-utils
+     <https://git.pengutronix.de/cgit/tools/dt-utils>`_ version 2021.03.0
+
 ``boot-attempts``
   This configures the number of boot attempts to set when a slot is marked good
   through the D-Bus API or via the command line tool.

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -36,6 +36,7 @@ typedef struct {
 	gchar *system_variant;
 	gchar *system_bootloader;
 	gchar *system_bb_statename;
+	gchar *system_bb_dtbpath;
 	gint boot_default_attempts;
 	gint boot_attempts_primary;
 	gchar *grubenv_path;

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -80,6 +80,10 @@ static gboolean barebox_state_get(const gchar* bootname, BareboxSlotState *bb_st
 	g_ptr_array_add(args, g_strdup_printf(BOOTSTATE_PREFIX ".%s.priority", bootname));
 	g_ptr_array_add(args, g_strdup("-g"));
 	g_ptr_array_add(args, g_strdup_printf(BOOTSTATE_PREFIX ".%s.remaining_attempts", bootname));
+	if (r_context()->config->system_bb_dtbpath) {
+		g_ptr_array_add(args, g_strdup("-i"));
+		g_ptr_array_add(args, g_strdup(r_context()->config->system_bb_dtbpath));
+	}
 	g_ptr_array_add(args, NULL);
 
 	sub = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_STDOUT_PIPE, &ierror);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -220,6 +220,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 
 	if (g_strcmp0(c->system_bootloader, "barebox") == 0) {
 		c->system_bb_statename = key_file_consume_string(key_file, "system", "barebox-statename", NULL);
+		c->system_bb_dtbpath = key_file_consume_string(key_file, "system", "barebox-dtbpath", NULL);
 	} else if (g_strcmp0(c->system_bootloader, "grub") == 0) {
 		c->grubenv_path = resolve_path(filename,
 				key_file_consume_string(key_file, "system", "grubenv", NULL));


### PR DESCRIPTION
This makes use of the new feature of dt-utils' barebox-state command
`-i` switch that takes the path to a devicetree file to read the state
information from (introduced by v2021.03.0 release).

We add a new configuration option only being enabled when using
'barebox' boot selection backend: `barebox-dtbpath`.
Example:
``` ini
  [system]
  ...
  bootloader=barebox
  barebox-dtbpath=/run/efi/EFI/BAREBOX/state.dtb
```
This is especially meant to be used for platforms that do not use
devicetrees for booting, thus mainly x86 ones.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>