### PR TITLE
src/manifest: fix leaking hooks string list variables

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -19,7 +19,7 @@ static gboolean parse_image(GKeyFile *key_file, const gchar *group, RaucImage **
 	g_autoptr(RaucImage) iimage = g_new0(RaucImage, 1);
 	g_auto(GStrv) groupsplit = NULL;
 	gchar *value;
-	gchar **hooks;
+	g_auto(GStrv) hooks = NULL;
 	gsize entries;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
@@ -71,8 +71,6 @@ static gboolean parse_image(GKeyFile *key_file, const gchar *group, RaucImage **
 	}
 	g_key_file_remove_key(key_file, group, "hooks", NULL);
 
-	g_strfreev(hooks);
-
 	if (!check_remaining_keys(key_file, group, &ierror)) {
 		g_propagate_error(error, ierror);
 		goto out;
@@ -104,7 +102,7 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 	g_autofree gchar *tmp = NULL;
 	gchar **groups;
 	gsize group_count;
-	gchar **bundle_hooks;
+	g_auto(GStrv) bundle_hooks = NULL;
 	gsize hook_entries;
 
 	g_assert_null(*manifest);
@@ -177,7 +175,6 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 			goto free;
 		}
 	}
-	g_strfreev(bundle_hooks);
 
 	if (!check_remaining_keys(key_file, "hooks", &ierror)) {
 		g_propagate_error(error, ierror);


### PR DESCRIPTION
This fixes memory leaks introduced by PR #719 (commit f0f8a335) and
reported by coverity:

>  *** CID 1452216:  Resource leaks  (RESOURCE_LEAK)
>  /src/manifest.c: 86 in parse_image()
>  80     	g_key_file_remove_group(key_file, group, NULL);
>  81
>  82     	res = TRUE;
>  83     	*image = g_steal_pointer(&iimage);
>  84
>  85     out:
>  -->     CID 1452216:  Resource leaks  (RESOURCE_LEAK)
>  -->     Variable "hooks" going out of scope leaks the storage it points to.
>  86     	return res;
>  87     }
>  88
>  89     /* Parses key_file into RaucManifest structure
>  90      *
>  91      * key_file - input key file
> 
>  ** CID 1452215:  Resource leaks  (RESOURCE_LEAK)
>  /src/manifest.c: 258 in parse_manifest()

The above-mentioned commit made the function return earlier in case of an error which will then bypass the cleanup of the variables with `g_strfreev()`.

Both fix and simplify this by using auto cleanup functionality here, too.
