### PR TITLE
docs/reference: Fix U-Boot variable

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1241,18 +1241,18 @@ U-Boot
 ~~~~~~
 
 The U-Boot implementation assumes to have variables `BOOT_ORDER` and
-`BOOT_x_ATTEMPTS` handled by the bootloader scripting.
+`BOOT_x_LEFT` handled by the bootloader scripting.
 
 :state bad:
-  Sets the `BOOT_x_ATTEMPTS` variable of the slot to `0` and removes it from
+  Sets the `BOOT_x_LEFT` variable of the slot to `0` and removes it from
   the `BOOT_ORDER` list
 
 :state good:
-  Sets the `BOOT_x_ATTEMPTS` variable back to its default value (`3`).
+  Sets the `BOOT_x_LEFT` variable back to its default value (`3`).
 
 :primary:
   Moves the slot from its current position in the list in `BOOT_ORDER` to the
-  first place and sets `BOOT_x_ATTEMPTS` to its initial value (`3`).
+  first place and sets `BOOT_x_LEFT` to its initial value (`3`).
   If BOOT_ORDER was unset before, it generates a new list of all slots known to
   RAUC with the one to activate at the first position.
 


### PR DESCRIPTION
The bootchooser code and the contrib u-boot script both use
'BOOT_x_LEFT' since implemented in 9760752217c1 ("bootchooser: add
support for uboot via fw_setenv"), which was even before the
documentation on this was added.

Fixes: 631cfb38b8bc ("docs: reference: add section about bootloader interface")
Signed-off-by: Alexander Dahl <ada@thorsis.com>