### PR TITLE
src/main: add rauc mount command

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -670,6 +670,7 @@ Command Line Tool
     extract               Extract the bundle content
     install               Install a bundle
     info                  Show file information
+    mount                 Mount a bundle (for development purposes)
     service               Start RAUC service
     status                Show status
     write-slot            Write image to slot and bypass all update logic

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -627,6 +627,40 @@ It may also be worth starting the RAUC service via command line on a second
 shell to have a live view of what is going on when you invoke e.g. ``rauc
 install`` on the first shell.
 
+Inspecting Bundle Contents
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes during development, it is useful to check whether the bundle contents
+are as expected.
+While RAUC bundles could just be mounted as a squashfs, using ``rauc mount``
+also uses the same checks and mechanisms as ``rauc install``
+(device-mapper/loopback & network support).
+The bundle is mounted below the configured mount prefix (``/mnt/rauc/bundle`` by
+default).
+When you are done, just use ``umount <mount point>`` to unmount the bundle.
+
+.. code-block:: sh
+
+  $ rauc mount /var/tmp/test/good-verity-bundle.raucb
+  rauc-Message: 12:37:36.869: Reading bundle: /var/tmp/test/good-verity-bundle.raucb
+  rauc-Message: 12:37:36.889: Verifying bundle signature...
+  rauc-Message: 12:37:36.894: Verified inline signature by 'O = Test Org, CN = Test Org Release-1'
+  rauc-Message: 12:37:36.896: Mounting bundle '/var/tmp/test/good-verity-bundle.raucb' to '/mnt/rauc/bundle'
+  rauc-Message: 12:37:36.931: Configured loop device '/dev/loop0' for 24576 bytes
+  rauc-Message: 12:37:36.934: Configured dm-verity device '/dev/dm-0'
+  Mounted bundle at /mnt/rauc/bundle. Use 'umount /mnt/rauc/bundle' to unmount.
+  $ ls -l /mnt/rauc/bundle
+  total 21
+  -rw-r--r-- 1 root root 8192 Jun 21 14:51 appfs.img
+  -rwxr-xr-x 1 root root 2241 Sep 15  2017 custom_handler.sh
+  -rwxr-xr-x 1 root root 1421 Aug 31  2017 hook.sh
+  -rw-r--r-- 1 root root  308 Jun 21 14:51 manifest.raucm
+  -rw-r--r-- 1 root root 8192 Jun 21 14:51 rootfs.img
+  $ umount /mnt/rauc/bundle
+
+.. note::
+  This command is only intended for use during development.
+
 Increasing Debug Verbosity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -600,7 +600,7 @@ In each case it is quite essential to know that RAUC, if not compiled with
 ``--disable-service`` runs as a service on your target that is either
 controlled by your custom application or by the RAUC command line interface.
 
-The frontend will always only show the 'high level' error outpt, e.g. when an
+The frontend will always only show the 'high level' error output, e.g. when an
 installation failed:
 
 .. code-block:: sh

--- a/rauc.1
+++ b/rauc.1
@@ -23,6 +23,9 @@ rauc \- safe and secure updating
 [\fIOPTIONS\fR...] \fBinfo\fR \fIBUNDLE\fR
 
 .B rauc
+[\fIOPTIONS\fR...] \fBmount\fR \fIBUNDLE\fR
+
+.B rauc
 [\fIOPTIONS\fR...] \fBstatus\fR [\fISLOTNAME\fR | \fBmark-\fR{\fBgood\fR,\fBbad\fR,\fBactive\fR} [\fBbooted\fR|\fBother\fR|\fISLOTNAME\fR]]
 
 .B rauc
@@ -72,7 +75,7 @@ intermediate CA file name
 
 .TP
 \fB\-\-mount=\fR\fIPATH\fR
-mount prefix
+mount prefix (/mnt/rauc by default)
 
 .TP
 \fB\-\-override\-boot\-slot=\fR\fIBOOTNAME\fR
@@ -208,6 +211,16 @@ select output format
 .TP
 \fB\-\-dump\-cert\fR
 dump certificate
+
+
+.RE
+.RE
+.PP
+\fBmount\fR \fIBUNDLE\fR
+
+.RS 4
+Mount a bundle for development purposes to the bundle directory in RAUC's mount
+prefix. It must be unmounted manually by the user.
 
 .RE
 .RE

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -307,6 +307,19 @@ test_expect_success PKCS11 "rauc bundle with PKCS11 (key mismatch)" "
     bundle $SHARNESS_TEST_DIRECTORY/install-content ${TEST_TMPDIR}/out.raucb
 "
 
+test_expect_success ROOT "rauc mount" "
+  test ! -f /mnt/rauc/bundle/manifest.raucm &&
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&
+  test_when_finished umount /mnt/rauc/bundle &&
+  ls ${TEST_TMPDIR} &&
+  rauc --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+    mount ${TEST_TMPDIR}/good-bundle.raucb &&
+  mount &&
+  test -f /mnt/rauc/bundle/manifest.raucm &&
+  test -f /mnt/rauc/bundle/rootfs.img
+"
+
 test_expect_success SERVICE "rauc service double-init failure" "
   start_rauc_dbus_service \
     --conf=${SHARNESS_TEST_DIRECTORY}/test.conf \


### PR DESCRIPTION
This allows easy inspection of bundle contents. As this uses squashfs in the
kernel (as `rauc install` does), this also doesn't allow --no-verify.