### PR TITLE
src: introduce --trust-environment option for 'rauc convert'

### DIFF
--- a/include/bundle.h
+++ b/include/bundle.h
@@ -47,6 +47,11 @@ typedef enum {
 	                                          // checking the validity period of
 	                                          // certificates and CRLs against
 	                                          // the current time.
+	CHECK_BUNDLE_TRUST_ENV     = BIT(3),      // If set, the runtime environment
+	                                          // is fully trusted and no attempts
+	                                          // will be made to protect against
+	                                          // concurrent modification of the
+	                                          // bundle.
 } CheckBundleParams;
 
 /**

--- a/rauc.1
+++ b/rauc.1
@@ -173,6 +173,10 @@ Convert an existing bundle to casync index bundle and store.
 .RS 4
 
 .TP
+\fB\-\-trust\-environment\fR
+trust environment and skip bundle access checks
+
+.TP
 \fB\-\-no\-verify\fR
 disable bundle verification
 

--- a/rauc.1
+++ b/rauc.1
@@ -173,6 +173,10 @@ Convert an existing bundle to casync index bundle and store.
 .RS 4
 
 .TP
+\fB\-\-no\-verify\fR
+disable bundle verification
+
+.TP
 \fB\-\-signing\-keyring=\fR\fIPEMFILE\fR
 verification keyring file
 

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1509,6 +1509,7 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleP
 			ibundle->payload_verified = TRUE;
 		} else {
 			int fd = g_file_descriptor_based_get_fd(G_FILE_DESCRIPTOR_BASED(ibundle->stream));
+			gboolean trust_env = (params & CHECK_BUNDLE_TRUST_ENV);
 
 			if (!(r_context()->config->bundle_formats_mask & 1 << R_MANIFEST_FORMAT_VERITY)) {
 				g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_FORMAT,
@@ -1517,7 +1518,7 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleP
 				goto out;
 			}
 
-			if (!check_bundle_access(fd, &ierror)) {
+			if (!trust_env && !check_bundle_access(fd, &ierror)) {
 				ibundle->exclusive_check_error = g_strdup(ierror->message);
 				g_clear_error(&ierror);
 			} else {

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@ GMainLoop *r_loop = NULL;
 int r_exit_status = 0;
 
 gboolean install_ignore_compatible, install_progressbar = FALSE;
+gboolean trust_environment = FALSE;
 gboolean verification_disabled = FALSE;
 gboolean no_check_time = FALSE;
 gboolean info_dumpcert = FALSE;
@@ -648,6 +649,8 @@ static gboolean convert_start(int argc, char **argv)
 
 	if (verification_disabled)
 		check_bundle_params |= CHECK_BUNDLE_NO_VERIFY;
+	if (trust_environment)
+		check_bundle_params |= CHECK_BUNDLE_TRUST_ENV;
 
 	if (!check_bundle(argv[2], &bundle, check_bundle_params, &ierror)) {
 		g_printerr("%s\n", ierror->message);
@@ -1814,6 +1817,7 @@ static GOptionEntry entries_resign[] = {
 };
 
 static GOptionEntry entries_convert[] = {
+	{"trust-environment", '\0', 0, G_OPTION_ARG_NONE, &trust_environment, "trust environment and skip bundle access checks", NULL},
 	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
 	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
 	{"mksquashfs-args", '\0', 0, G_OPTION_ARG_STRING, &mksquashfs_args, "mksquashfs extra args", "ARGS"},

--- a/src/main.c
+++ b/src/main.c
@@ -613,6 +613,7 @@ out:
 G_GNUC_UNUSED
 static gboolean convert_start(int argc, char **argv)
 {
+	CheckBundleParams check_bundle_params = CHECK_BUNDLE_DEFAULT;
 	RaucBundle *bundle = NULL;
 	GError *ierror = NULL;
 	g_debug("convert start");
@@ -645,7 +646,10 @@ static gboolean convert_start(int argc, char **argv)
 	g_debug("input bundle: %s", argv[2]);
 	g_debug("output bundle: %s", argv[3]);
 
-	if (!check_bundle(argv[2], &bundle, CHECK_BUNDLE_DEFAULT, &ierror)) {
+	if (verification_disabled)
+		check_bundle_params |= CHECK_BUNDLE_NO_VERIFY;
+
+	if (!check_bundle(argv[2], &bundle, check_bundle_params, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -1810,6 +1814,7 @@ static GOptionEntry entries_resign[] = {
 };
 
 static GOptionEntry entries_convert[] = {
+	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
 	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
 	{"mksquashfs-args", '\0', 0, G_OPTION_ARG_STRING, &mksquashfs_args, "mksquashfs extra args", "ARGS"},
 	{"casync-args", '\0', 0, G_OPTION_ARG_STRING, &casync_args, "casync extra args", "ARGS"},


### PR DESCRIPTION
In some cases it might not be possible or wanted that RAUC (used as a host tool) performs its standard bundle access checks.

For example when running 'rauc convert' from within a (docker) container, RAUC might not be able to get the underlying device of the bundle's storage location. This way it cannot determine if the mount point is owend by root and will abort with

> initial check_bundle_access failed with: unable to find mounted device for bundle

While --no-verify potentially already works around this, it is a too big hammer for most cases where you actually want to benefit from the usual signature verificaton of the input bundle and just get stopped by the exclusiv access check.

Not the --trust-environment option allows to tell RAUC that we assume we have our environmet we run RAUC in under control and it can skip the exclusive access checks.

Fixes #679, #688

Note: bases on #769