### PR TITLE
Testing Documentation & 'qemu-test system' Command

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -35,6 +35,91 @@ Documentation
 - Use `semantic linefeeds
   <http://rhodesmill.org/brandon/2012/one-sentence-per-line/>`_ in .rst files.
 
+Check Scripts & Test Suite
+--------------------------
+
+To ensure we do not break existing behavior and detect potential bugs, RAUC
+runs a test suite consisting of several components.
+Some of them only run in CI, but most of them can be executed locally.
+When working on a new feature or fixing a bug, please make sure these tests
+succeed.
+
+Code Style - uncrustify 
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To maintain a consistent code style, we use the `uncrustify
+<https://github.com/uncrustify/uncrustify>`_ code beautifier that also runs in
+the CI loop.
+
+To make sure your changes match the expected code style, run::
+
+  ./uncrustify.sh
+
+from the RAUC source code's root directory.
+It will adapt style where necessary.
+
+CLI Tests - sharness
+~~~~~~~~~~~~~~~~~~~~
+
+For high-level tests of the RAUC command line interface we use the `sharness
+<https://github.com/chriscool/sharness>`_ shell library.
+
+You can run these checks manually by executing::
+
+  cd test
+  ./rauc.t
+
+from the RAUC source code's root directory but they will also be triggered by
+the general test suite run (see below).
+If you add or change subcommands or arguments of the CLI tool, make sure these
+tests succeed and extend them if possible.
+As many of these tests need root permissions, we recommend running them using the 
+``qemu-test`` helper below.
+
+glib Unit Tests - gtest
+~~~~~~~~~~~~~~~~~~~~~~~
+
+For testing the different C modules of RAUC's source code, we use the `glib
+Test Framework <https://developer.gnome.org/glib/stable/glib-Testing.html>`_.
+
+All tests reside in the ``test/`` folder and are named according to the module
+they test (``test/bundle.c`` contains tests for ``src/bundle.c``).
+
+To build and run an individual test, do::
+
+  make test/bundle.test
+  ./test/bundle.test
+
+To run all tests, run::
+
+  make check
+
+This will also run the sharness CLI tests mentioned above.
+
+.. note:: Although some of the tests need to run as root, do NOT use 'sudo', but
+   use our ``qemu-test`` helper instead!
+
+QEMU Test Runner - qemu-test
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As many of the unit tests require root privileges and thus could potentially
+damage your host system, we provide a QEMU-based test environment where one can
+safely run all checks in a virtual environment.
+
+To run the entire test suite, type::
+
+  ./qemu-test
+
+For optimal performance, run::
+
+  ./qemu-test passthrough
+
+which will pass through your host's CPU features to the guest.
+
+For interactive access to the test environment, use::
+
+  ./qemu-test shell
+
 Developer's Certificate of Origin
 ---------------------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -99,6 +99,8 @@ This will also run the sharness CLI tests mentioned above.
 .. note:: Although some of the tests need to run as root, do NOT use 'sudo', but
    use our ``qemu-test`` helper instead!
 
+.. _sec-contributing-qemu-test:
+
 QEMU Test Runner - qemu-test
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -674,3 +674,40 @@ Example invocation:
 
   G_MESSAGES_DEBUG="rauc rauc-subprocess" rauc service
 
+Reproducing Issues using QEMU Test Setup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The RAUC source code repository provides a :ref:``qemu-test
+sec-contributing-qemu-test`` script, mainly meant to be used for running the
+unit tests in a safe environment. But this can also be used to reproduce and
+debug basic functionality of rauc.
+
+When running::
+
+  $ ./qemu-test system
+
+you will boot into a QEMU shell that has a mocked RAUC setup allowing you to
+inspect status, install procedure, etc.
+For example::
+
+  root@qemu-test:/home/user/git/rauc# rauc status
+  === System Info ===
+  Compatible:  Test Config
+  Variant:
+  Booted from: rootfs.0 (A)
+
+  === Bootloader ===
+  Activated: rootfs.0 (A)
+
+  === Slot States ===
+  x [rootfs.0] (/dev/root, raw, booted)
+          bootname: A
+          mounted: /
+          boot status: good
+      [appfs.0] (/dev/null, raw, active)
+
+  o [rootfs.1] (/tmp/rootdev, raw, inactive)
+          bootname: B
+          boot status: good
+      [appfs.1] (/tmp/appdev, raw, inactive)
+

--- a/qemu-test
+++ b/qemu-test
@@ -16,6 +16,7 @@
 #   distcheck   Run distcheck make target
 #   passthrough Enable passthrough of the host's CPU features
 #   shell       Setup qemu test system and provide an interactive shell
+#   system      Setup qemu dummy system that behaves like a target (without reboot!)
 #
 # When no argument is given, the default test suite will be executed
 
@@ -48,9 +49,12 @@ check_kernel || exit 1
 make TESTS= check > /dev/null
 
 QEMU_ARGS=""
+BOOTNAME="system0"
 for x in "$@"; do
   if [ "$x" = "passthrough" ]; then
     QEMU_ARGS="$QEMU_ARGS -cpu host"
+  elif [ "$x" = "system" ]; then
+    BOOTNAME="A"
   fi
 done
 
@@ -70,6 +74,6 @@ qemu-system-x86_64 \
   -no-reboot \
   -virtfs local,id=rootfs,path=/,security_model=none,mount_tag=/dev/root \
   -nic user,model=virtio-net-pci \
-  -append "loglevel=6 console=ttyS0 nandsim.id_bytes=0x20,0xa2,0x00,0x15 nandsim.parts=0x100, mtdram.total_size=32768 root=/dev/root rootfstype=9p rw init=$(pwd)/qemu-test-init rauc.slot=system0 $*"
+  -append "loglevel=6 console=ttyS0 nandsim.id_bytes=0x20,0xa2,0x00,0x15 nandsim.parts=0x100, mtdram.total_size=32768 root=/dev/root rootfstype=9p rw init=$(pwd)/qemu-test-init rauc.slot=$BOOTNAME $*"
 
 test -f qemu-test-ok

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -83,6 +83,8 @@ if [ -c /dev/mtd3 ] && type ubiattach; then
   export RAUC_TEST_MTD_UBIVOL=/dev/ubi0_0
 fi
 
+echo "use ctrl-a x to exit and ctrl-a c to access the qemu monitor"
+
 echo "system ready"
 
 if [ -n "$SHELL" ]; then

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -19,6 +19,9 @@ for x in $(cat /proc/cmdline); do
     MAKE_TARGET="check-code-coverage"
   elif [ "$x" = "distcheck" ]; then
     MAKE_TARGET="distcheck"
+  elif [ "$x" = "system" ]; then
+    SHELL=1
+    SERVICE=1
   fi
 done
 
@@ -50,6 +53,14 @@ grub-editenv test/grubenv.test create
 touch /tmp/boot/grub/grubenv
 mount --bind test/grubenv.test /tmp/boot/grub/grubenv
 
+grub-editenv /tmp/boot/grub/grubenv set ORDER="A B" A_TRY="0" B_TRY="0" A_OK="1" B_OK="1"
+
+# fake slot devices
+truncate --size=64M /tmp/rootdev
+mkfs.ext4 /tmp/rootdev
+truncate --size=64M /tmp/appdev
+mkfs.ext4 /tmp/appdev
+
 # dbus daemon
 cp -a /etc/dbus-1/system.d /tmp
 cp -a data/de.pengutronix.rauc.conf /tmp/system.d
@@ -59,6 +70,13 @@ mount --bind /tmp/system.d /etc/dbus-1/system.d
 mount -t tmpfs none /var/run
 mkdir -p /var/run/dbus
 time dbus-daemon --system --fork --nopidfile --nosyslog --print-address
+
+# rauc binary in PATH
+if [ -n "$SHELL" ]; then
+  mkdir /tmp/bin
+  cp -a rauc /tmp/bin/rauc
+  export PATH=/tmp/bin:$PATH
+fi
 
 if type losetup; then
   truncate --size=64M /tmp/rauc-disk.img
@@ -83,6 +101,14 @@ if [ -c /dev/mtd3 ] && type ubiattach; then
   export RAUC_TEST_MTD_UBIVOL=/dev/ubi0_0
 fi
 
+# rauc system config & service start
+if [ -n "$SERVICE" ]; then
+  mkdir /tmp/rauc
+  cp qemu-test-rauc-config /tmp/rauc/system.conf
+  cp test/openssl-ca/dev-ca.pem /tmp/rauc/ca.cert.pem
+  rauc service --conf=/tmp/rauc/system.conf &
+fi
+
 echo "use ctrl-a x to exit and ctrl-a c to access the qemu monitor"
 
 echo "system ready"
@@ -91,6 +117,10 @@ if [ -n "$SHELL" ]; then
   HISTFILE="$(pwd)/.qemu_bash_history" \
   setsid bash </dev/ttyS0 >/dev/ttyS0 2>&1 || echo exit-code=$?
   echo o > /proc/sysrq-trigger
+fi
+
+if [ -n "$SERVICE" ]; then
+  rauc status mark-good
 fi
 
 if make $MAKE_TARGET; then

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -61,7 +61,7 @@ mkdir -p /var/run/dbus
 time dbus-daemon --system --fork --nopidfile --nosyslog --print-address
 
 if type losetup; then
-  dd if=/dev/zero of=/tmp/rauc-disk.img bs=1M count=64
+  truncate --size=64M /tmp/rauc-disk.img
   losetup -P /dev/loop0 /tmp/rauc-disk.img
   export RAUC_TEST_BLOCK_LOOP=/dev/loop0
 fi

--- a/qemu-test-rauc-config
+++ b/qemu-test-rauc-config
@@ -1,0 +1,25 @@
+[system]
+compatible=Test Config
+bootloader=grub
+grubenv=/tmp/boot/grub/grubenv
+# HACK: must be on a separate partition for real systems
+statusfile=/tmp/rauc.status
+
+[keyring]
+path=ca.cert.pem
+
+[slot.rootfs.0]
+device=/dev/root
+bootname=A
+
+[slot.rootfs.1]
+device=/tmp/rootdev
+bootname=B
+
+[slot.appfs.0]
+device=/dev/null
+parent=rootfs.0
+
+[slot.appfs.1]
+device=/tmp/appdev
+parent=rootfs.1


### PR DESCRIPTION
This first adds some initial documentation about the general test infrastructure in RAUC and introduces then a new subcommand for `qemu-test` to allow booting into a mocked RAUC system for debugging and testing purposes.