### PR TITLE
src/bootchooser: handle external dtb also in barebox_state_set()

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -172,6 +172,10 @@ static gboolean barebox_state_set(GPtrArray *pairs, GError **error)
 		g_ptr_array_add(args, g_strdup("-s"));
 		g_ptr_array_add(args, g_strdup(pairs->pdata[i]));
 	}
+	if (r_context()->config->system_bb_dtbpath) {
+		g_ptr_array_add(args, g_strdup("-i"));
+		g_ptr_array_add(args, g_strdup(r_context()->config->system_bb_dtbpath));
+	}
 	g_ptr_array_add(args, NULL);
 
 	sub = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);


### PR DESCRIPTION
While `barebox_state_get()` allows passing -i argument to barebox-state when 'barebox-dtbpath' is set, `barebox_state_set()` ignored this. This prevents the feature from being useful.

Fixes commit 9e13bdd5 ("src: allow passing separate devicetree file to barebox-state").

Fixes #720