### PR TITLE
Remove Long Deprecated Sections from Manifest Parsing.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -162,6 +162,7 @@ AC_CONFIG_LINKS([test/good-casync-bundle-1.4.raucb:test/good-casync-bundle-1.4.r
 AC_CONFIG_LINKS([test/good-casync-bundle-1.5.1.raucb:test/good-casync-bundle-1.5.1.raucb])
 AC_CONFIG_LINKS([test/invalid-sig-bundle.raucb:test/invalid-sig-bundle.raucb])
 AC_CONFIG_LINKS([test/manifest.raucm:test/manifest.raucm])
+AC_CONFIG_LINKS([test/broken-manifest.raucm:test/broken-manifest.raucm])
 AC_CONFIG_LINKS([test/dummy.verity:test/dummy.verity])
 AC_CONFIG_LINKS([test/openssl-ca/manifest:test/openssl-ca/manifest])
 AC_CONFIG_LINKS([test/openssl-ca/root/ca.cert.pem:test/openssl-ca/root/ca.cert.pem])

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -55,8 +55,6 @@ typedef struct {
 	gchar *bundle_verity_hash;
 	guint64 bundle_verity_size;
 
-	gchar *keyring;
-
 	gchar *handler_name;
 	gchar *handler_args;
 

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -32,13 +32,6 @@ typedef struct {
 	SlotHooks hooks;
 } RaucImage;
 
-typedef struct {
-	gchar* slotclass;
-	RaucChecksum checksum;
-	gchar* filename;
-	gchar* destname;
-} RaucFile;
-
 typedef enum {
 	R_MANIFEST_FORMAT_PLAIN = 0,
 	R_MANIFEST_FORMAT_VERITY,
@@ -62,7 +55,6 @@ typedef struct {
 	InstallHooks hooks;
 
 	GList *images;
-	GList *files;
 } RaucManifest;
 
 /**
@@ -174,13 +166,6 @@ G_GNUC_WARN_UNUSED_RESULT;
 void r_free_image(gpointer data);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucImage, r_free_image);
-
-/**
- * Frees a rauc file
- */
-void r_free_file(gpointer data);
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucFile, r_free_file);
 
 static inline const gchar *r_manifest_bundle_format_to_str(RManifestBundleFormat format)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -639,7 +639,6 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 	formatter_shell_append(text, "RAUC_MF_DESCRIPTION", manifest->update_description);
 	formatter_shell_append(text, "RAUC_MF_BUILD", manifest->update_build);
 	g_string_append_printf(text, "RAUC_MF_IMAGES=%d\n", g_list_length(manifest->images));
-	g_string_append_printf(text, "RAUC_MF_FILES=%d\n", g_list_length(manifest->files));
 
 	hooks = g_ptr_array_new();
 	if (manifest->hooks.install_check == TRUE) {
@@ -679,17 +678,6 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 		g_free(hookstring);
 
 		g_ptr_array_unref(hooks);
-		cnt++;
-	}
-
-	cnt = 0;
-	for (GList *l = manifest->files; l != NULL; l = l->next) {
-		RaucFile *file = l->data;
-		g_string_append_printf(text, "RAUC_FILE_NAME_%d=%s\n", cnt, file->filename);
-		g_string_append_printf(text, "RAUC_FILE_CLASS_%d=%s\n", cnt, file->slotclass);
-		g_string_append_printf(text, "RAUC_FILE_DEST_%d=%s\n", cnt, file->destname);
-		g_string_append_printf(text, "RAUC_FILE_DIGEST_%d=%s\n", cnt, file->checksum.digest);
-		g_string_append_printf(text, "RAUC_FILE_SIZE_%d=%"G_GOFFSET_FORMAT "\n", cnt, file->checksum.size);
 		cnt++;
 	}
 
@@ -757,19 +745,6 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 
 		g_ptr_array_unref(hooks);
 
-		cnt++;
-	}
-
-	cnt = g_list_length(manifest->files);
-	g_string_append_printf(text, "%d File%s%s\n", cnt, cnt == 1 ? "" : "s", cnt > 0 ? ":" : "");
-	cnt = 1;
-	for (GList *l = manifest->files; l != NULL; l = l->next) {
-		RaucFile *file = l->data;
-		g_string_append_printf(text, "(%d)\t%s\n", cnt, file->filename);
-		g_string_append_printf(text, "\tSlotclass: %s\n", file->slotclass);
-		g_string_append_printf(text, "\tDest:      %s\n", file->destname);
-		g_string_append_printf(text, "\tChecksum:  %s\n", file->checksum.digest);
-		g_string_append_printf(text, "\tSize:      %"G_GOFFSET_FORMAT "\n", file->checksum.size);
 		cnt++;
 	}
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -6,7 +6,6 @@
 #include "utils.h"
 
 #define RAUC_IMAGE_PREFIX	"image"
-#define RAUC_FILE_PREFIX	"file"
 
 #define R_MANIFEST_ERROR r_manifest_error_quark()
 GQuark r_manifest_error_quark(void)
@@ -174,7 +173,7 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 	}
 	g_key_file_remove_group(key_file, "hooks", NULL);
 
-	/* parse [image.<slotclass>] and [file.<slotclass>/<destname>] sections */
+	/* parse [image.<slotclass>] sections */
 	groups = g_key_file_get_groups(key_file, &group_count);
 	for (gsize i = 0; i < group_count; i++) {
 		if (g_str_has_prefix(groups[i], RAUC_IMAGE_PREFIX ".")) {
@@ -186,51 +185,6 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 			}
 
 			raucm->images = g_list_append(raucm->images, image);
-		} else if (g_str_has_prefix(groups[i], RAUC_FILE_PREFIX ".")) {
-			RaucFile *file;
-			gchar *value;
-			gchar **groupsplit = g_strsplit(groups[i], ".", 2);
-			gchar **destsplit = NULL;
-			if (groupsplit == NULL || g_strv_length(groupsplit) < 2) {
-				g_strfreev(groupsplit);
-				continue;
-			}
-			destsplit = g_strsplit(groupsplit[1], "/", 2);
-			g_strfreev(groupsplit);
-
-			if (destsplit == NULL || g_strv_length(destsplit) < 2) {
-				g_strfreev(destsplit);
-				continue;
-			}
-
-			file = g_new0(RaucFile, 1);
-
-			file->slotclass = g_strdup(destsplit[0]);
-			file->destname = g_strdup(destsplit[1]);
-
-			value = key_file_consume_string(key_file, groups[i], "sha256", NULL);
-			if (value) {
-				file->checksum.type = G_CHECKSUM_SHA256;
-				file->checksum.digest = value;
-			}
-			file->checksum.size = g_key_file_get_uint64(key_file,
-					groups[i], "size", NULL);
-			g_key_file_remove_key(key_file, groups[i], "size", NULL);
-
-
-			file->filename = key_file_consume_string(key_file, groups[i], "filename", &ierror);
-			if (file->filename == NULL) {
-				g_propagate_error(error, ierror);
-				goto free;
-			}
-
-			raucm->files = g_list_append(raucm->files, file);
-
-			if (!check_remaining_keys(key_file, groups[i], &ierror)) {
-				g_propagate_error(error, ierror);
-				goto free;
-			}
-			g_key_file_remove_group(key_file, groups[i], NULL);
 		}
 	}
 
@@ -576,24 +530,6 @@ static GKeyFile *prepare_manifest(const RaucManifest *mf)
 		}
 	}
 
-	for (GList *l = mf->files; l != NULL; l = l->next) {
-		RaucFile *file = l->data;
-		g_autofree gchar *group = NULL;
-
-		if (!file || !file->slotclass || !file->destname)
-			continue;
-
-		group = g_strconcat(RAUC_FILE_PREFIX ".", file->slotclass, "/", file->destname, NULL);
-
-		if (file->checksum.type == G_CHECKSUM_SHA256)
-			g_key_file_set_string(key_file, group, "sha256", file->checksum.digest);
-		if (file->checksum.size)
-			g_key_file_set_uint64(key_file, group, "size", file->checksum.size);
-
-		if (file->filename)
-			g_key_file_set_string(key_file, group, "filename", file->filename);
-	}
-
 	return g_steal_pointer(&key_file);
 }
 
@@ -646,19 +582,6 @@ void r_free_image(gpointer data)
 	g_free(image);
 }
 
-void r_free_file(gpointer data)
-{
-	RaucFile *file = (RaucFile*) data;
-
-	g_return_if_fail(file);
-
-	g_free(file->slotclass);
-	g_free(file->destname);
-	g_free(file->checksum.digest);
-	g_free(file->filename);
-	g_free(file);
-}
-
 void free_manifest(RaucManifest *manifest)
 {
 	g_return_if_fail(manifest);
@@ -673,12 +596,11 @@ void free_manifest(RaucManifest *manifest)
 	g_free(manifest->handler_args);
 	g_free(manifest->hook_name);
 	g_list_free_full(manifest->images, r_free_image);
-	g_list_free_full(manifest->files, r_free_file);
 	g_free(manifest);
 }
 
 /**
- * Updates checksums for files and images listed in the manifest and found in
+ * Updates checksums for images listed in the manifest and found in
  * the bundle directory.
  *
  * @param manifest pointer to the manifest
@@ -697,18 +619,6 @@ static gboolean update_manifest_checksums(RaucManifest *manifest, const gchar *d
 		RaucImage *image = elem->data;
 		g_autofree gchar *filename = g_build_filename(dir, image->filename, NULL);
 		res = compute_checksum(&image->checksum, filename, &ierror);
-		if (!res) {
-			g_warning("Failed updating checksum: %s", ierror->message);
-			g_clear_error(&ierror);
-			had_errors = TRUE;
-			break;
-		}
-	}
-
-	for (GList *elem = manifest->files; elem != NULL; elem = elem->next) {
-		RaucFile *file = elem->data;
-		g_autofree gchar *filename = g_build_filename(dir, file->filename, NULL);
-		res = compute_checksum(&file->checksum, filename, &ierror);
 		if (!res) {
 			g_warning("Failed updating checksum: %s", ierror->message);
 			g_clear_error(&ierror);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -145,14 +145,6 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 	}
 	g_key_file_remove_group(key_file, "bundle", NULL);
 
-	/* parse [keyring] section */
-	raucm->keyring = key_file_consume_string(key_file, "keyring", "archive", NULL);
-	if (!check_remaining_keys(key_file, "keyring", &ierror)) {
-		g_propagate_error(error, ierror);
-		goto free;
-	}
-	g_key_file_remove_group(key_file, "keyring", NULL);
-
 	/* parse [handler] section */
 	raucm->handler_name = key_file_consume_string(key_file, "handler", "filename", NULL);
 	raucm->handler_args = key_file_consume_string(key_file, "handler", "args", NULL);
@@ -524,9 +516,6 @@ static GKeyFile *prepare_manifest(const RaucManifest *mf)
 			break;
 	}
 
-	if (mf->keyring)
-		g_key_file_set_string(key_file, "keyring", "archive", mf->keyring);
-
 	if (mf->handler_name)
 		g_key_file_set_string(key_file, "handler", "filename", mf->handler_name);
 
@@ -680,7 +669,6 @@ void free_manifest(RaucManifest *manifest)
 	g_free(manifest->update_build);
 	g_free(manifest->bundle_verity_hash);
 	g_free(manifest->bundle_verity_salt);
-	g_free(manifest->keyring);
 	g_free(manifest->handler_name);
 	g_free(manifest->handler_args);
 	g_free(manifest->hook_name);

--- a/test/install.c
+++ b/test/install.c
@@ -272,14 +272,6 @@ filename=appfs.ext4\n\
 sha256=ecf4c031d01cb9bfa9aa5ecfce93efcf9149544bdbf91178d2c2d9d1d24076ca\n\
 filename=demofs.ext4\n\
 \n\
-[file.rootfs/vmlinuz]\n\
-sha256=5fb50868cd1f2e34ff531d6680c9b734ba35ed4944072f396a50871e9c2d5155\n\
-filename=linux.img\n\
-\n\
-[file.rootfs/initramfs]\n\
-sha256=d37328d0d80779573b204762ee8aa011c22a5c43088f7541a8c1f591f8e3be6a\n\
-filename=initramfs.cpio.gz\n\
-\n\
 [image.bootloader]\n\
 sha256=ecf4c031d01cb9bfa9aa5ecfce93efcf9149544bdbf91178d2c2d9d1d24076ca\n\
 filename=bootloader.img";

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -48,26 +48,30 @@ static void test_load_manifest(void)
 {
 	RaucManifest *rm = NULL;
 	GError *error = NULL;
+	gboolean res;
 
 	// Load valid manifest file
-	g_assert_true(load_manifest_file("test/manifest.raucm", &rm, &error));
-	g_assert_null(error);
+	res = load_manifest_file("test/manifest.raucm", &rm, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
 	manifest_check_common(rm);
 
 	g_clear_pointer(&rm, free_manifest);
 	g_assert_null(rm);
 
 	// Load non-existing manifest file
-	g_assert_false(load_manifest_file("test/nonexisting.raucm", &rm, &error));
-	g_assert_nonnull(error);
+	res = load_manifest_file("test/nonexisting.raucm", &rm, &error);
+	g_assert_error(error, G_FILE_ERROR, G_FILE_ERROR_NOENT);
+	g_assert_false(res);
 
 	g_clear_pointer(&rm, free_manifest);
 	g_clear_error(&error);
 	g_assert_null(rm);
 
 	// Load broken manifest file
-	g_assert_false(load_manifest_file("test/broken-manifest.raucm", &rm, &error));
-	g_assert_nonnull(error);
+	res = load_manifest_file("test/broken-manifest.raucm", &rm, &error);
+	g_assert_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND);
+	g_assert_false(res);
 
 	g_clear_pointer(&rm, free_manifest);
 	g_clear_error(&error);
@@ -226,6 +230,7 @@ static void test_manifest_load_variants(void)
 	gchar *tmpdir;
 	RaucManifest *rm = NULL;
 	gchar* manifestpath = NULL;
+	gboolean res;
 	GError *error = NULL;
 	RaucImage *test_img = NULL;
 	const gchar *mffile = "\
@@ -257,8 +262,9 @@ filename=rootfs-var2.ext4\n\
 
 	g_free(tmpdir);
 
-	g_assert_true(load_manifest_file(manifestpath, &rm, &error));
+	res = load_manifest_file(manifestpath, &rm, &error);
 	g_assert_no_error(error);
+	g_assert_true(res);
 
 	g_clear_error(&error);
 	g_free(manifestpath);

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -26,7 +26,6 @@ static void manifest_check_common(RaucManifest *rm)
 	g_assert_nonnull(rm->images);
 
 	g_assert_cmpuint(g_list_length(rm->images), ==, 2);
-	g_assert_cmpuint(g_list_length(rm->files), ==, 2);
 
 	for (GList *l = rm->images; l != NULL; l = l->next) {
 		RaucImage *img = l->data;
@@ -34,15 +33,6 @@ static void manifest_check_common(RaucManifest *rm)
 		g_assert_nonnull(img->slotclass);
 		g_assert_nonnull(img->checksum.digest);
 		g_assert_nonnull(img->filename);
-	}
-
-	for (GList *l = rm->files; l != NULL; l = l->next) {
-		RaucFile *file = l->data;
-		g_assert_nonnull(file);
-		g_assert_nonnull(file->slotclass);
-		g_assert_nonnull(file->destname);
-		g_assert_nonnull(file->checksum.digest);
-		g_assert_nonnull(file->filename);
 	}
 }
 
@@ -94,7 +84,6 @@ static void check_manifest_contents(const RaucManifest *rm)
 	g_assert_cmpstr(rm->hook_name, ==, "hook.sh");
 
 	g_assert_cmpuint(g_list_length(rm->images), ==, 3);
-	g_assert_cmpuint(g_list_length(rm->files), ==, 1);
 
 	for (GList *l = rm->images; l != NULL; l = l->next) {
 		RaucImage *image = (RaucImage*) l->data;
@@ -102,15 +91,6 @@ static void check_manifest_contents(const RaucManifest *rm)
 		g_assert_nonnull(image->slotclass);
 		g_assert_nonnull(image->checksum.digest);
 		g_assert_nonnull(image->filename);
-	}
-
-	for (GList *l = rm->files; l != NULL; l = l->next) {
-		RaucFile *file = l->data;
-		g_assert_nonnull(file);
-		g_assert_nonnull(file->slotclass);
-		g_assert_nonnull(file->destname);
-		g_assert_nonnull(file->checksum.digest);
-		g_assert_nonnull(file->filename);
 	}
 
 	g_assert_nonnull(g_list_nth_data(rm->images, 0));
@@ -133,7 +113,6 @@ static void test_save_load_manifest(void)
 	gboolean res = FALSE;
 	RaucManifest *rm = g_new0(RaucManifest, 1);
 	RaucImage *new_image;
-	RaucFile *new_file;
 	GBytes *mem = NULL;
 
 	rm->update_compatible = g_strdup("BarCorp FooBazzer");
@@ -172,17 +151,7 @@ static void test_save_load_manifest(void)
 	new_image->filename = g_strdup("myappimg.ext4");
 	rm->images = g_list_append(rm->images, new_image);
 
-	new_file = g_new0(RaucFile, 1);
-
-	new_file->slotclass = g_strdup("rootfs");
-	new_file->destname = g_strdup("vmlinuz");
-	new_file->checksum.type = G_CHECKSUM_SHA256;
-	new_file->checksum.digest = g_strdup("5ce231b9683db16623783b8bcff120c11969e8d29755f25bc87a6fae92e06741");
-	new_file->filename = g_strdup("mykernel.img");
-	rm->files = g_list_append(rm->files, new_file);
-
 	g_assert_cmpuint(g_list_length(rm->images), ==, 3);
-	g_assert_cmpuint(g_list_length(rm->files), ==, 1);
 
 	res = save_manifest_file("test/savedmanifest.raucm", rm, &error);
 	g_assert_no_error(error);

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -20,7 +20,6 @@ static void manifest_check_common(RaucManifest *rm)
 	g_assert_nonnull(rm);
 	g_assert_cmpstr(rm->update_compatible, ==, "FooCorp Super BarBazzer");
 	g_assert_cmpstr(rm->update_version, ==, "2015.04-1");
-	g_assert_cmpstr(rm->keyring, ==, "release.tar");
 	g_assert_cmpstr(rm->handler_name, ==, "custom_handler.sh");
 	g_assert_cmpstr(rm->handler_args, ==, NULL);
 	g_assert_cmpstr(rm->hook_name, ==, "hook.sh");
@@ -90,7 +89,6 @@ static void check_manifest_contents(const RaucManifest *rm)
 	g_assert_nonnull(rm);
 	g_assert_cmpstr(rm->update_compatible, ==, "BarCorp FooBazzer");
 	g_assert_cmpstr(rm->update_version, ==, "2011.03-1");
-	g_assert_cmpstr(rm->keyring, ==, "mykeyring.tar");
 	g_assert_cmpstr(rm->handler_name, ==, "myhandler.sh");
 	g_assert_cmpstr(rm->handler_args, ==, "--foo");
 	g_assert_cmpstr(rm->hook_name, ==, "hook.sh");
@@ -140,7 +138,6 @@ static void test_save_load_manifest(void)
 
 	rm->update_compatible = g_strdup("BarCorp FooBazzer");
 	rm->update_version = g_strdup("2011.03-1");
-	rm->keyring = g_strdup("mykeyring.tar");
 	rm->handler_name = g_strdup("myhandler.sh");
 	rm->handler_args = g_strdup("--foo");
 	rm->hook_name = g_strdup("hook.sh");
@@ -266,9 +263,6 @@ static void test_manifest_load_variants(void)
 [update]\n\
 compatible=FooCorp Super BarBazzer\n\
 version=2015.04-1\n\
-\n\
-[keyring]\n\
-archive=release.tar\n\
 \n\
 [handler]\n\
 filename=custom_handler.sh\n\

--- a/test/manifest.raucm
+++ b/test/manifest.raucm
@@ -4,9 +4,6 @@
 compatible=FooCorp Super BarBazzer
 version=2015.04-1
 
-[keyring]
-archive=release.tar
-
 [handler]
 filename=custom_handler.sh
 

--- a/test/manifest.raucm
+++ b/test/manifest.raucm
@@ -18,11 +18,3 @@ hooks=pre-install;post-install
 [image.appfs]
 sha256=ecf4c031d01cb9bfa9aa5ecfce93efcf9149544bdbf91178d2c2d9d1d24076ca
 filename=appfs.ext4
-
-[file.rootfs/vmlinuz]
-sha256=5fb50868cd1f2e34ff531d6680c9b734ba35ed4944072f396a50871e9c2d5155
-filename=linux.img
-
-[file.rootfs/initramfs]
-sha256=d37328d0d80779573b204762ee8aa011c22a5c43088f7541a8c1f591f8e3be6a
-filename=initramfs.cpio.gz


### PR DESCRIPTION
This removes two manifest config options which were parsed but not actually used anywhere in the code.
This is unexpected and violates the concept that a manifest configuration/content actually has an impact on the installation.

Removed sections are:

* The `file.<slotclass>/<filename>` sections which originates from the long deprecated bundle-free network mode (not to be confused with the current network capabilities of RAUC) we had in the early days of RAUC.
* The `keyring` section that existed since the initial concept but actually never gained any implementation in RAUC

Note this might break very rare cases where one accidentally had one of the deprecated sections in the manifest and probably requires fixing the update bundle in this case. On the other hand, this will prevent future confusion and ensure we get distinct errors for things that are not working, anyway.

Fixes #709.