### PR TITLE
add HTTP streaming support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,10 @@ Release 1.7 (development)
 
 .. rubric:: Enhancements
 
+* Add support for streaming installation from a HTTP(S) server for verity
+  bundles.
+  This avoids the need for a temporary bundle storage location and prepares for
+  more efficient incremental updates.
 
 .. rubric:: Bug fixes
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,7 @@ CODE_COVERAGE_IGNORE_PATTERN = "*-generated.c"
 
 GC_CFLAGS = -fdata-sections -ffunction-sections
 GC_LDFLAGS = -Wl,--gc-sections -Wl,-Map,$@.map
-AM_CFLAGS = -DG_LOG_DOMAIN=\"rauc\" $(GC_CFLAGS) $(WARN_CFLAGS) $(GLIB_CFLAGS) $(CURL_CFLAGS)
+AM_CFLAGS = -DG_LOG_DOMAIN=\"rauc\" $(GC_CFLAGS) $(WARN_CFLAGS) $(GLIB_CFLAGS) $(CURL_CFLAGS) $(NL3_CFLAGS)
 AM_LDFLAGS = $(GC_LDFLAGS) $(WARN_LDFLAGS) $(GLIB_LDFLAGS) $(CURL_LDFLAGS) $(OPENSSL_LDFLAGS)
 AM_CPPFLAGS = -I${top_srcdir}/include -include ${top_builddir}/config.h $(OPENSSL_INCLUDES)
 
@@ -90,7 +90,7 @@ nodist_librauc_la_SOURCES = \
 	$(gdbus_installer_generated)
 librauc_la_CFLAGS = $(AM_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 librauc_la_LDFLAGS = $(AM_LDFLAGS) $(CODE_COVERAGE_LDFLAGS)
-librauc_la_LIBADD = $(GLIB_LIBS) $(CURL_LIBS) $(OPENSSL_LIBS) $(FDISK_LIBS)
+librauc_la_LIBADD = $(GLIB_LIBS) $(CURL_LIBS) $(OPENSSL_LIBS) $(FDISK_LIBS) $(NL3_LIBS)
 
 bin_PROGRAMS = rauc
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -86,6 +86,10 @@ if WANT_GPT
 librauc_la_SOURCES += src/gpt.c
 endif
 
+if ENABLE_STREAMING
+librauc_la_SOURCES += src/nbd.c include/nbd.h src/stats.c include/stats.h
+endif
+
 nodist_librauc_la_SOURCES = \
 	$(gdbus_installer_generated)
 librauc_la_CFLAGS = $(AM_CFLAGS) $(CODE_COVERAGE_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -164,6 +164,10 @@ if WANT_NETWORK
 check_PROGRAMS += test/network.test
 endif
 
+if ENABLE_STREAMING
+check_PROGRAMS += test/nbd.test
+endif
+
 if WANT_JSON
 check_PROGRAMS += test/boot_switch.test
 endif
@@ -234,6 +238,9 @@ test_dm_test_LDADD = librauctest.la
 
 test_manifest_test_SOURCES = test/manifest.c
 test_manifest_test_LDADD = librauctest.la
+
+test_nbd_test_SOURCES = test/nbd.c
+test_nbd_test_LDADD = librauctest.la
 
 test_service_test_CFLAGS = $(AM_CFLAGS) -DTEST_SERVICES=\""$(abs_top_builddir)"\"
 test_service_test_SOURCES = test/service.c rauc-installer-generated.h

--- a/configure.ac
+++ b/configure.ac
@@ -116,6 +116,12 @@ AS_IF([test "x$enable_streaming" = "xyes"], [
         enable_streaming=no
 ])
 
+AC_ARG_WITH([streaming_user],
+        AS_HELP_STRING([--with-streaming-user=USERNAME], [unpriviledged user for the streaming subprocess]),
+        [],
+        [with_streaming_user=nobody])
+AC_DEFINE_UNQUOTED([STREAMING_USER], ["$with_streaming_user"], [Set the unpriviledged user for the streaming subprocess])
+
 AC_ARG_ENABLE([json],
         AS_HELP_STRING([--disable-json], [Disable JSON support])
 )

--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,34 @@ AS_IF([test "x$enable_network" = "xyes"], [
         enable_network=no
 ])
 
+AC_ARG_ENABLE([streaming],
+        AS_HELP_STRING([--disable-streaming], [Disable streaming update mode])
+)
+AS_IF([test "x$enable_streaming" != "xno"], [
+        AS_IF([test "x$enable_streaming" = "xyes" -a "x$enable_network" != "xyes"], [
+                AC_MSG_ERROR([streaming support requested but network support not enabled])
+        ])
+        PKG_CHECK_MODULES([NL3], [libnl-genl-3.0 >= 3.1], [have_nl3=yes], [
+                AS_IF([test "x$enable_streaming" = "xyes"], [
+                        AC_MSG_ERROR([streaming support requested but libnl-genl not found])
+                ])
+        ])
+        AC_CHECK_HEADERS([linux/nbd-netlink.h], [have_nbd=yes], [
+                AS_IF([test "x$enable_streaming" = "xyes"], [
+                        AC_MSG_ERROR([streaming support requested but linux/nbd-netlink.h not found])
+                ])
+        ])
+        AS_IF([test "x$enable_network" = "xyes" -a "x$have_nl3" = "xyes" -a "x$have_nbd" = "xyes"], [
+                enable_streaming=yes
+        ])
+])
+AM_CONDITIONAL([ENABLE_STREAMING], [test "x$enable_streaming" = "xyes"])
+AS_IF([test "x$enable_streaming" = "xyes"], [
+        AC_DEFINE([ENABLE_STREAMING], [1], [Define to 1 to enable building with streaming update support])
+], [
+        AC_DEFINE([ENABLE_STREAMING], [0])
+        enable_streaming=no
+])
 
 AC_ARG_ENABLE([json],
         AS_HELP_STRING([--disable-json], [Disable JSON support])
@@ -221,3 +249,9 @@ AC_CONFIG_FILES([
         Makefile
 ])
 AC_OUTPUT
+AC_MSG_RESULT([
+        $PACKAGE_NAME $PACKAGE_VERSION
+
+        network:                ${enable_network}
+        streaming:              ${enable_streaming}
+])

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -216,3 +216,21 @@ unusable.
 For most cases it might be desired to either select one of the redundant slots
 as fallback or boot into a recovery system.
 This handling is up to your bootloader.
+
+HTTP Streaming
+--------------
+
+Since RAUC 1.6, bundles can be installed directly from a HTTP(S) server,
+without having to download and store the bundle locally.
+Simply use the bundle URL as the ``rauc install`` argument instead of a local
+file.
+
+Using streaming has a few requirements:
+
+* configure RAUC with ``--enable-streaming``
+* create bundles using the :ref:`verity format <sec_ref_format_verity>`
+* host the bundle on a server which supports HTTP Range Requests
+* enable NBD support in the kernel
+
+See the :ref:`HTTP Streaming <http-streaming>` section in the Advanced chapter
+for more details.

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -193,6 +193,8 @@ In kernel Kconfig you have to enable the following options:
   CONFIG_SQUASHFS=y
   CONFIG_CRYPTO_SHA256=y
 
+For streaming support, you have to add `CONFIG_BLK_DEV_NBD`.
+
 .. note::
    These drivers may also be loaded as modules. Kernel versions v5.0 to v5.7
    will require the patch ``7e81f99afd91c937f0e66dc135e26c1c4f78b003``

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -221,10 +221,37 @@ signature.
 
 .. _verify: https://www.openssl.org/docs/man1.1.1/man1/verify.html
 
+.. _streaming-config-section:
+
+**[streaming] section**
+
+The ``streaming`` section contains streaming-related settings.
+For more information about using the streaming support of RAUC, refer to
+:ref:`http-streaming`.
+
+``sandbox-user``
+  This option can be used to set the user name which is used to run the
+  streaming helper process.
+  By default, the `nobody` user is used.
+  At compile time, the default can be defined using the
+  ``--with-streaming-user=USERNAME`` configure option.
+
+``tls-cert``
+  This option can be used to set the path or PKCS#11 URL for the TLS/HTTPS
+  client certificate.
+
+``tls-key``
+  This option can be used to set the path or PKCS#11 URL for the TLS/HTTPS
+  client private key.
+
+``tls-ca``
+  This option can be used to set the path of the CA certificate which should be
+  used instead of the system wide store of trusted TLS/HTTPS certificates.
+
 **[casync] section**
 
 The ``casync`` section contains casync-related settings.
-For more information about using casync support of RAUC, refer to
+For more information about using the casync support of RAUC, refer to
 :ref:`casync-support`.
 
 ``storepath``
@@ -1054,6 +1081,22 @@ IN a{sv} *args*:
     :STRING 'ignore-compatible', VARIANT 'b' <true/false>: Ignore the default compatible check for forcing
         installation of bundles on platforms that a compatible not matching the one
         of the bundle to be installed
+
+    :STRING 'tls-cert', VARIANT 's' <filename/pkcs11-url>: Use the provided
+        certificate for TLS client authentication
+
+    :STRING 'tls-key', VARIANT 's' <filename/pkcs11-url>: Use the provided
+        private key for TLS client authentication
+
+    :STRING 'tls-ca', VARIANT 's' <filename/pkcs11-url>: Use the provided
+        certificate to authenticate the server (instead of the system wide
+        store)
+
+    :STRING 'http-headers', VARIANT 'as' <array of strings>: Add the provided
+        headers to every request (i.e. for bearer tokens)
+
+    :STRING 'tls-no-verify', VARIANT 'b' <true/false>: Ignore verification
+        errors for the server certificate
 
 .. _gdbus-method-de-pengutronix-rauc-Installer.Install:
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -720,6 +720,15 @@ Example invocation:
 
   G_MESSAGES_DEBUG="rauc rauc-subprocess" rauc service
 
+Enabling Verbose CURL Output
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you suspect an issue is related to network access (using the CURL library),
+you can set ``RAUC_CURL_VERBOSE=1``.
+This will cause RAUC to enable `CURLOPT_VERBOSE
+<https://curl.se/libcurl/c/CURLOPT_VERBOSE.html>`_ when configuring a CURL
+context.
+
 Reproducing Issues using QEMU Test Setup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -20,6 +20,14 @@ typedef enum {
 } RBundleError;
 
 typedef struct {
+	gchar *tls_cert;
+	gchar *tls_key;
+	gchar *tls_ca;
+	gboolean tls_no_verify;
+	GStrv http_headers;
+} RaucBundleAccessArgs;
+
+typedef struct {
 	gchar *path;
 	gchar *origpath;
 	gchar *storepath;
@@ -76,11 +84,12 @@ G_GNUC_WARN_UNUSED_RESULT;
  *               This will contain all bundle information obtained by
  *               check_bundle
  * @param params bit-field enum CheckBundleParams with additional flags for the check
+ * @param access_args Optional arguments to control streaming access
  * @param error Return location for a GError
  *
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleParams params, GError **error)
+gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleParams params, RaucBundleAccessArgs *access_args, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
@@ -238,3 +247,11 @@ gboolean umount_bundle(RaucBundle *bundle, GError **error);
 void free_bundle(RaucBundle *bundle);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucBundle, free_bundle);
+
+/**
+ * Frees the memory pointed to by the RaucBundleAccessArgs, but not the
+ * structure itself.
+ *
+ * @param access_args RaucBundleAccessArgs to clear
+ */
+void clear_bundle_access_args(RaucBundleAccessArgs *access_args);

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -5,6 +5,7 @@
 #include <gio/gio.h>
 
 #include "manifest.h"
+#include "nbd.h"
 #include "utils.h"
 
 #define R_BUNDLE_ERROR r_bundle_error_quark()
@@ -31,7 +32,12 @@ typedef struct {
 	gchar *path;
 	gchar *origpath;
 	gchar *storepath;
+
+	RaucNBDDevice *nbd_dev;
+	RaucNBDServer *nbd_srv;
+
 	GInputStream *stream;
+
 	goffset size;
 	GBytes *sigdata;
 	gchar *mount_point;

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -66,6 +66,12 @@ typedef struct {
 
 	gchar *systeminfo_handler;
 
+	/* streaming */
+	gchar *streaming_sandbox_user;
+	gchar *streaming_tls_cert;
+	gchar *streaming_tls_key;
+	gchar *streaming_tls_ca;
+
 	GHashTable *slots;
 } RaucConfig;
 

--- a/include/install.h
+++ b/include/install.h
@@ -2,6 +2,7 @@
 
 #include <glib.h>
 
+#include "bundle.h"
 #include "manifest.h"
 
 #define R_INSTALL_ERROR r_install_error_quark()
@@ -31,6 +32,7 @@ typedef struct {
 	gint status_result;
 	/* install options */
 	gboolean ignore_compatible;
+	RaucBundleAccessArgs access_args;
 } RaucInstallArgs;
 
 /**

--- a/include/nbd.h
+++ b/include/nbd.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <glib.h>
+#include <gio/gio.h>
+
+/* FD used to pass the open NBD socket to the server process */
+#define RAUC_SOCKET_FD 3
+
+#define R_NBD_ERROR r_nbd_error_quark()
+GQuark r_nbd_error_quark(void);
+
+typedef enum {
+	R_NBD_ERROR_CONFIGURATION,
+	R_NBD_ERROR_STARTUP,
+	R_NBD_ERROR_READ,
+	R_NBD_ERROR_UNAUTHORIZED,
+	R_NBD_ERROR_NOT_FOUND,
+	R_NBD_ERROR_SHUTDOWN,
+} RNBDError;
+
+typedef struct {
+	gint sock;
+	guint32 index;
+	gboolean index_valid;
+	gchar *dev;
+	guint64 data_size;
+} RaucNBDDevice;
+
+typedef struct {
+	gint sock; /* client side socket */
+	GSubprocess *sproc;
+
+	/* configuration */
+	gchar *url;
+	gchar *tls_cert; /* local file or PKCS#11 URI */
+	gchar *tls_key; /* local file or PKCS#11 URI */
+	gchar *tls_ca; /* local file */
+	gboolean tls_no_verify;
+	GStrv headers; /* array of strings such as 'Foo: bar' */
+
+	/* discovered information */
+	guint64 data_size; /* bundle size */
+	gchar *effective_url; /* url after redirects */
+	guint64 current_time; /* date header from server */
+	guint64 modified_time; /* last-modified header from server */
+} RaucNBDServer;
+
+RaucNBDDevice *r_nbd_new_device(void);
+void r_nbd_free_device(RaucNBDDevice *nbd_dev);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucNBDDevice, r_nbd_free_device);
+
+RaucNBDServer *r_nbd_new_server(void);
+void r_nbd_free_server(RaucNBDServer *nbd_srv);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucNBDServer, r_nbd_free_server);
+
+/**
+ * Configure a NBD device in the kernel using the provided parameters and
+ * return the resulting device name in the struct.
+ *
+ * @param nbd struct with configuration
+ * @param error Return location for a GError
+ *
+ * @return TRUE on success, FALSE if an error occurred
+ */
+gboolean r_nbd_setup_device(RaucNBDDevice *nbd_dev, GError **error);
+
+/**
+ * Remove a previously configured NBD device from the kernel.
+ *
+ * @param nbd struct with configuration
+ * @param error Return location for a GError
+ *
+ * @return TRUE on success, FALSE if an error occurred
+ */
+gboolean r_nbd_remove_device(RaucNBDDevice *nbd_dev, GError **error);
+
+gboolean r_nbd_run_server(gint sock, GError **error);
+
+gboolean r_nbd_start_server(RaucNBDServer *nbd_srv, GError **error);
+gboolean r_nbd_stop_server(RaucNBDServer *nbd_srv, GError **error);
+
+gboolean r_nbd_read(gint sock, guint8 *data, size_t size, off64_t offset, GError **error);

--- a/include/stats.h
+++ b/include/stats.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <glib.h>
+
+struct RaucStats {
+	gdouble values[64];
+	guint64 count, next;
+	gdouble sum;
+	gdouble min, max;
+};
+
+void r_stats_init(struct RaucStats *stats);
+
+void r_stats_add(struct RaucStats *stats, gdouble value);
+
+gdouble r_stats_get_avg(const struct RaucStats *stats);
+
+gdouble r_stats_get_recent_avg(const struct RaucStats *stats);
+
+void r_stats_show(const struct RaucStats *stats, const gchar *prefix);

--- a/include/utils.h
+++ b/include/utils.h
@@ -191,3 +191,8 @@ guint8 *r_hex_decode(const gchar *hex, size_t len)
 G_GNUC_WARN_UNUSED_RESULT;
 gchar *r_hex_encode(const guint8 *raw, size_t len)
 G_GNUC_WARN_UNUSED_RESULT;
+
+gboolean r_read_exact(const int fd, guint8 *data, size_t size, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+gboolean r_write_exact(const int fd, const guint8 *data, size_t size, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;

--- a/include/utils.h
+++ b/include/utils.h
@@ -5,6 +5,18 @@
 
 #define BIT(nr) (1UL << (nr))
 
+/* Evaluate EXPRESSION, and repeat as long as it returns -1 with `errno'
+ * set to EINTR. Needed for builds against musl, taken from glibc's unistd.h.
+ */
+#ifndef TEMP_FAILURE_RETRY
+#define TEMP_FAILURE_RETRY(expression) \
+	(__extension__ \
+		 ({ long int __result; \
+		    do {__result = (long int) (expression);} \
+		    while (__result == -1L && errno == EINTR); \
+		    __result; }))
+#endif
+
 /* Use
  *
  *   g_auto(filedesc) fd = -1

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -79,6 +79,7 @@ if [ -n "$SHELL" ]; then
   cp -a rauc /tmp/bin/rauc
   export PATH=/tmp/bin:$PATH
 fi
+export RAUC_TEST_NBD_SERVER="$(realpath rauc)"
 
 if type losetup; then
   truncate --size=64M /tmp/rauc-disk.img

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1390,7 +1390,7 @@ out:
 	return res;
 }
 
-gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleParams params, GError **error)
+gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleParams params, RaucBundleAccessArgs *access_args, GError **error)
 {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
@@ -1771,7 +1771,7 @@ gboolean replace_signature(RaucBundle *bundle, const gchar *insig, const gchar *
 		params |= CHECK_BUNDLE_NO_VERIFY;
 	}
 
-	res = check_bundle(outpath, &outbundle, params, &ierror);
+	res = check_bundle(outpath, &outbundle, params, NULL, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
@@ -2100,4 +2100,14 @@ void free_bundle(RaucBundle *bundle)
 	if (bundle->verified_chain)
 		sk_X509_pop_free(bundle->verified_chain, X509_free);
 	g_free(bundle);
+}
+
+void clear_bundle_access_args(RaucBundleAccessArgs *access_args)
+{
+	g_free(access_args->tls_cert);
+	g_free(access_args->tls_key);
+	g_free(access_args->tls_ca);
+	g_strfreev(access_args->http_headers);
+
+	memset(access_args, 0, sizeof(*access_args));
 }

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -452,6 +452,18 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	}
 	g_key_file_remove_group(key_file, "casync", NULL);
 
+	/* parse [streaming] section */
+	c->streaming_sandbox_user = key_file_consume_string(key_file, "streaming", "sandbox-user", NULL);
+	c->streaming_tls_cert = key_file_consume_string(key_file, "streaming", "tls-cert", NULL);
+	c->streaming_tls_key = key_file_consume_string(key_file, "streaming", "tls-key", NULL);
+	c->streaming_tls_ca = key_file_consume_string(key_file, "streaming", "tls-ca", NULL);
+	if (!check_remaining_keys(key_file, "streaming", &ierror)) {
+		g_propagate_error(error, ierror);
+		res = FALSE;
+		goto free;
+	}
+	g_key_file_remove_group(key_file, "streaming", NULL);
+
 	/* parse [autoinstall] section */
 	c->autoinstall_path = resolve_path(filename,
 			key_file_consume_string(key_file, "autoinstall", "path", NULL));
@@ -775,6 +787,10 @@ void free_config(RaucConfig *config)
 	g_free(config->systeminfo_handler);
 	g_free(config->preinstall_handler);
 	g_free(config->postinstall_handler);
+	g_free(config->streaming_sandbox_user);
+	g_free(config->streaming_tls_cert);
+	g_free(config->streaming_tls_key);
+	g_free(config->streaming_tls_ca);
 	g_clear_pointer(&config->slots, g_hash_table_destroy);
 	g_free(config);
 }

--- a/src/install.c
+++ b/src/install.c
@@ -1073,7 +1073,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	// TODO: mount info in context ?
 	install_args_update(args, "Checking and mounting bundle...");
 
-	res = check_bundle(bundlefile, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
+	res = check_bundle(bundlefile, &bundle, CHECK_BUNDLE_DEFAULT, &args->access_args, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;
@@ -1202,6 +1202,7 @@ void install_args_free(RaucInstallArgs *args)
 	g_mutex_clear(&args->status_mutex);
 	g_assert_cmpint(args->status_result, >=, 0);
 	g_assert_true(g_queue_is_empty(&args->status_messages));
+	clear_bundle_access_args(&args->access_args);
 	g_free(args);
 }
 

--- a/src/install.c
+++ b/src/install.c
@@ -1073,7 +1073,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	// TODO: mount info in context ?
 	install_args_update(args, "Checking and mounting bundle...");
 
-	res = check_bundle(bundlefile, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(bundlefile, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;

--- a/src/main.c
+++ b/src/main.c
@@ -503,7 +503,7 @@ static gboolean resign_start(int argc, char **argv)
 	if (no_check_time)
 		check_bundle_params |= CHECK_BUNDLE_NO_CHECK_TIME;
 
-	if (!check_bundle(argv[2], &bundle, check_bundle_params, &ierror)) {
+	if (!check_bundle(argv[2], &bundle, check_bundle_params, NULL, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -561,7 +561,7 @@ static gboolean replace_signature_start(int argc, char **argv)
 	if (trust_environment)
 		check_bundle_params |= CHECK_BUNDLE_TRUST_ENV;
 
-	if (!check_bundle(argv[2], &bundle, check_bundle_params, &ierror)) {
+	if (!check_bundle(argv[2], &bundle, check_bundle_params, NULL, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -606,7 +606,7 @@ static gboolean extract_signature_start(int argc, char **argv)
 	g_debug("input bundle: %s", argv[2]);
 	g_debug("output file: %s", argv[3]);
 
-	if (!check_bundle(argv[2], &bundle, CHECK_BUNDLE_DEFAULT, &ierror)) {
+	if (!check_bundle(argv[2], &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -651,7 +651,7 @@ static gboolean extract_start(int argc, char **argv)
 	g_debug("input bundle: %s", argv[2]);
 	g_debug("output dir: %s", argv[3]);
 
-	if (!check_bundle(argv[2], &bundle, CHECK_BUNDLE_DEFAULT, &ierror)) {
+	if (!check_bundle(argv[2], &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -710,7 +710,7 @@ static gboolean convert_start(int argc, char **argv)
 	if (trust_environment)
 		check_bundle_params |= CHECK_BUNDLE_TRUST_ENV;
 
-	if (!check_bundle(argv[2], &bundle, check_bundle_params, &ierror)) {
+	if (!check_bundle(argv[2], &bundle, check_bundle_params, NULL, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -1017,7 +1017,7 @@ static gboolean info_start(int argc, char **argv)
 	if (no_check_time)
 		check_bundle_params |= CHECK_BUNDLE_NO_CHECK_TIME;
 
-	res = check_bundle(bundlelocation, &bundle, check_bundle_params, &error);
+	res = check_bundle(bundlelocation, &bundle, check_bundle_params, NULL, &error);
 	if (!res) {
 		g_printerr("%s\n", error->message);
 		g_clear_error(&error);
@@ -1791,7 +1791,7 @@ static gboolean mount_start(int argc, char **argv)
 		goto out; /* an error message was already printed by resolve_bundle_path */
 	g_debug("input bundle: %s", bundlelocation);
 
-	res = check_bundle(bundlelocation, &bundle, CHECK_BUNDLE_DEFAULT, &error);
+	res = check_bundle(bundlelocation, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &error);
 	if (!res) {
 		g_printerr("%s\n", error->message);
 		g_clear_error(&error);

--- a/src/main.c
+++ b/src/main.c
@@ -40,6 +40,7 @@ gchar *casync_args = NULL;
 gchar *handler_args = NULL;
 gchar *bootslot = NULL;
 gboolean utf8_supported = FALSE;
+RaucBundleAccessArgs access_args = {0};
 
 static gchar* make_progress_line(gint percentage)
 {
@@ -1919,6 +1920,15 @@ static GOptionEntry entries_service[] = {
 	{0}
 };
 
+static GOptionEntry entries_bundle_access[] = {
+	{"tls-cert", '\0', 0, G_OPTION_ARG_STRING, &access_args.tls_cert, "TLS client certificate file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
+	{"tls-key", '\0', 0, G_OPTION_ARG_STRING, &access_args.tls_key, "TLS client key file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
+	{"tls-ca", '\0', 0, G_OPTION_ARG_FILENAME, &access_args.tls_ca, "TLS CA file", "PEMFILE"},
+	{"tls-no-verify", '\0', 0, G_OPTION_ARG_NONE, &access_args.tls_no_verify, "do not verify TLS server certificate", NULL},
+	{"http-header", 'H', 0, G_OPTION_ARG_STRING_ARRAY, &access_args.http_headers, "HTTP request header (multiple uses supported)", "'HEADER: VALUE'"},
+	{0}
+};
+
 static GOptionGroup *install_group;
 static GOptionGroup *bundle_group;
 static GOptionGroup *resign_group;
@@ -1932,6 +1942,8 @@ static void create_option_groups(void)
 {
 	install_group = g_option_group_new("install", "Install options:", "help dummy", NULL, NULL);
 	g_option_group_add_entries(install_group, entries_install);
+	if (ENABLE_STREAMING)
+		g_option_group_add_entries(install_group, entries_bundle_access);
 
 	if (ENABLE_CREATE) {
 		bundle_group  = g_option_group_new("bundle", "Bundle options:", "help dummy", NULL, NULL);
@@ -1949,6 +1961,8 @@ static void create_option_groups(void)
 
 	info_group    = g_option_group_new("info", "Info options:", "help dummy", NULL, NULL);
 	g_option_group_add_entries(info_group, entries_info);
+	if (ENABLE_STREAMING)
+		g_option_group_add_entries(info_group, entries_bundle_access);
 
 	status_group  = g_option_group_new("status", "Status options:", "help dummy", NULL, NULL);
 	g_option_group_add_entries(status_group, entries_status);

--- a/src/nbd.c
+++ b/src/nbd.c
@@ -1,0 +1,1247 @@
+#undef G_LOG_DOMAIN
+#define G_LOG_DOMAIN "rauc-nbd"
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <pwd.h>
+#include <sys/ioctl.h>
+#include <sys/prctl.h>
+#include <sys/sysmacros.h>
+
+#include <glib.h>
+#include <gio/gio.h>
+#include <glib/gstdio.h>
+
+#include <linux/nbd-netlink.h>
+#include <linux/nbd.h>
+
+#include <netlink/netlink.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+
+#include <curl/curl.h>
+
+#include "context.h"
+#include "nbd.h"
+#include "stats.h"
+#include "utils.h"
+
+/* these are only used before passing the socket to the kernel */
+#define RAUC_NBD_CMD_CONFIGURE 0x1000
+#define RAUC_NBD_HANDLE "\x89\xce\x48\x24\x0c\xe4\x82\xce"
+
+GQuark
+r_nbd_error_quark(void)
+{
+	return g_quark_from_static_string("r-nbd-error-quark");
+}
+
+RaucNBDDevice *r_nbd_new_device(void)
+{
+	RaucNBDDevice *nbd_dev = g_malloc0(sizeof(RaucNBDDevice));
+
+	nbd_dev->sock = -1;
+
+	return nbd_dev;
+}
+
+void r_nbd_free_device(RaucNBDDevice *nbd_dev)
+{
+	g_return_if_fail(nbd_dev);
+
+	if (nbd_dev->index_valid) {
+		g_autoptr(GError) ierror = NULL;
+		if (!r_nbd_remove_device(nbd_dev, &ierror)) {
+			g_message("failed to remove ndb device: %s", ierror->message);
+		}
+	}
+
+	g_free(nbd_dev);
+}
+
+RaucNBDServer *r_nbd_new_server(void)
+{
+	RaucNBDServer *nbd_srv = g_malloc0(sizeof(RaucNBDServer));
+
+	nbd_srv->sock = -1;
+
+	return nbd_srv;
+}
+
+void r_nbd_free_server(RaucNBDServer *nbd_srv)
+{
+	g_return_if_fail(nbd_srv);
+
+	if (nbd_srv->sproc) {
+		g_autoptr(GError) ierror = NULL;
+		if (!r_nbd_stop_server(nbd_srv, &ierror)) {
+			g_message("failed to stop ndb server: %s", ierror->message);
+		}
+	}
+
+	g_free(nbd_srv->url);
+	g_free(nbd_srv->tls_cert);
+	g_free(nbd_srv->tls_key);
+	g_free(nbd_srv->tls_ca);
+	g_strfreev(nbd_srv->headers);
+	g_free(nbd_srv);
+}
+
+static int netlink_connect_cb(struct nl_msg *msg, void *arg)
+{
+	struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+	RaucNBDDevice *nbd_dev = arg;
+	struct nlattr *msg_attr[NBD_ATTR_MAX + 1];
+	int ret;
+
+	ret = nla_parse(msg_attr, NBD_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0), NULL);
+	if (ret)
+		g_error("invalid response from the kernel");
+	if (!msg_attr[NBD_ATTR_INDEX])
+		g_error("did not receive index from the kernel");
+	nbd_dev->index = nla_get_u32(msg_attr[NBD_ATTR_INDEX]);
+	nbd_dev->index_valid = TRUE;
+
+	return NL_OK;
+}
+
+static struct nl_sock *netlink_connect(int *driver_id, GError **error)
+{
+	struct nl_sock *nl = nl_socket_alloc();
+	int err;
+
+	if (!nl) {
+		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "failed to allocate netlink socket");
+		goto out;
+	}
+
+	err = genl_connect(nl);
+	if (err) {
+		nl_socket_free(nl);
+		nl = NULL;
+		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "failed to connect netlink socket: %s", nl_geterror(err));
+		goto out;
+	}
+
+	*driver_id = genl_ctrl_resolve(nl, "nbd");
+	if (*driver_id < 0) {
+		nl_close(nl);
+		nl_socket_free(nl);
+		nl = NULL;
+		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "failed to resolve 'nbd' netlink family - BLK_DEV_NBD not enabled in kernel?");
+		goto out;
+	}
+
+out:
+	return nl;
+}
+
+gboolean r_nbd_setup_device(RaucNBDDevice *nbd_dev, GError **error)
+{
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+	int driver_id;
+	struct nl_sock *nl = NULL;
+	struct nl_msg *msg = NULL;
+	struct nlattr *attr_sockets = NULL;
+	struct nlattr *attr_item = NULL;
+
+	g_return_val_if_fail(nbd_dev != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	g_assert(nbd_dev->data_size % 4096 == 0);
+
+	g_message("configuring nbd device");
+
+	nl = netlink_connect(&driver_id, &ierror);
+	if (!nl) {
+		res = FALSE;
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
+	msg = nlmsg_alloc();
+	if (!msg)
+		g_error("failed to allocate netlink message");
+
+	if (!genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, driver_id, 0, 0, NBD_CMD_CONNECT, 0))
+		g_error("failed to add generic netlink headers to message");
+
+	/* do not set NBD_ATTR_INDEX to let nbd return a free nbd device index */
+	NLA_PUT_U64(msg, NBD_ATTR_SIZE_BYTES, nbd_dev->data_size);
+	NLA_PUT_U64(msg, NBD_ATTR_BLOCK_SIZE_BYTES, 4096);
+	NLA_PUT_U64(msg, NBD_ATTR_SERVER_FLAGS, 0);
+	NLA_PUT_U64(msg, NBD_ATTR_CLIENT_FLAGS,
+			NBD_CFLAG_DISCONNECT_ON_CLOSE
+			);
+	NLA_PUT_U64(msg, NBD_ATTR_TIMEOUT, 300);
+
+	attr_sockets = nla_nest_start(msg, NBD_ATTR_SOCKETS);
+	if (!attr_sockets)
+		g_error("failed to allocate nested NBD_ATTR_SOCKETS netlink message");
+	attr_item = nla_nest_start(msg, NBD_SOCK_ITEM);
+	if (!attr_item)
+		g_error("failed to allocate nested NBD_SOCK_ITEM netlink message");
+	NLA_PUT_U32(msg, NBD_SOCK_FD, nbd_dev->sock);
+	nla_nest_end(msg, attr_item);
+	nla_nest_end(msg, attr_sockets);
+
+	nl_socket_modify_cb(nl, NL_CB_VALID, NL_CB_CUSTOM, netlink_connect_cb, nbd_dev);
+	if (nl_send_sync(nl, msg) < 0) {
+		res = FALSE;
+		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "netlink send_sync failed");
+		goto out;
+	}
+	if (!nbd_dev->index_valid)
+		g_error("failed to create nbd device");
+
+	nbd_dev->dev = g_strdup_printf("/dev/nbd%"G_GUINT32_FORMAT, nbd_dev->index);
+
+	g_message("setup done for %s", nbd_dev->dev);
+
+	res = TRUE;
+	goto out;
+
+	/* This label is used by the NLA_PUT macros. */
+nla_put_failure:
+	g_error("failed to put netlink attribute");
+
+out:
+	if (nl) {
+		nl_close(nl);
+		nl_socket_free(nl);
+	}
+	return res;
+}
+
+gboolean r_nbd_remove_device(RaucNBDDevice *nbd_dev, GError **error)
+{
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+	int driver_id;
+	struct nl_sock *nl = NULL;
+	struct nl_msg *msg = NULL;
+
+	g_return_val_if_fail(nbd_dev != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (!nbd_dev->index_valid)
+		return TRUE;
+
+	g_message("r_nbd_remove_device");
+
+	nl = netlink_connect(&driver_id, &ierror);
+	if (!nl) {
+		res = FALSE;
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
+	msg = nlmsg_alloc();
+	if (!msg)
+		g_error("failed to allocate netlink message");
+
+	if (!genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, driver_id, 0, 0, NBD_CMD_DISCONNECT, 0))
+		g_error("failed to add generic netlink headers to message");
+
+	NLA_PUT_U32(msg, NBD_ATTR_INDEX, nbd_dev->index);
+
+	if (nl_send_sync(nl, msg) < 0) {
+		g_message("nbd device is already removed");
+	}
+
+	nbd_dev->index_valid = FALSE;
+	nbd_dev->index = 0;
+
+	/* maybe reuse the socket to get final statistics/error message? */
+	g_close(nbd_dev->sock, NULL);
+	nbd_dev->sock = -1;
+	g_clear_pointer(&nbd_dev->dev, g_free);
+
+	res = TRUE;
+	goto out;
+
+	/* This label is used by the NLA_PUT macros. */
+nla_put_failure:
+	g_error("failed to put netlink attribute");
+
+out:
+	if (nl) {
+		nl_close(nl);
+		nl_socket_free(nl);
+	}
+	return res;
+}
+
+struct RaucNBDContext {
+	gint sock;
+
+	/* configuration */
+	guint64 data_size;
+	gchar *url;
+	gchar *tls_cert; /* local file or PKCS#11 URI */
+	gchar *tls_key; /* local file or PKCS#11 URI */
+	gchar *tls_ca; /* local file */
+	gboolean tls_no_verify;
+	GStrv headers; /* array of strings such as 'Foo: bar' */
+
+	/* runtime state */
+	CURLM *multi;
+	gboolean done;
+	struct curl_slist *headers_slist;
+
+	/* statistics */
+	struct RaucStats dl_size, dl_speed,
+	                 namelookup, connect, starttransfer, total;
+};
+
+struct RaucNBDTransfer {
+	struct RaucNBDContext *ctx;
+
+	/* curl */
+	CURL *easy;
+	char errbuf[CURL_ERROR_SIZE];
+
+	struct nbd_request request;
+	struct nbd_reply reply;
+	gboolean done;
+	guint errors;
+
+	guint8 *buffer;
+	curl_off_t buffer_size;
+	curl_off_t buffer_pos;
+
+	/* configure request */
+	guint64 content_size;
+	guint64 current_time; /* date header from server */
+	guint64 modified_time; /* last-modified header from server */
+};
+
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+	struct RaucNBDTransfer *xfer = userdata;
+	size_t remaining = 0;
+
+	g_assert_cmpint(size, ==, 1); /* according to the docs, size is always 1 */
+
+	remaining = xfer->buffer_size - xfer->buffer_pos;
+	if (remaining < nmemb) {
+		return 0;
+	}
+	memcpy(xfer->buffer + xfer->buffer_pos, ptr, nmemb);
+	xfer->buffer_pos += nmemb;
+
+	return nmemb;
+}
+
+static size_t header_cb(char *buffer, size_t size, size_t nitems, void *userdata)
+{
+	struct RaucNBDTransfer *xfer = userdata;
+	g_autofree gchar *header = NULL;
+	g_auto(GStrv) h_pair = NULL;
+
+	g_assert_cmpint(size, ==, 1); /* according to the docs, size is always 1 */
+
+	/* make sure we have a 0-terminated lowercase string */
+	header = g_strchomp(g_ascii_strdown(buffer, nitems));
+
+	h_pair = g_strsplit(header, ": ", 2);
+	if (g_strv_length(h_pair) < 2)
+		return nitems;
+
+	if (g_str_equal(h_pair[0], "content-range")) {
+		g_auto(GStrv) h_elements = NULL;
+		g_auto(GStrv) h_range = NULL;
+		gchar *endptr = NULL;
+		guint64 range_size = 0;
+
+		h_elements = g_strsplit(h_pair[1], " ", 2);
+		if (g_strv_length(h_elements) != 2) {
+			g_message("failed to parse content-range header");
+			return 0;
+		}
+
+		h_range = g_strsplit(h_elements[1], "/", 2);
+		if (g_strv_length(h_range) != 2) {
+			g_message("failed to split content-range value");
+			return 0;
+		}
+
+		if (!g_str_equal(h_range[0], "0-3") || g_str_equal(h_range[1], "*")) {
+			g_message("invalid content-range value");
+			return 0;
+		}
+
+		errno = 0;
+		range_size = g_ascii_strtoull(h_range[1], &endptr, 10);
+		if (errno != 0 || endptr[0] != '\0') {
+			g_message("failed to parse content-range size");
+			return 0;
+		}
+
+		xfer->content_size = range_size;
+
+		g_message("total size %"G_GUINT64_FORMAT, range_size);
+	} else if (g_str_equal(h_pair[0], "date")) {
+		time_t date = curl_getdate(h_pair[1], NULL);
+		if (date >= 0) {
+			xfer->current_time = date;
+			g_message("server date %"G_GUINT64_FORMAT, xfer->current_time);
+		}
+	} else if (g_str_equal(h_pair[0], "last-modified")) {
+		time_t date = curl_getdate(h_pair[1], NULL);
+		if (date >= 0) {
+			xfer->modified_time = date;
+			g_message("file date %"G_GUINT64_FORMAT, xfer->modified_time);
+		}
+	}
+
+	return nitems;
+}
+
+static void prepare_curl(struct RaucNBDTransfer *xfer)
+{
+	CURLcode code = 0;
+	g_assert_null(xfer->easy);
+
+	xfer->easy = curl_easy_init();
+	if (!xfer->easy)
+		g_error("unexpected error from curl_easy_init in %s", G_STRFUNC);
+
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_ERRORBUFFER, xfer->errbuf);
+
+	if (g_getenv("RAUC_CURL_VERBOSE"))
+		code |= curl_easy_setopt(xfer->easy, CURLOPT_VERBOSE, 1L);
+
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_URL, xfer->ctx->url);
+	if (xfer->ctx->tls_cert)
+		code |= curl_easy_setopt(xfer->easy, CURLOPT_SSLCERT, xfer->ctx->tls_cert);
+	if (xfer->ctx->tls_key)
+		code |= curl_easy_setopt(xfer->easy, CURLOPT_SSLKEY, xfer->ctx->tls_key);
+	if (xfer->ctx->tls_ca) {
+		code |= curl_easy_setopt(xfer->easy, CURLOPT_CAINFO, xfer->ctx->tls_ca);
+		code |= curl_easy_setopt(xfer->easy, CURLOPT_CAPATH, NULL);
+	}
+
+	if (xfer->ctx->tls_no_verify)
+		code |= curl_easy_setopt(xfer->easy, CURLOPT_SSL_VERIFYPEER, 0L);
+	if (xfer->ctx->headers_slist)
+		code |= curl_easy_setopt(xfer->easy, CURLOPT_HTTPHEADER, xfer->ctx->headers_slist);
+
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_FOLLOWLOCATION, 1L);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_MAXREDIRS, 8L);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_UNRESTRICTED_AUTH, 1L); /* send authentication to redirect targets as well */
+
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_NOSIGNAL, 1L); /* avoid signals for threading */
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_FAILONERROR, 1L);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
+
+	/* a proxy may be configured using .netrc */
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_HTTPPROXYTUNNEL, 1L);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_SUPPRESS_CONNECT_HEADERS, 1L);
+
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_PRIVATE, xfer);
+
+	if (code)
+		g_error("unexpected error from curl_easy_setopt in %s", G_STRFUNC);
+}
+
+static void collect_curl_stats(struct RaucNBDContext *ctx, struct RaucNBDTransfer *xfer)
+{
+	CURLcode code;
+	double time;
+	curl_off_t size;
+
+	code = curl_easy_getinfo(xfer->easy, CURLINFO_NAMELOOKUP_TIME, &time);
+	if (code == CURLE_OK) {
+		//g_message("NAMELOOKUP %.3f", time);
+		r_stats_add(&ctx->namelookup, time);
+	}
+
+	code = curl_easy_getinfo(xfer->easy, CURLINFO_CONNECT_TIME, &time);
+	if (code == CURLE_OK) {
+		//g_message("CONNECT %.3f", time);
+		r_stats_add(&ctx->connect, time);
+	}
+
+	code = curl_easy_getinfo(xfer->easy, CURLINFO_STARTTRANSFER_TIME, &time);
+	if (code == CURLE_OK) {
+		//g_message("STARTTRANSFER %.3f", time);
+		r_stats_add(&ctx->starttransfer, time);
+	}
+
+	code = curl_easy_getinfo(xfer->easy, CURLINFO_TOTAL_TIME, &time);
+	if (code == CURLE_OK) {
+		//g_message("TOTAL %.3f", time);
+		r_stats_add(&ctx->total, time);
+	}
+	code = curl_easy_getinfo(xfer->easy, CURLINFO_SIZE_DOWNLOAD_T, &size);
+	if (code == CURLE_OK) {
+		//g_message("SIZE_DOWNLOAD %ld", size);
+		r_stats_add(&ctx->dl_size, size);
+	}
+
+	code = curl_easy_getinfo(xfer->easy, CURLINFO_SPEED_DOWNLOAD, &time);
+	if (code == CURLE_OK) {
+		//g_message("SPEED_DOWNLOAD %.3f", time);
+		r_stats_add(&ctx->dl_speed, time);
+	}
+}
+
+static void start_read(struct RaucNBDContext *ctx, struct RaucNBDTransfer *xfer)
+{
+	CURLcode code = 0;
+	CURLMcode mcode = 0;
+	g_autofree gchar *range = NULL;
+
+	xfer->buffer = g_malloc(xfer->request.len);
+	xfer->buffer_size = xfer->request.len;
+	xfer->buffer_pos = 0;
+
+	prepare_curl(xfer);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_WRITEFUNCTION, write_cb);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_WRITEDATA, xfer);
+	range = g_strdup_printf("%"G_GUINT64_FORMAT "-%"G_GUINT64_FORMAT,
+			(guint64)xfer->request.from,
+			(guint64)xfer->request.from + xfer->request.len - 1);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_RANGE, range);
+	if (code)
+		g_error("unexpected error from curl_easy_setopt in %s", G_STRFUNC);
+
+	mcode = curl_multi_add_handle(ctx->multi, xfer->easy);
+	if (mcode != CURLM_OK)
+		g_error("unexpected error from curl_multi_add_handle in %s", G_STRFUNC);
+}
+
+static struct curl_slist *gstrv_to_slist(const GStrv strv)
+{
+	struct curl_slist *slist = NULL;
+	struct curl_slist *temp = NULL;
+
+	for (GStrv str = strv; *str != NULL; str++) {
+		temp = curl_slist_append(slist, *str);
+		if (temp == NULL) {
+			curl_slist_free_all(slist);
+			g_error("unexpected error from curl_slist_append in %s (out of memory?)", G_STRFUNC);
+			return NULL;
+		}
+		slist = temp;
+	}
+
+	return slist;
+}
+
+static void start_configure(struct RaucNBDContext *ctx, struct RaucNBDTransfer *xfer)
+{
+	gboolean res = FALSE;
+	CURLcode code = 0;
+	CURLMcode mcode = 0;
+	g_autofree guint8 *data = g_malloc(xfer->request.len);
+	g_autoptr(GVariant) v = NULL;
+	GVariantDict dict;
+
+	/* only read from the client on the first try */
+	if (!ctx->url) {
+		res = r_read_exact(ctx->sock, (guint8*)data, xfer->request.len, NULL);
+		g_assert_true(res);
+
+		v = g_variant_new_from_data(G_VARIANT_TYPE_VARDICT,
+				data, xfer->request.len,
+				FALSE,
+				NULL, NULL);
+		g_assert_nonnull(v);
+		g_message("received: %s", g_variant_print(v, TRUE));
+
+		g_variant_dict_init(&dict, v);
+
+		g_variant_dict_lookup(&dict, "url", "s", &ctx->url);
+		g_variant_dict_lookup(&dict, "cert", "s", &ctx->tls_cert);
+		g_variant_dict_lookup(&dict, "key", "s", &ctx->tls_key);
+		g_variant_dict_lookup(&dict, "ca", "s", &ctx->tls_ca);
+		g_variant_dict_lookup(&dict, "no-verify", "b", &ctx->tls_no_verify);
+		g_variant_dict_lookup(&dict, "headers", "^as", &ctx->headers);
+		g_assert_nonnull(ctx->url);
+
+		if (ctx->headers) {
+			ctx->headers_slist = gstrv_to_slist(ctx->headers);
+		}
+	}
+
+	g_message("configuring for URL: %s", ctx->url);
+
+	prepare_curl(xfer);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_USERAGENT, PACKAGE_NAME "/" PACKAGE_VERSION);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_HEADERFUNCTION, header_cb);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_HEADERDATA, xfer);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_WRITEFUNCTION, write_cb);
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_WRITEDATA, xfer);
+	/* we could try a HEAD request, but prefer to check if range requests work */
+	code |= curl_easy_setopt(xfer->easy, CURLOPT_RANGE, "0-3"); /* get the "sqsh" magic */
+
+	if (code)
+		g_error("unexpected error from curl_easy_setopt in %s", G_STRFUNC);
+
+	xfer->buffer = g_malloc(4);
+	xfer->buffer_size = 4;
+	xfer->buffer_pos = 0;
+
+	mcode = curl_multi_add_handle(ctx->multi, xfer->easy);
+	if (mcode != CURLM_OK)
+		g_error("unexpected error from curl_multi_add_handle in %s", G_STRFUNC);
+}
+
+static void start_request(struct RaucNBDContext *ctx, struct RaucNBDTransfer *xfer)
+{
+	switch (xfer->request.type) {
+		case NBD_CMD_READ: {
+			start_read(ctx, xfer);
+			break;
+		}
+		case NBD_CMD_DISC: {
+			g_message("disconnect");
+			ctx->done = TRUE;
+			break;
+		}
+		case RAUC_NBD_CMD_CONFIGURE: {
+			start_configure(ctx, xfer);
+			break;
+		}
+		default: {
+			g_error("bad request type");
+			break;
+		}
+	}
+}
+
+static gboolean finish_read(struct RaucNBDContext *ctx, struct RaucNBDTransfer *xfer)
+{
+	gboolean res = FALSE;
+	CURLcode code;
+	long response_code = 0;
+
+	if (!xfer->done) { /* retry */
+		res = TRUE;
+		goto out;
+	}
+
+	code = curl_easy_getinfo(xfer->easy, CURLINFO_RESPONSE_CODE, &response_code);
+	if (code != CURLE_OK)
+		g_error("unexpected error from curl_easy_getinfo in %s", G_STRFUNC);
+	if (response_code != 206)
+		g_error("unexpected HTTP response code %ld from curl_easy_getinfo in %s", response_code, G_STRFUNC);
+
+	if (!r_write_exact(ctx->sock, (guint8*)&xfer->reply, sizeof(xfer->reply), NULL))
+		g_error("failed to send nbd read reply header");
+	if (xfer->reply.error == 0) {
+		if (xfer->buffer_size != xfer->buffer_pos)
+			g_error("incomplete data received from server");
+
+		if (!r_write_exact(ctx->sock, xfer->buffer, xfer->buffer_size, NULL))
+			g_error("failed to send nbd read reply body");
+	}
+
+	collect_curl_stats(ctx, xfer);
+
+	res = TRUE;
+out:
+	g_clear_pointer(&xfer->buffer, g_free);
+
+	return res;
+}
+
+static gboolean finish_configure(struct RaucNBDContext *ctx, struct RaucNBDTransfer *xfer)
+{
+	gboolean res = FALSE;
+	CURLcode code;
+	long response_code = 0;
+	const char *effective_url = NULL;
+	g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
+	g_autoptr(GVariant) v = NULL;
+	guint32 reply_size;
+
+	if (!xfer->done) { /* retry */
+		res = TRUE;
+		goto out;
+	}
+
+	code = curl_easy_getinfo(xfer->easy, CURLINFO_RESPONSE_CODE, &response_code);
+	if (code != CURLE_OK)
+		g_error("unexpected error from curl_easy_getinfo in %s", G_STRFUNC);
+
+	if (response_code != 206) {
+		g_autofree gchar *error = NULL;
+		switch (response_code) {
+			case 0:
+				error = g_strdup_printf("server not responding");
+				break;
+			case 200:
+				error = g_strdup_printf("range requests not supported by server");
+				break;
+			default:
+				error = g_strdup_printf("unexpected HTTP error code %ld", response_code);
+		}
+		g_variant_dict_insert(&dict, "error", "s", error);
+		g_variant_dict_insert(&dict, "error-http-code", "u", (guint32)response_code);
+		res = FALSE;
+		goto reply;
+	}
+
+	if (xfer->buffer_size != xfer->buffer_pos) {
+		g_variant_dict_insert(&dict, "error", "s", "incomplete HTTP response");
+		res = FALSE;
+		goto reply;
+	}
+
+	/* any other error detected by curl */
+	if (xfer->reply.error) {
+		g_variant_dict_insert(&dict, "error", "s", xfer->errbuf);
+		res = FALSE;
+		goto reply;
+	}
+
+	code = curl_easy_getinfo(xfer->easy, CURLINFO_EFFECTIVE_URL, &effective_url);
+	if (code == CURLE_OK) {
+		if (!g_str_equal(ctx->url, effective_url))
+			g_message("redirected from %s to %s",ctx->url, effective_url);
+		g_free(ctx->url);
+		ctx->url = g_strdup(effective_url);
+	}
+
+	collect_curl_stats(ctx, xfer);
+
+	res = TRUE;
+
+reply:
+	/* this reply is not handled by the kernel, so we can always include body */
+	if (!r_write_exact(ctx->sock, (guint8*)&xfer->reply, sizeof(xfer->reply), NULL))
+		g_error("failed to send nbd config reply header");
+
+	if (ctx->url)
+		g_variant_dict_insert(&dict, "url", "s", ctx->url);
+	if (xfer->content_size)
+		g_variant_dict_insert(&dict, "size", "t", xfer->content_size);
+	if (xfer->current_time)
+		g_variant_dict_insert(&dict, "current-time", "t", xfer->current_time);
+	if (xfer->modified_time)
+		g_variant_dict_insert(&dict, "modified-time", "t", xfer->modified_time);
+
+	v = g_variant_dict_end(&dict);
+	reply_size = g_variant_get_size(v);
+
+	if (!r_write_exact(ctx->sock, (guint8*)&reply_size, sizeof(reply_size), NULL))
+		g_error("failed to send nbd config reply size");
+	if (!r_write_exact(ctx->sock, g_variant_get_data(v), g_variant_get_size(v), NULL))
+		g_error("failed to send nbd config reply body");
+
+out:
+	g_clear_pointer(&xfer->buffer, g_free);
+
+	return res;
+}
+
+static gboolean finish_request(struct RaucNBDContext *ctx, struct RaucNBDTransfer *xfer)
+{
+	gboolean res = FALSE;
+
+	switch (xfer->request.type) {
+		case NBD_CMD_READ: {
+			res = finish_read(ctx, xfer);
+			break;
+		}
+		case RAUC_NBD_CMD_CONFIGURE: {
+			res = finish_configure(ctx, xfer);
+			break;
+		}
+		default: {
+			g_message("bad request type");
+			break;
+		}
+	}
+
+	if (xfer->easy) {
+		curl_multi_remove_handle(ctx->multi, xfer->easy);
+		curl_easy_cleanup(xfer->easy);
+		xfer->easy = NULL;
+	}
+
+	return res;
+}
+
+gboolean r_nbd_run_server(gint sock, GError **error)
+{
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+	struct RaucNBDContext ctx = {0};
+	struct curl_waitfd waitfd = {0};
+
+	g_return_val_if_fail(sock >= 0, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) == -1) {
+		g_set_error(
+				error,
+				G_FILE_ERROR, g_file_error_from_errno(errno),
+				"failed to enable NO_NEW_PRIVS: %s", strerror(errno));
+		return FALSE;
+	}
+
+	g_message("running as UID %d, GID %d", getuid(), getgid());
+
+	r_stats_init(&ctx.dl_size);
+	r_stats_init(&ctx.dl_speed);
+	r_stats_init(&ctx.namelookup);
+	r_stats_init(&ctx.connect);
+	r_stats_init(&ctx.starttransfer);
+	r_stats_init(&ctx.total);
+
+	ctx.sock = sock;
+	ctx.multi = curl_multi_init();
+
+	waitfd.fd = sock;
+	waitfd.events = CURL_WAIT_POLLIN;
+
+	while (!ctx.done) {
+		int numfds = 0;
+		int still_running = 0;
+		CURLMcode mcode = curl_multi_wait(ctx.multi, &waitfd, 1, 1000, &numfds);
+		if (mcode != CURLM_OK)
+			g_error("unexpected error from curl_multi_wait in %s", G_STRFUNC);
+
+		if ((numfds > 0) && (waitfd.revents & CURL_WAIT_POLLIN)) { /* new event from the client */
+			struct RaucNBDTransfer *xfer = g_malloc0(sizeof(struct RaucNBDTransfer));
+			xfer->ctx = &ctx;
+
+			res = r_read_exact(sock, (guint8*)&xfer->request, sizeof(xfer->request), &ierror);
+			if (!res) {
+				if (!ierror) { /* disconnected */
+					ctx.done = TRUE;
+					break;
+				} else {
+					g_propagate_prefixed_error(
+							error,
+							ierror,
+							"failed to read request from client: ");
+					res = FALSE;
+					goto out;
+				}
+			}
+
+			g_assert(xfer->request.magic == GUINT32_TO_BE(NBD_REQUEST_MAGIC));
+			xfer->request.type = GUINT32_FROM_BE(xfer->request.type);
+			xfer->request.from = GUINT64_FROM_BE(xfer->request.from);
+			xfer->request.len = GUINT32_FROM_BE(xfer->request.len);
+			//g_message("type 0x%x: from 0x%llx+0x%x", xfer->request.type, xfer->request.from, xfer->request.len);
+
+			xfer->reply.magic = GUINT32_TO_BE(NBD_REPLY_MAGIC);
+			memcpy(xfer->reply.handle, xfer->request.handle, sizeof(xfer->reply.handle));
+
+			start_request(&ctx, xfer);
+		}
+
+		mcode = curl_multi_perform(ctx.multi, &still_running);
+		g_assert(mcode == CURLM_OK);
+
+		while (1) {
+			CURLcode code = 0;
+			int msgs_in_queue = 0;
+			struct RaucNBDTransfer *xfer = NULL;
+			struct CURLMsg *msg = curl_multi_info_read(ctx.multi, &msgs_in_queue);
+			if (!msg)
+				break;
+
+			if (msg->msg != CURLMSG_DONE) {
+				g_message("still running");
+				continue;
+			}
+
+			code = curl_easy_getinfo(msg->easy_handle, CURLINFO_PRIVATE, &xfer);
+			g_assert(code == CURLE_OK);
+
+			if (msg->data.result == CURLE_OK) {
+				g_debug("request done");
+				xfer->reply.error = 0;
+				xfer->done = TRUE;
+			} else if (xfer->errors >= 5) {
+				g_message("request failed (no more retries)");
+				xfer->reply.error = GUINT32_TO_BE(5); /* NBD_EIO */
+				xfer->done = TRUE;
+			} else {
+				g_message("request failed (retrying)");
+				xfer->errors++;
+			}
+
+			res = finish_request(&ctx, xfer);
+			if (!res) {
+				g_set_error(
+						error,
+						R_NBD_ERROR, R_NBD_ERROR_SHUTDOWN,
+						"finish_request failed, shutting down");
+				goto out;
+			}
+
+			if (xfer->done) {
+				g_free(xfer);
+			} else {
+				/* retry */
+				sleep(1);
+				start_request(&ctx, xfer);
+			}
+		};
+	}
+
+	r_stats_show(&ctx.dl_size, "dl size");
+	r_stats_show(&ctx.dl_speed, "dlspeed");
+	r_stats_show(&ctx.namelookup, "name lookup");
+	r_stats_show(&ctx.connect, "connect");
+	r_stats_show(&ctx.starttransfer, "start transfer");
+	r_stats_show(&ctx.total, "total");
+
+	res = TRUE;
+out:
+	curl_multi_cleanup(ctx.multi);
+	g_message("exiting nbd server");
+	return res;
+}
+
+/* for development */
+G_GNUC_UNUSED
+static gpointer nbd_server_thread(gpointer data)
+{
+	g_autofree gint *sockp = data;
+	g_message("started thread %d", *sockp);
+	r_nbd_run_server(*sockp, NULL);
+	return NULL;
+}
+
+static gboolean nbd_configure(RaucNBDServer *nbd_srv, GError **error)
+{
+	struct nbd_request request = {0};
+	struct nbd_reply reply = {0};
+	guint32 reply_size = 0;
+	g_autofree guint8 *reply_data = NULL;
+	g_autofree guint8 *reply_error = NULL;
+	g_autoptr(GVariant) v = NULL;
+	g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
+
+	g_return_val_if_fail(nbd_srv != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* send config request */
+	g_variant_dict_insert(&dict, "url", "s", nbd_srv->url);
+	if (nbd_srv->tls_cert)
+		g_variant_dict_insert(&dict, "cert", "s", nbd_srv->tls_cert);
+	if (nbd_srv->tls_key)
+		g_variant_dict_insert(&dict, "key", "s", nbd_srv->tls_key);
+	if (nbd_srv->tls_ca)
+		g_variant_dict_insert(&dict, "ca", "s", nbd_srv->tls_ca);
+	if (nbd_srv->tls_no_verify)
+		g_variant_dict_insert(&dict, "no-verify", "b", nbd_srv->tls_no_verify);
+	if (nbd_srv->headers)
+		g_variant_dict_insert(&dict, "headers", "^as", nbd_srv->headers);
+	v = g_variant_dict_end(&dict);
+	g_message("sending: %s", g_variant_print(v, TRUE));
+
+	request.magic = GUINT32_TO_BE(NBD_REQUEST_MAGIC);
+	request.type = GUINT32_TO_BE(RAUC_NBD_CMD_CONFIGURE);
+	request.len = GUINT32_TO_BE(g_variant_get_size(v));
+	memcpy(request.handle, RAUC_NBD_HANDLE, sizeof(request.handle));
+
+	if (!r_write_exact(nbd_srv->sock, (guint8*)&request, sizeof(request), NULL))
+		g_error("failed to send nbd config request header");
+	if (!r_write_exact(nbd_srv->sock, g_variant_get_data(v), g_variant_get_size(v), NULL))
+		g_error("failed to send nbd config request body");
+	g_clear_pointer(&v, g_variant_unref);
+
+	/* receive config reply */
+	if (!r_read_exact(nbd_srv->sock, (guint8*)&reply, sizeof(reply), NULL))
+		g_error("failed to recv nbd config reply header");
+
+	if (reply.magic != GUINT32_TO_BE(NBD_REPLY_MAGIC))
+		g_error("invalid nbd reply magic");
+	if (memcmp(reply.handle, RAUC_NBD_HANDLE, sizeof(reply.handle)) != 0)
+		g_error("invalid nbd reply handle");
+	/* reply.error is not relevant here, as we have a reply body in any case */
+
+	if (!r_read_exact(nbd_srv->sock, (guint8*)&reply_size, sizeof(reply_size), NULL))
+		g_error("failed to recv nbd config reply size");
+	reply_data = g_malloc(reply_size);
+	if (!r_read_exact(nbd_srv->sock, reply_data, reply_size, NULL))
+		g_error("failed to recv nbd config reply body");
+
+	v = g_variant_new_from_data(G_VARIANT_TYPE_VARDICT,
+			reply_data, reply_size,
+			FALSE,
+			NULL, NULL);
+	if (!v)
+		g_error("failed to deserialize nbd config reply");
+
+	g_variant_dict_init(&dict, v);
+
+	g_variant_dict_lookup(&dict, "error", "s", &reply_error);
+	if (reply_error) {
+		guint32 http_code = 0;
+		g_variant_dict_lookup(&dict, "error-http-code", "u", &http_code);
+		g_message("received http error %"G_GUINT32_FORMAT, http_code);
+		if (http_code == 401) {
+			g_set_error(
+					error,
+					R_NBD_ERROR, R_NBD_ERROR_UNAUTHORIZED,
+					"unauthorized: %s", reply_error);
+		} else if (http_code == 404) {
+			g_set_error(
+					error,
+					R_NBD_ERROR, R_NBD_ERROR_NOT_FOUND,
+					"not found: %s", reply_error);
+		} else {
+			g_set_error(
+					error,
+					R_NBD_ERROR, R_NBD_ERROR_CONFIGURATION,
+					"failed to configure streaming: %s", reply_error);
+		}
+		return FALSE;
+	}
+
+	g_variant_dict_lookup(&dict, "url", "s", &nbd_srv->effective_url);
+	g_variant_dict_lookup(&dict, "size", "t", &nbd_srv->data_size);
+	g_message("received total size %"G_GUINT64_FORMAT, nbd_srv->data_size);
+	g_variant_dict_lookup(&dict, "current-time", "t", &nbd_srv->current_time);
+	g_message("received current time %"G_GUINT64_FORMAT, nbd_srv->current_time);
+	g_variant_dict_lookup(&dict, "modified-time", "t", &nbd_srv->modified_time);
+	g_message("received modified time %"G_GUINT64_FORMAT, nbd_srv->modified_time);
+
+	return TRUE;
+}
+
+struct child_setup_args {
+	uid_t uid;
+	gid_t gid;
+};
+
+static void nbd_server_child_setup(gpointer user_data)
+{
+	/* see signal-safety(7) for functions which can be used here */
+	struct child_setup_args *args = user_data;
+
+	if (args->gid) {
+		if (setgid(args->gid) == -1) {
+			const char *msg = "setgid failed\n";
+			write(STDOUT_FILENO, msg, strlen(msg));
+			exit(1);
+		}
+	}
+	if (args->uid) {
+		if (setuid(args->uid) == -1) {
+			const char *msg = "setuid failed\n";
+			write(STDOUT_FILENO, msg, strlen(msg));
+			exit(1);
+		}
+	}
+}
+
+static gboolean nbd_server_child_prepare(struct child_setup_args *args, GError **error)
+{
+	const gchar *user = NULL;
+	struct passwd passwd = {0};
+	struct passwd *result = NULL;
+	g_autofree gchar *buf = NULL;
+	long bufsize;
+	int err;
+
+	g_return_val_if_fail(args != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	user = r_context()->config->streaming_sandbox_user;
+	if (user == NULL)
+		user = STREAMING_USER;
+
+	bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+	if (bufsize == -1)
+		bufsize = 16384;
+	buf = g_malloc0(bufsize);
+
+	err = getpwnam_r(user, &passwd, buf, bufsize, &result);
+	if (result == NULL) {
+		if (err == 0) {
+			g_set_error(
+					error,
+					R_NBD_ERROR, R_NBD_ERROR_STARTUP,
+					"user %s not found in user database", user);
+			return FALSE;
+		} else {
+			g_set_error(
+					error,
+					G_IO_ERROR, g_io_error_from_errno(err),
+					"failed to get user %s from database: %s", user, g_strerror(err));
+			return FALSE;
+		}
+	}
+
+	args->uid = result->pw_uid;
+	args->gid = result->pw_gid;
+
+	return TRUE;
+}
+
+gboolean r_nbd_start_server(RaucNBDServer *nbd_srv, GError **error)
+{
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+	gint sockets[2] = {-1, -1};
+
+	g_return_val_if_fail(nbd_srv != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0) {
+		g_set_error(
+				error,
+				G_IO_ERROR, g_io_error_from_errno(errno),
+				"failed to create unix socket pair: %s",
+				g_strerror(errno));
+		res = FALSE;
+		goto out;
+	}
+
+	if (1) { /* subprocess */
+		struct child_setup_args child_args = {0};
+		g_autofree gchar *executable = NULL;
+		g_autoptr(GSubprocessLauncher) launcher = NULL;
+		g_autoptr(GPtrArray) args = g_ptr_array_new_full(3, g_free);
+
+		if (!nbd_server_child_prepare(&child_args, &ierror)) {
+			g_propagate_prefixed_error(
+					error,
+					ierror,
+					"failed to prepare streaming subprocess: ");
+			res = FALSE;
+			goto out;
+		}
+
+		/* allow overriding the path for testing */
+		executable = g_strdup(g_getenv("RAUC_TEST_NBD_SERVER"));
+		if (!executable)
+			executable = g_strdup("/proc/self/exe");
+		g_ptr_array_add(args, g_steal_pointer(&executable));
+		g_ptr_array_add(args, NULL);
+
+		launcher = g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_NONE);
+		g_subprocess_launcher_set_child_setup(launcher, nbd_server_child_setup, &child_args, NULL);
+		g_subprocess_launcher_setenv(launcher, "RAUC_NBD_SERVER", "", TRUE);
+		g_subprocess_launcher_take_fd(launcher, sockets[0], RAUC_SOCKET_FD);
+
+		nbd_srv->sproc = r_subprocess_launcher_spawnv(launcher, args, &ierror);
+		if (nbd_srv->sproc == NULL) {
+			g_propagate_prefixed_error(
+					error,
+					ierror,
+					"failed to start streaming subprocess: ");
+			res = FALSE;
+			goto out;
+		}
+	} else { /* thread for testing */
+		gint *sockp = g_malloc(sizeof(gint));
+		*sockp = sockets[0];
+		g_thread_new("nbd", nbd_server_thread, sockp);
+	}
+
+	sockets[0] = -1; /* GSubprocess takes ownership */
+
+	nbd_srv->sock = sockets[1];
+	sockets[1] = -1; /* RaucNBDServer takes ownership */
+
+	if (!nbd_configure(nbd_srv, &ierror)) {
+		g_propagate_error(error, ierror);
+		res = FALSE;
+		goto out;
+	}
+
+	g_message("nbd server started");
+
+	res = TRUE;
+
+out:
+	if (sockets[0] >= 0)
+		g_close(sockets[0], NULL);
+	if (sockets[1] >= 0)
+		g_close(sockets[1], NULL);
+	return res;
+}
+
+gboolean r_nbd_stop_server(RaucNBDServer *nbd_srv, GError **error)
+{
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+
+	g_return_val_if_fail(nbd_srv != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (!nbd_srv->sproc)
+		return TRUE;
+
+	g_message("nbd server stopping");
+
+	if (nbd_srv->sock >= 0) {
+		g_close(nbd_srv->sock, NULL);
+		nbd_srv->sock = -1;
+	}
+
+	res = g_subprocess_wait_check(nbd_srv->sproc, NULL, &ierror);
+	if (!res) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed to stop streaming subprocess: ");
+		goto out;
+	}
+
+	g_message("nbd server stopped");
+
+out:
+	g_clear_object(&nbd_srv->sproc);
+	return res;
+}
+
+gboolean r_nbd_read(gint sock, guint8 *data, size_t size, off64_t offset, GError **error)
+{
+	struct nbd_request request = {0};
+	struct nbd_reply reply = {0};
+	gboolean res = FALSE;
+
+	g_return_val_if_fail(sock >= 0, FALSE);
+	g_return_val_if_fail(data, FALSE);
+	g_return_val_if_fail(size > 0, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	request.magic = GUINT32_TO_BE(NBD_REQUEST_MAGIC);
+	request.type = GUINT32_TO_BE(NBD_CMD_READ);
+	request.from = GUINT64_TO_BE(offset);
+	request.len = GUINT32_TO_BE(size);
+	memcpy(request.handle, RAUC_NBD_HANDLE, sizeof(request.handle));
+
+	if (!r_write_exact(sock, (guint8*)&request, sizeof(request), NULL))
+		g_error("failed to send nbd read request header");
+	if (!r_read_exact(sock, (guint8*)&reply, sizeof(reply), NULL))
+		g_error("failed to receive nbd read reply header");
+
+	if (reply.magic != GUINT32_TO_BE(NBD_REPLY_MAGIC))
+		g_error("invalid nbd reply magic");
+	if (memcmp(reply.handle, RAUC_NBD_HANDLE, sizeof(reply.handle)) != 0)
+		g_error("invalid nbd reply handle");
+	if (reply.error != GUINT32_TO_BE(0)) {
+		g_set_error(
+				error,
+				R_NBD_ERROR, R_NBD_ERROR_READ,
+				"failed to read data from remote server");
+		goto out;
+	}
+
+	if (!r_read_exact(sock, data, size, NULL))
+		g_error("failed to receive nbd read reply body");
+
+	res = TRUE;
+
+out:
+	return res;
+}

--- a/src/service.c
+++ b/src/service.c
@@ -79,6 +79,16 @@ static gboolean r_on_handle_install_bundle(
 
 	if (g_variant_dict_lookup(&dict, "ignore-compatible", "b", &args->ignore_compatible))
 		g_variant_dict_remove(&dict, "ignore-compatible");
+	if (g_variant_dict_lookup(&dict, "tls-cert", "s", &args->access_args.tls_cert))
+		g_variant_dict_remove(&dict, "tls-cert");
+	if (g_variant_dict_lookup(&dict, "tls-key", "s", &args->access_args.tls_key))
+		g_variant_dict_remove(&dict, "tls-key");
+	if (g_variant_dict_lookup(&dict, "tls-ca", "s", &args->access_args.tls_ca))
+		g_variant_dict_remove(&dict, "tls-ca");
+	if (g_variant_dict_lookup(&dict, "tls-no-verify", "b", &args->access_args.tls_no_verify))
+		g_variant_dict_remove(&dict, "tls-no-verify");
+	if (g_variant_dict_lookup(&dict, "http-headers", "^as", &args->access_args.http_headers))
+		g_variant_dict_remove(&dict, "http-headers");
 
 	/* Check for unhandled keys */
 	g_variant_iter_init(&iter, g_variant_dict_end(&dict));

--- a/src/service.c
+++ b/src/service.c
@@ -138,7 +138,7 @@ static gboolean r_on_handle_info(RInstaller *interface,
 	if (!res)
 		goto out;
 
-	res = check_bundle(arg_bundle, &bundle, CHECK_BUNDLE_DEFAULT, &error);
+	res = check_bundle(arg_bundle, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &error);
 	if (!res) {
 		g_warning("%s", error->message);
 		g_clear_error(&error);

--- a/src/stats.c
+++ b/src/stats.c
@@ -1,0 +1,72 @@
+#include "stats.h"
+
+void r_stats_init(struct RaucStats *stats)
+{
+	g_return_if_fail(stats);
+
+	memset(stats, 0, sizeof(*stats));
+
+	stats->min = G_MAXDOUBLE;
+	stats->min = G_MINDOUBLE;
+}
+
+void r_stats_add(struct RaucStats *stats, gdouble value)
+{
+	g_return_if_fail(stats);
+
+	stats->values[stats->next] = value;
+	stats->next = (stats->next + 1) % 64;
+	stats->count++;
+
+	stats->sum += value;
+
+	if (value < stats->min)
+		stats->min = value;
+	if (value > stats->max)
+		stats->max = value;
+}
+
+gdouble r_stats_get_avg(const struct RaucStats *stats)
+{
+	g_return_val_if_fail(stats, 0.0);
+
+	if (stats->count)
+		return stats->sum / stats->count;
+	else
+		return 0.0;
+}
+
+gdouble r_stats_get_recent_avg(const struct RaucStats *stats)
+{
+	gdouble sum = 0.0;
+	guint64 count = stats->count;
+
+	g_return_val_if_fail(stats, 0.0);
+
+	if (count > 64)
+		count = 64;
+
+	for (unsigned int i = 0; i < count; i++)
+		sum += stats->values[i];
+
+	if (count)
+		return sum / count;
+	else
+		return 0.0;
+}
+
+void r_stats_show(const struct RaucStats *stats, const gchar *prefix)
+{
+	g_autoptr(GString) msg = g_string_sized_new(128);
+
+	g_return_if_fail(stats);
+	g_return_if_fail(prefix);
+
+	g_string_append_printf(msg, "%s: count=%"G_GUINT64_FORMAT, prefix, stats->count);
+	if (!stats->count)
+		return;
+	g_string_append_printf(msg, " sum=%.3f min=%.3f max=%.3f avg=%.3f",
+			stats->sum, stats->min, stats->max, r_stats_get_avg(stats));
+	g_string_append_printf(msg, " recent-avg=%.3f", r_stats_get_recent_avg(stats));
+	g_message("%s", msg->str);
+}

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -130,7 +130,7 @@ static void test_check_empty_bundle(BundleFixture *fixture,
 	bundlename = write_random_file(fixture->tmpdir, "bundle.raucb", 0, 1234);
 	g_assert_nonnull(bundlename);
 
-	res = check_bundle(bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_false(res);
 	g_assert_error(ierror, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT);
 	g_assert_null(bundle);
@@ -147,7 +147,7 @@ static void test_check_invalid_bundle(BundleFixture *fixture,
 	bundlename = write_random_file(fixture->tmpdir, "bundle.raucb", 1024, 1234);
 	g_assert_nonnull(bundlename);
 
-	res = check_bundle(bundlename, &bundle, CHECK_BUNDLE_NO_VERIFY, &ierror);
+	res = check_bundle(bundlename, &bundle, CHECK_BUNDLE_NO_VERIFY, NULL, &ierror);
 	g_assert_false(res);
 	g_assert_error(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_IDENTIFIER);
 	g_assert_null(bundle);
@@ -160,7 +160,7 @@ static void bundle_test_create_check_error(BundleFixture *fixture,
 	g_autoptr(GError) ierror = NULL;
 	gboolean res = FALSE;
 
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_false(res);
 	g_assert_error(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_FORMAT);
 	g_assert_null(bundle);
@@ -178,7 +178,7 @@ static void bundle_test_create_extract(BundleFixture *fixture,
 	outputdir = g_build_filename(fixture->tmpdir, "output", NULL);
 	g_assert_nonnull(outputdir);
 
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -211,7 +211,7 @@ static void bundle_test_create_mount_extract(BundleFixture *fixture,
 	if (!test_running_as_root())
 		return;
 
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_NO_VERIFY, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_NO_VERIFY, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -236,7 +236,7 @@ static void bundle_test_extract_signature(BundleFixture *fixture,
 	outputsig = g_build_filename(fixture->tmpdir, "bundle.sig", NULL);
 	g_assert_nonnull(outputsig);
 
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -285,7 +285,7 @@ static void bundle_test_check_casync_old(BundleFixture *fixture, gconstpointer u
 	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
 			"Verifying bundle signature*" );
 
-	res = check_bundle(bundlepath, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(bundlepath, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -314,7 +314,7 @@ static void bundle_test_check_casync_new(BundleFixture *fixture, gconstpointer u
 	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
 			"Verifying bundle signature*" );
 
-	res = check_bundle(bundlepath, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(bundlepath, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -346,7 +346,7 @@ static void bundle_test_replace_signature(BundleFixture *fixture,
 	g_assert_nonnull(resignbundle);
 
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_TRUST_ENV, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_TRUST_ENV, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
@@ -354,7 +354,7 @@ static void bundle_test_replace_signature(BundleFixture *fixture,
 
 	/* Verify input bundle with 'dev' keyring */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-only-ca.pem");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_TRUST_ENV, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_TRUST_ENV, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
@@ -370,13 +370,13 @@ static void bundle_test_replace_signature(BundleFixture *fixture,
 	g_clear_pointer(&bundle, free_bundle);
 
 	/* Verify resigned bundle with old 'dev' key */
-	res = check_bundle(resignbundle, &bundle, CHECK_BUNDLE_TRUST_ENV, &ierror);
+	res = check_bundle(resignbundle, &bundle, CHECK_BUNDLE_TRUST_ENV, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
 
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	res = check_bundle(resignbundle, &bundle, CHECK_BUNDLE_TRUST_ENV, &ierror);
+	res = check_bundle(resignbundle, &bundle, CHECK_BUNDLE_TRUST_ENV, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
@@ -391,7 +391,7 @@ static void bundle_test_replace_signature(BundleFixture *fixture,
 	g_clear_pointer(&bundle, free_bundle);
 
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-only-ca.pem");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_TRUST_ENV, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_TRUST_ENV, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
@@ -400,21 +400,21 @@ static void bundle_test_replace_signature(BundleFixture *fixture,
 	g_assert_true(res);
 	g_clear_pointer(&bundle, free_bundle);
 
-	res = check_bundle(replacebundle, &bundle, CHECK_BUNDLE_TRUST_ENV, &ierror);
+	res = check_bundle(replacebundle, &bundle, CHECK_BUNDLE_TRUST_ENV, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
 	g_clear_pointer(&bundle, free_bundle);
 
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	res = check_bundle(replacebundle, &bundle, CHECK_BUNDLE_TRUST_ENV, &ierror);
+	res = check_bundle(replacebundle, &bundle, CHECK_BUNDLE_TRUST_ENV, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_clear_pointer(&bundle, free_bundle);
 
 	/* Test without verify */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-only-ca.pem");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_TRUST_ENV, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_TRUST_ENV, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
@@ -432,14 +432,14 @@ static void bundle_test_replace_signature(BundleFixture *fixture,
 	g_clear_pointer(&bundle, free_bundle);
 	g_clear_pointer(&sigpath, g_free);
 
-	res = check_bundle(replacebundle, &bundle, CHECK_BUNDLE_TRUST_ENV, &ierror);
+	res = check_bundle(replacebundle, &bundle, CHECK_BUNDLE_TRUST_ENV, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_pointer(&bundle, free_bundle);
 	g_clear_error(&ierror);
 	g_assert_false(res);
 
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	res = check_bundle(replacebundle, &bundle, CHECK_BUNDLE_TRUST_ENV, &ierror);
+	res = check_bundle(replacebundle, &bundle, CHECK_BUNDLE_TRUST_ENV, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
@@ -463,7 +463,7 @@ static void bundle_test_resign(BundleFixture *fixture,
 	 * the context's 'pending' flag which would cause a re-initialization
 	 * of context and thus overwrite content of 'config' member. */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
@@ -472,7 +472,7 @@ static void bundle_test_resign(BundleFixture *fixture,
 
 	/* Verify input bundle with 'dev' keyring */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-only-ca.pem");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
@@ -493,7 +493,7 @@ static void bundle_test_resign(BundleFixture *fixture,
 	 * installing development bundles as well as moving to production
 	 * bundles. */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/dev-only-ca.pem");
-	res = check_bundle(resignbundle, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(resignbundle, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
@@ -502,7 +502,7 @@ static void bundle_test_resign(BundleFixture *fixture,
 
 	/* Verify resigned bundle with rel keyring */
 	r_context()->config->keyring_path = g_strdup("test/openssl-ca/rel-ca.pem");
-	res = check_bundle(resignbundle, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(resignbundle, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
@@ -517,7 +517,7 @@ static void bundle_test_wrong_capath(BundleFixture *fixture,
 	g_autoptr(GError) ierror = NULL;
 	r_context()->config->keyring_path = g_strdup("does/not/exist.pem");
 
-	g_assert_false(check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror));
+	g_assert_false(check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror));
 	g_assert_null(bundle);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_CA_LOAD);
 
@@ -540,7 +540,7 @@ static void bundle_test_verify_no_crl_warn(BundleFixture *fixture,
 			"Reading bundle*");
 	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
 			"Detected CRL but CRL checking is disabled!");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -554,7 +554,7 @@ static void bundle_test_verify_revoked(BundleFixture *fixture,
 	g_autoptr(RaucBundle) bundle = NULL;
 	g_autoptr(GError) ierror = NULL;
 
-	g_assert_false(check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror));
+	g_assert_false(check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror));
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_assert_null(bundle);
 }
@@ -570,7 +570,7 @@ static void bundle_test_purpose_default(BundleFixture *fixture,
 
 	g_message("testing default purpose with default cert");
 	r_context()->config->keyring_check_purpose = NULL;
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -578,7 +578,7 @@ static void bundle_test_purpose_default(BundleFixture *fixture,
 
 	g_message("testing purpose 'smimesign' with default cert");
 	r_context()->config->keyring_check_purpose = g_strdup("smimesign");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -586,14 +586,14 @@ static void bundle_test_purpose_default(BundleFixture *fixture,
 
 	g_message("testing purpose 'codesign' with default cert");
 	r_context()->config->keyring_check_purpose = g_strdup("codesign");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
 
 	g_message("testing purpose 'any' with default cert");
 	r_context()->config->keyring_check_purpose = g_strdup("any");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -613,7 +613,7 @@ static void bundle_test_purpose_email(BundleFixture *fixture,
 
 	g_message("testing default purpose with 'smimesign' cert");
 	r_context()->config->keyring_check_purpose = NULL;
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -621,7 +621,7 @@ static void bundle_test_purpose_email(BundleFixture *fixture,
 
 	g_message("testing purpose 'smimesign' with 'smimesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("smimesign");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -629,7 +629,7 @@ static void bundle_test_purpose_email(BundleFixture *fixture,
 
 	g_message("testing purpose 'codesign' with 'smimesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("codesign");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
@@ -637,7 +637,7 @@ static void bundle_test_purpose_email(BundleFixture *fixture,
 
 	g_message("testing purpose 'any' with 'smimesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("any");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -657,7 +657,7 @@ static void bundle_test_purpose_codesign(BundleFixture *fixture,
 
 	g_message("testing default purpose with 'codesign' cert");
 	r_context()->config->keyring_check_purpose = NULL;
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
@@ -665,7 +665,7 @@ static void bundle_test_purpose_codesign(BundleFixture *fixture,
 
 	g_message("testing purpose 'smimesign' with 'codesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("smimesign");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
 	g_assert_false(res);
@@ -673,7 +673,7 @@ static void bundle_test_purpose_codesign(BundleFixture *fixture,
 
 	g_message("testing purpose 'codesign' with 'codesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("codesign");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);
@@ -681,7 +681,7 @@ static void bundle_test_purpose_codesign(BundleFixture *fixture,
 
 	g_message("testing purpose 'any' with 'codesign' cert");
 	r_context()->config->keyring_check_purpose = g_strdup("any");
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
+	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 	g_assert_nonnull(bundle);

--- a/test/nbd.c
+++ b/test/nbd.c
@@ -1,0 +1,449 @@
+#include <stdio.h>
+#include <locale.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+
+#include <bundle.h>
+#include <context.h>
+#include <manifest.h>
+#include <signature.h>
+#include <utils.h>
+#include <nbd.h>
+
+#include "common.h"
+
+typedef struct {
+	gchar *tmpdir;
+} NBDFixture;
+
+typedef struct {
+	const gchar *bundle_url;
+	RaucBundleAccessArgs access_args;
+
+	gboolean needs_backend;
+
+	GQuark err_domain;
+	gint err_code;
+} NBDData;
+
+static gboolean have_http_server(void)
+{
+	if (!g_getenv("RAUC_TEST_HTTP_SERVER")) {
+		g_test_message("no HTTP server for testing found (define RAUC_TEST_HTTP_SERVER)");
+		g_test_skip("RAUC_TEST_HTTP_SERVER undefined");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static void nbd_fixture_set_up(NBDFixture *fixture, gconstpointer user_data)
+{
+	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+	g_assert_nonnull(fixture->tmpdir);
+	g_print("tmpdir: %s\n", fixture->tmpdir);
+}
+
+static void nbd_fixture_tear_down(NBDFixture *fixture, gconstpointer user_data)
+{
+	g_assert_true(rm_tree(fixture->tmpdir, NULL));
+	g_free(fixture->tmpdir);
+
+	g_test_assert_expected_messages();
+}
+
+static void test_direct_read(NBDFixture *fixture, gconstpointer user_data)
+{
+	NBDData *data = (NBDData*)user_data;
+	g_autoptr(RaucNBDServer) nbd_srv = NULL;
+	g_autoptr(GError) ierror = NULL;
+	gboolean res = FALSE;
+	guint32 magic = 0;
+
+	if (!have_http_server())
+		return;
+
+	nbd_srv = r_nbd_new_server();
+	nbd_srv->url = g_strdup(data->bundle_url);
+	nbd_srv->tls_cert = g_strdup(data->access_args.tls_cert);
+	nbd_srv->tls_key = g_strdup(data->access_args.tls_key);
+	nbd_srv->tls_ca = g_strdup(data->access_args.tls_ca);
+	nbd_srv->tls_no_verify = data->access_args.tls_no_verify;
+	nbd_srv->headers = g_strdupv(data->access_args.http_headers);
+
+	res = r_nbd_start_server(nbd_srv, &ierror);
+	if (!data->err_domain) {
+		g_assert_no_error(ierror);
+		g_assert_true(res);
+	} else {
+		g_assert_error(ierror, data->err_domain, data->err_code);
+		g_assert_false(res);
+		return;
+	}
+
+	res = r_nbd_read(nbd_srv->sock, (guint8*)&magic, sizeof(magic), 0, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_cmphex(magic, ==, GUINT32_TO_LE(0x73717368));
+}
+
+static void test_check_invalid_bundle(NBDFixture *fixture, gconstpointer user_data)
+{
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
+	gboolean res = FALSE;
+
+	if (!have_http_server())
+		return;
+
+	res = check_bundle("http://127.0.0.1/test/invalid-sig-bundle.raucb", &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
+	g_assert_error(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_FORMAT);
+	g_assert_false(res);
+	g_assert_null(bundle);
+}
+
+static void test_check_not_found(NBDFixture *fixture, gconstpointer user_data)
+{
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
+	gboolean res = FALSE;
+
+	if (!have_http_server())
+		return;
+
+	res = check_bundle("http://127.0.0.1/test/missing-bundle.raucb", &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
+	g_assert_error(ierror, R_NBD_ERROR, R_NBD_ERROR_NOT_FOUND);
+	g_assert_false(res);
+	g_assert_null(bundle);
+}
+
+static void test_plain_bundle(NBDFixture *fixture, gconstpointer user_data)
+{
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
+	gboolean res = FALSE;
+
+	if (!have_http_server())
+		return;
+
+	res = check_bundle("http://127.0.0.1/test/good-bundle.raucb", &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
+	g_assert_error(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_FORMAT);
+	g_assert_false(res);
+	g_assert_null(bundle);
+}
+
+static void test_verity_bundle(NBDFixture *fixture, gconstpointer user_data)
+{
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
+	gboolean res = FALSE;
+
+	if (!have_http_server())
+		return;
+
+	res = check_bundle("http://127.0.0.1/test/good-verity-bundle.raucb", &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_nonnull(bundle);
+}
+
+static void test_extract(NBDFixture *fixture, gconstpointer user_data)
+{
+	g_autofree gchar *outputdir = NULL;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
+	gboolean res = FALSE;
+
+	if (!have_http_server())
+		return;
+
+	outputdir = g_build_filename(fixture->tmpdir, "output", NULL);
+	g_assert_nonnull(outputdir);
+
+	res = check_bundle("http://127.0.0.1/test/good-verity-bundle.raucb", &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_nonnull(bundle);
+
+	res = extract_bundle(bundle, outputdir, &ierror);
+	g_assert_error(ierror, R_BUNDLE_ERROR, R_BUNDLE_ERROR_UNSAFE);
+	g_assert_false(res);
+}
+
+static void test_nbd_mount(NBDFixture *fixture, gconstpointer user_data)
+{
+	NBDData *data = (NBDData*)user_data;
+	g_autoptr(RaucBundle) bundle = NULL;
+	g_autoptr(GError) ierror = NULL;
+	gboolean res = FALSE;
+
+	/* mount needs to run as root */
+	if (!test_running_as_root())
+		return;
+
+	if (!have_http_server())
+		return;
+
+	if (data->needs_backend) {
+		if (!g_getenv("RAUC_TEST_HTTP_BACKEND")) {
+			g_test_message("no aiohttp backend for testing found (define RAUC_TEST_HTTP_BACKEND)");
+			g_test_skip("RAUC_TEST_HTTP_BACKEND undefined");
+			return;
+		}
+	}
+
+	res = check_bundle(data->bundle_url, &bundle, CHECK_BUNDLE_DEFAULT, &data->access_args, &ierror);
+	if (!data->err_domain) {
+		g_assert_no_error(ierror);
+		g_assert_true(res);
+		g_assert_nonnull(bundle);
+	} else {
+		g_assert_error(ierror, data->err_domain, data->err_code);
+		g_assert_false(res);
+		g_assert_null(bundle);
+		return;
+	}
+
+	res = mount_bundle(bundle, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+
+	res = umount_bundle(bundle, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+}
+
+int main(int argc, char *argv[])
+{
+	const char * http_headers[2] = {NULL, NULL};
+	NBDData *nbd_data;
+	setlocale(LC_ALL, "C");
+
+	r_context_conf()->configpath = g_strdup("test/test.conf");
+	r_context();
+
+	g_test_init(&argc, &argv, NULL);
+
+	/* low level connect and read */
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "http://127.0.0.1/test/good-verity-bundle.raucb",
+	}));
+	g_test_add(g_strdup_printf("/nbd/direct_read/good"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_direct_read,
+			nbd_fixture_tear_down);
+
+	/* 404 handling */
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "http://127.0.0.1/error/404",
+		.err_domain = R_NBD_ERROR,
+		.err_code = R_NBD_ERROR_NOT_FOUND,
+	}));
+	g_test_add(g_strdup_printf("/nbd/direct_read/404"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_direct_read,
+			nbd_fixture_tear_down);
+
+	/* basic auth */
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "http://127.0.0.1/basic/test/good-verity-bundle.raucb",
+		.err_domain = R_NBD_ERROR,
+		.err_code = R_NBD_ERROR_UNAUTHORIZED,
+	}));
+	g_test_add(g_strdup_printf("/nbd/basic-auth/fail"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_direct_read,
+			nbd_fixture_tear_down);
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "http://rauc:rauctest@127.0.0.1/basic/test/good-verity-bundle.raucb",
+	}));
+	g_test_add(g_strdup_printf("/nbd/basic-auth/good-1"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_direct_read,
+			nbd_fixture_tear_down);
+	http_headers[0] = "Authorization: Basic cmF1YzpyYXVjdGVzdA==";
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "http://127.0.0.1/basic/test/good-verity-bundle.raucb",
+		.access_args = {
+		        .http_headers = memdup(http_headers),
+		},
+	}));
+	g_test_add(g_strdup_printf("/nbd/basic-auth/good-2"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_direct_read,
+			nbd_fixture_tear_down);
+
+	/* basic bundle handling */
+	g_test_add(g_strdup_printf("/nbd/check_invalid_bundle"),
+			NBDFixture, NULL,
+			nbd_fixture_set_up, test_check_invalid_bundle,
+			nbd_fixture_tear_down);
+
+	g_test_add(g_strdup_printf("/nbd/check_not_found"),
+			NBDFixture, NULL,
+			nbd_fixture_set_up, test_check_not_found,
+			nbd_fixture_tear_down);
+
+	g_test_add(g_strdup_printf("/nbd/plain_bundle"),
+			NBDFixture, NULL,
+			nbd_fixture_set_up, test_plain_bundle,
+			nbd_fixture_tear_down);
+
+	g_test_add(g_strdup_printf("/nbd/verity_bundle"),
+			NBDFixture, NULL,
+			nbd_fixture_set_up, test_verity_bundle,
+			nbd_fixture_tear_down);
+
+	g_test_add(g_strdup_printf("/nbd/check_extract"),
+			NBDFixture, NULL,
+			nbd_fixture_set_up, test_extract,
+			nbd_fixture_tear_down);
+
+	/* mount via HTTP */
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "http://127.0.0.1/test/good-verity-bundle.raucb",
+	}));
+	g_test_add(g_strdup_printf("/nbd/mount/http"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+
+	/* mount via HTTPS */
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "https://127.0.0.1/test/good-verity-bundle.raucb",
+		.err_domain = R_NBD_ERROR,
+		.err_code = R_NBD_ERROR_CONFIGURATION, /* missing CA cert */
+	}));
+	g_test_add(g_strdup_printf("/nbd/mount/https-bad-ca"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "https://127.0.0.1/test/good-verity-bundle.raucb",
+		.access_args = {
+		        .tls_no_verify = TRUE,
+		},
+	}));
+	g_test_add(g_strdup_printf("/nbd/mount/https-no-verify"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "https://127.0.0.1/test/good-verity-bundle.raucb",
+		.access_args = {
+		        .tls_ca = g_strdup("test/openssl-ca/web-ca.pem"),
+		},
+	}));
+	g_test_add(g_strdup_printf("/nbd/mount/https"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+
+	/* mount via HTTPS with HTTP/2 */
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "https://127.0.0.2/test/good-verity-bundle.raucb",
+		.access_args = {
+		        .tls_ca = g_strdup("test/openssl-ca/web-ca.pem"),
+		},
+	}));
+	g_test_add(g_strdup_printf("/nbd/mount/http2"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+
+	/* mount via HTTPS with client certificates checking */
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "https://127.0.0.3/test/good-verity-bundle.raucb",
+		.access_args = {
+		        .tls_cert = g_strdup("test/openssl-ca/web/client-1.cert.pem"),
+		        .tls_key = g_strdup("test/openssl-ca/web/private/client-1.pem"),
+		        .tls_ca = g_strdup("test/openssl-ca/web-ca.pem"),
+		},
+	}));
+	g_test_add(g_strdup_printf("/nbd/mount/client-cert/good"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+
+	/* 404 via HTTPS & client cert */
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "https://127.0.0.3/error/404",
+		.access_args = {
+		        .tls_cert = g_strdup("test/openssl-ca/web/client-1.cert.pem"),
+		        .tls_key = g_strdup("test/openssl-ca/web/private/client-1.pem"),
+		        .tls_ca = g_strdup("test/openssl-ca/web-ca.pem"),
+		},
+		.err_domain = R_NBD_ERROR,
+		.err_code = R_NBD_ERROR_NOT_FOUND,
+	}));
+	g_test_add(g_strdup_printf("/nbd/mount/client-cert/404"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+
+	/* HTTPS with missing client cert */
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "https://127.0.0.3/test/good-verity-bundle.raucb",
+		.access_args = {
+		        .tls_ca = g_strdup("test/openssl-ca/web-ca.pem"),
+		},
+		.err_domain = R_NBD_ERROR,
+		.err_code = R_NBD_ERROR_CONFIGURATION, /* missing client cert */
+	}));
+	g_test_add(g_strdup_printf("/nbd/mount/client-cert/unauth"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+
+	/* HTTP with sporadic errors */
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "http://127.0.0.1/backend/sporadic.raucb",
+		.needs_backend = TRUE,
+	}));
+	g_test_add(g_strdup_printf("/nbd/mount/http-sporadic-errors"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+
+	/* HTTP with cookie/token auth*/
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "http://127.0.0.1/backend/token.raucb",
+		.needs_backend = TRUE,
+		.err_domain = R_NBD_ERROR,
+		.err_code = R_NBD_ERROR_UNAUTHORIZED,
+	}));
+	g_test_add(g_strdup_printf("/nbd/token/missing"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+	http_headers[0] = "Cookie: token=wrong";
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "http://127.0.0.1/backend/token.raucb",
+		.access_args = {
+		        .http_headers = memdup(http_headers),
+		},
+		.needs_backend = TRUE,
+		.err_domain = R_NBD_ERROR,
+		.err_code = R_NBD_ERROR_UNAUTHORIZED,
+	}));
+	g_test_add(g_strdup_printf("/nbd/token/wrong"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+	http_headers[0] = "Cookie: token=secret";
+	nbd_data = memdup((&(NBDData) {
+		.bundle_url = "http://127.0.0.1/backend/token.raucb",
+		.needs_backend = TRUE,
+		.access_args = {
+		        .http_headers = memdup(http_headers),
+		},
+	}));
+	g_test_add(g_strdup_printf("/nbd/token/good"),
+			NBDFixture, nbd_data,
+			nbd_fixture_set_up, test_nbd_mount,
+			nbd_fixture_tear_down);
+
+	return g_test_run();
+}


### PR DESCRIPTION
This adds support `rauc install https://update-server.example/update.rauc` for verity format bundles without needing temporary space. Internally, it is based on mounting the bundle using NBD and a underprivileged helper process.

- [x] better configure.ac error handling
- [x] documentation
- [x] improved tests
- [x] release notes