### PR TITLE
docs: add CONFIG_CRYPTO_SHA256=y requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,8 +147,12 @@ Target Prerequisites
 
 Required kernel options:
 
+-  ``CONFIG_MD=y``
+-  ``CONFIG_BLK_DEV_DM=y``
 -  ``CONFIG_BLK_DEV_LOOP=y``
+-  ``CONFIG_DM_VERITY=y``
 -  ``CONFIG_SQUASHFS=y``
+-  ``CONFIG_CRYPTO_SHA256=y``
 
 For using tar archive in RAUC bundles with Busybox tar, you have to enable the
 following Busybox feature:

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -191,12 +191,18 @@ In kernel Kconfig you have to enable the following options:
   CONFIG_BLK_DEV_LOOP=y
   CONFIG_DM_VERITY=y
   CONFIG_SQUASHFS=y
+  CONFIG_CRYPTO_SHA256=y
 
 .. note::
    These drivers may also be loaded as modules. Kernel versions v5.0 to v5.7
    will require the patch ``7e81f99afd91c937f0e66dc135e26c1c4f78b003``
    backporting to fix a bug where the bundles cannot be mounted in a small
    number of cases.
+
+.. note::
+   On ARM SoCs, there are optimized alternative SHA256 implementations
+   available (for example ``CONFIG_CRYPTO_SHA2_ARM_CE``, ``CRYPTO_SHA256_ARM``
+   or hardware accellerators such as ``CONFIG_CRYPTO_DEV_FSL_CAAM_AHASH_API``).
 
 .. _sec_ref_host_tools:
 


### PR DESCRIPTION
For verity bundles, we use SHA256, so the kernel implementation is required.
