### PR TITLE
src/main: allow passing 'no-verify' to rauc convert

### DIFF
--- a/rauc.1
+++ b/rauc.1
@@ -157,6 +157,10 @@ Convert an existing bundle to casync index bundle and store.
 .RS 4
 
 .TP
+\fB\-\-no\-verify\fR
+disable bundle verification
+
+.TP
 \fB\-\-signing\-keyring=\fR\fIPEMFILE\fR
 verification keyring file
 

--- a/src/main.c
+++ b/src/main.c
@@ -638,7 +638,7 @@ static gboolean convert_start(int argc, char **argv)
 	g_debug("input bundle: %s", argv[2]);
 	g_debug("output bundle: %s", argv[3]);
 
-	if (!check_bundle(argv[2], &bundle, TRUE, &ierror)) {
+	if (!check_bundle(argv[2], &bundle, !verification_disabled, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -1792,6 +1792,7 @@ static GOptionEntry entries_resign[] = {
 };
 
 static GOptionEntry entries_convert[] = {
+	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
 	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
 	{"mksquashfs-args", '\0', 0, G_OPTION_ARG_STRING, &mksquashfs_args, "mksquashfs extra args", "ARGS"},
 	{"casync-args", '\0', 0, G_OPTION_ARG_STRING, &casync_args, "casync extra args", "ARGS"},


### PR DESCRIPTION
This option allows to disable the verification of the input bundle (and thus omitting --keyring argument) when converting a conventional to a casync-based bundle.

However, this is not recommended as signature checks are there for a reason of course.

But, as we also already allow this for similar subcommands like ('info' or 'resign') and should give the responsible user the freedom to 'know what he's doing', we enable this for convert, too.

Another quite relevant point where this can be used as a workaround is when being inside an environment (e.g. a docker container) where the standard RAUC bundle access check mechanisms must fail) and trigger errors like

> initial check_bundle_access failed with: unable to find mounted device for bundle

This happens when RAUC attempts to find the underlying device of the mountpoint the bundle is located at but cannot as the device is hidden by the container.

Addresses: #679, #688