### PR TITLE
src/bundle: Allow bundle to be stored on ramfs filesystem

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1114,7 +1114,6 @@ static gboolean check_bundle_access(int bundle_fd, GError **error)
 			case JFFS2_SUPER_MAGIC:
 			case MSDOS_SUPER_MAGIC:
 			case NTFS_SB_MAGIC:
-			case RAMFS_MAGIC:
 			case ROMFS_MAGIC:
 			case SQUASHFS_MAGIC:
 			case UDF_SUPER_MAGIC:
@@ -1123,6 +1122,7 @@ static gboolean check_bundle_access(int bundle_fd, GError **error)
 			/* these are prepared by root */
 			case HOSTFS_SUPER_MAGIC:
 			case OVERLAYFS_SUPER_MAGIC:
+			case RAMFS_MAGIC:
 			case TMPFS_MAGIC:
 			case UBIFS_SUPER_MAGIC:
 			case ZFS_SUPER_MAGIC:


### PR DESCRIPTION
If the bundle being checked by `check_bundle_access()` is stored on a
filesystem of type 'ramfs' it will fail with the error message "unable
to find mounted device for bundle".  Fix it by treating the 'ramfs'
filesystem type the same as 'tmpfs' ("prepared by root" so no need to
check the underlying device, which does not exist anyway).

Signed-off-by: Ian Abbott <abbotti@mev.co.uk>