### PR TITLE
src/main: limit --override-boot-slot argument to specific subcommands

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -36,6 +36,7 @@ gchar *signing_keyring = NULL;
 gchar *mksquashfs_args = NULL;
 gchar *casync_args = NULL;
 gchar *handler_args = NULL;
+gchar *bootslot = NULL;
 gboolean utf8_supported = FALSE;
 
 static gchar* make_progress_line(gint percentage)
@@ -1683,6 +1684,7 @@ static GOptionEntry entries_install[] = {
 	{"progress", '\0', 0, G_OPTION_ARG_NONE, &install_progressbar, "show progress bar", NULL},
 #else
 	{"handler-args", '\0', 0, G_OPTION_ARG_STRING, &handler_args, "extra handler arguments", "ARGS"},
+	{"override-boot-slot", '\0', 0, G_OPTION_ARG_STRING, &bootslot, "override auto-detection of booted slot", "BOOTNAME"},
 #endif
 	{0}
 };
@@ -1716,11 +1718,15 @@ static GOptionEntry entries_info[] = {
 static GOptionEntry entries_status[] = {
 	{"detailed", '\0', 0, G_OPTION_ARG_NONE, &status_detailed, "show more status details", NULL},
 	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format", "FORMAT"},
+#if ENABLE_SERVICE == 0
+	{"override-boot-slot", '\0', 0, G_OPTION_ARG_STRING, &bootslot, "override auto-detection of booted slot", "BOOTNAME"},
+#endif
 	{0}
 };
 
 static GOptionEntry entries_service[] = {
 	{"handler-args", '\0', 0, G_OPTION_ARG_STRING, &handler_args, "extra handler arguments", "ARGS"},
+	{"override-boot-slot", '\0', 0, G_OPTION_ARG_STRING, &bootslot, "override auto-detection of booted slot", "BOOTNAME"},
 	{0}
 };
 
@@ -1761,8 +1767,7 @@ static void create_option_groups(void)
 static void cmdline_handler(int argc, char **argv)
 {
 	gboolean help = FALSE, debug = FALSE, version = FALSE;
-	gchar *confpath = NULL, *certpath = NULL, *keypath = NULL, *keyring = NULL, **intermediate = NULL, *mount = NULL,
-	      *bootslot = NULL;
+	gchar *confpath = NULL, *certpath = NULL, *keypath = NULL, *keyring = NULL, **intermediate = NULL, *mount = NULL;
 	char *cmdarg = NULL;
 	g_autoptr(GOptionContext) context = NULL;
 	GOptionEntry entries[] = {
@@ -1772,7 +1777,6 @@ static void cmdline_handler(int argc, char **argv)
 		{"keyring", '\0', 0, G_OPTION_ARG_FILENAME, &keyring, "keyring file", "PEMFILE"},
 		{"intermediate", '\0', 0, G_OPTION_ARG_FILENAME_ARRAY, &intermediate, "intermediate CA file name", "PEMFILE"},
 		{"mount", '\0', 0, G_OPTION_ARG_FILENAME, &mount, "mount prefix", "PATH"},
-		{"override-boot-slot", '\0', 0, G_OPTION_ARG_STRING, &bootslot, "override auto-detection of booted slot", "BOOTNAME"},
 		{"debug", 'd', 0, G_OPTION_ARG_NONE, &debug, "enable debug output", NULL},
 		{"version", '\0', 0, G_OPTION_ARG_NONE, &version, "display version", NULL},
 		{"help", 'h', 0, G_OPTION_ARG_NONE, &help, NULL, NULL},

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -408,7 +408,6 @@ test_expect_success SERVICE,GRUB "rauc status mark-good: via D-Bus" "
   test_when_finished stop_rauc_dbus_service &&
   rauc \
     --conf=${SHARNESS_TEST_DIRECTORY}/test.conf \
-    --override-boot-slot=system1 \
     status mark-good
 "
 
@@ -419,7 +418,6 @@ test_expect_success SERVICE,GRUB "rauc status mark-bad: via D-Bus" "
   test_when_finished stop_rauc_dbus_service &&
   rauc \
     --conf=${SHARNESS_TEST_DIRECTORY}/test.conf \
-    --override-boot-slot=system1 \
     status mark-bad
 "
 
@@ -430,7 +428,6 @@ test_expect_success SERVICE,GRUB "rauc status mark-active: via D-Bus" "
   test_when_finished stop_rauc_dbus_service &&
   rauc \
     --conf=${SHARNESS_TEST_DIRECTORY}/test.conf \
-    --override-boot-slot=system1 \
     status mark-active
 "
 


### PR DESCRIPTION
For most commands, `--override-boot-slot` will not have any impact as this is only evaluated for the service (or 'install' command when RAUC is being compiled without 'service' support).

Fix this by moving the parameter from the global option list to the options list of 'service' (and 'install' / 'status').

Also fix the sharness tests that had this argument set without any effect.

Resolves #620