### PR TITLE
Replaced deprecated Install with InstallBundle method

### DIFF
--- a/contrib/cgi/README.rst
+++ b/contrib/cgi/README.rst
@@ -17,7 +17,7 @@ Features
   `signals <http://rauc.readthedocs.io/en/latest/reference.html#signal-details>`_
   and `properties <http://rauc.readthedocs.io/en/latest/reference.html#property-details>`_
 * **PUT /**: uploading a bundle and triggering RAUC to install it via RAUC's
-  `Install method <http://rauc.readthedocs.io/en/latest/reference.html#the-install-method>`_
+  `InstallBundle method <http://rauc.readthedocs.io/en/latest/reference.html#the-installbundle-method>`_
 
 Building from Sources
 ---------------------

--- a/contrib/cgi/src/cgi.c
+++ b/contrib/cgi/src/cgi.c
@@ -674,12 +674,13 @@ static gint cgi_handler(int argc, char **argv)
 			goto error;
 		}
 	} else if (g_strcmp0("PUT", method) == 0) {
+		g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
 		/* save stdin to temporary file */
 		if (!stdin_to_file(&error))
 			goto remove_bundle_on_error;
 
 		/* start rauc install */
-		if (!r_installer_call_install_sync(installer, BUNDLE_TARGET_LOCATION, NULL, &error))
+		if (!r_installer_call_install_bundle_sync(installer, BUNDLE_TARGET_LOCATION, g_variant_dict_end(&dict), NULL, &error))
 			goto remove_bundle_on_error;
 
 		print_headers("200 OK", "text/plain");


### PR DESCRIPTION
According to [this ](https://rauc.readthedocs.io/en/latest/reference.html#the-install-method) the used `Install` method in `cgi.c` has been deprecated. Therefor it was replaced by `InstallBundle`. Currently no arguments are passed to installation. If you have an idea how to pass them (custom header? query param?) I can integrate it as well.