### PR TITLE
feature: extract signatue: add option to extract signature from bundle

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -567,6 +567,25 @@ normal users on their development hosts.
 It this case, the same mechanism for ensuring exclusive access as with plain
 bundles is used.
 
+.. _sec_ref_external_signing:
+
+External Signing and PKI
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some industrialization procedures require signing artifacts in a dedicated
+secure room with restricted access (as Public Key Infrastructure aka PKI).
+
+For this case `rauc extract-signature` can extract the bundle signature.
+
+As a `verity` format bundle signature is a detached CMS, you can easily resign
+it externally.
+For the `plain` format bundle signature it's slightly different, as the
+signature is detached, it contains just the message digest.
+You can use `openssl asn1parse` for retrieving the message digest in the CMS.
+
+.. note::
+  The `asn1parse` method can also be used for the `verity` bundle
+
 .. _slot-status:
 
 Slot Status
@@ -644,15 +663,16 @@ Command Line Tool
     -h, --help
 
   List of rauc commands:
-    bundle        Create a bundle
-    resign        Resign an already signed bundle
-    convert       Convert classic to casync bundle
-    extract       Extract the bundle content
-    install       Install a bundle
-    info          Show file information
-    service       Start RAUC service
-    status        Show status
-    write-slot    Write image to slot and bypass all update logic
+    bundle                Create a bundle
+    resign                Resign an already signed bundle
+    convert               Convert classic to casync bundle
+    extract-signature     Extract the bundle signature
+    extract               Extract the bundle content
+    install               Install a bundle
+    info                  Show file information
+    service               Start RAUC service
+    status                Show status
+    write-slot            Write image to slot and bypass all update logic
 
   Environment variables:
     RAUC_PKCS11_MODULE  Library filename for PKCS#11 module (signing only)

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -104,6 +104,23 @@ gboolean resign_bundle(RaucBundle *bundle, const gchar *outpath, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Extract a bundle signature.
+ *
+ * This will extract the bundle signature into a given file.
+ *
+ * @param bundle RaucBundle struct as returned by check_bundle()
+ * @param outputsig file to extract signature
+ * @param error Return location for a GError
+ *
+ * Note that check_bundle() must be called prior to this, to obtain a
+ * RaucBundle struct.
+ *
+ * @return TRUE on success, FALSE if an error occurred
+ */
+gboolean extract_signature(RaucBundle *bundle, const gchar *outputsig, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
  * Extract a bundle.
  *
  * This will extract the entire bundle content into a given directory.

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1625,6 +1625,43 @@ out:
 	return res;
 }
 
+gboolean extract_signature(RaucBundle *bundle, const gchar *outputsig, GError **error)
+{
+	GError *ierror = NULL;
+	g_autoptr(GFile) sigfile = NULL;
+	g_autoptr(GOutputStream) sigoutstream = NULL;
+	gboolean res = FALSE;
+
+	g_return_val_if_fail(bundle != NULL, FALSE);
+	g_return_val_if_fail(outputsig != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	r_context_begin_step("extract_signature", "Extracting bundle signature", 0);
+
+	sigfile = g_file_new_for_path(outputsig);
+	sigoutstream = (GOutputStream*)g_file_create(sigfile, G_FILE_CREATE_PRIVATE, NULL, &ierror);
+	if (sigoutstream == NULL) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed to create file to store signature: ");
+		goto out;
+	}
+
+	if (!output_stream_write_bytes_all(sigoutstream, bundle->sigdata, NULL, &ierror)) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed to write signature to file: ");
+		goto out;
+	}
+
+	res = TRUE;
+out:
+	r_context_end_step("extract_signature", res);
+	return res;
+}
+
 gboolean extract_bundle(RaucBundle *bundle, const gchar *outputdir, GError **error)
 {
 	GError *ierror = NULL;

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -259,6 +259,29 @@ static void bundle_test_extract_manifest(BundleFixture *fixture,
 	g_clear_pointer(&filepath, g_free);
 }
 
+static void bundle_test_extract_signature(BundleFixture *fixture,
+		gconstpointer user_data)
+{
+	g_autofree gchar *outputsig = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
+	gboolean res = FALSE;
+
+	outputsig = g_build_filename(fixture->tmpdir, "bundle.sig", NULL);
+	g_assert_nonnull(outputsig);
+
+	res = check_bundle(fixture->bundlename, &bundle, TRUE, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_nonnull(bundle);
+
+	res = extract_signature(bundle, outputsig, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+
+	g_assert_true(g_file_test(outputsig, G_FILE_TEST_IS_REGULAR));
+	g_clear_pointer(&outputsig, g_free);
+}
 
 static void assert_casync_manifest(RaucManifest *rm)
 {
@@ -621,6 +644,11 @@ int main(int argc, char *argv[])
 		g_test_add(g_strdup_printf("/bundle/create_mount_extract/%s", format_name),
 				BundleFixture, bundle_data,
 				bundle_fixture_set_up_bundle, bundle_test_create_mount_extract,
+				bundle_fixture_tear_down);
+
+		g_test_add(g_strdup_printf("/bundle/extract_signature/%s", format_name),
+				BundleFixture, bundle_data,
+				bundle_fixture_set_up_bundle, bundle_test_extract_signature,
 				bundle_fixture_tear_down);
 
 		g_test_add(g_strdup_printf("/bundle/extract_manifest/%s", format_name),

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -533,6 +533,17 @@ test_expect_success FAKETIME "rauc sign bundle with valid certificate" "
 "
 
 
+test_expect_success "rauc extract signature" "
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&
+  rauc \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+    extract-signature ${TEST_TMPDIR}/good-bundle.raucb $TEST_TMPDIR/bundle.sig &&
+  test -f $TEST_TMPDIR/bundle.sig &&
+  openssl asn1parse -inform DER -in $TEST_TMPDIR/bundle.sig -noout > /dev/null 2>&1 && \
+  rm -rf $TEST_TMPDIR/bundle.sig
+"
+
 test_expect_success "rauc extract" "
   cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
   test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&


### PR DESCRIPTION
Many industrialization procedure requires to sign any artifact in a
dedicated secure room with restricted access
(as Public Key Infrastructure aka PKI).

This purpose add a `extract-signature` command to extract the signature
and allow resigning the signature content externally.

Signed-off-by: Jean-Pierre Geslin <jarsop@outlook.com>