### PR TITLE
docs: explicit max-bundle-download-size in bytes

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -153,7 +153,7 @@ Example configuration:
 ``max-bundle-download-size``
   Defines the maximum downloadable bundle size in bytes, and thus must be
   a simple integer value (without unit) greater than zero.
-  It overwrites the compiled-in default value of 8 MiB.
+  It overwrites the compiled-in default value of 8388608 (8 MiB).
 
 ``variant-name``
   String to be used as variant name for this board.


### PR DESCRIPTION
The max-bundle-download-size value must be specified in bytes, without
unit. Specifying its default value in MiB might be confusing to some,
thus specify the actual value being used (8*1024*1024).

Signed-off-by: Vivien Didelot <vdidelot@pbsc.com>