### PR TITLE
RFC: Support alternative ubi rootfs format

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -369,10 +369,13 @@ RAUC supports parsing different variants for giving these device as listed below
 
 Giving the plain device name is supported, of course.
 
-.. note::
+::
 
-  The alternative ubi rootfs format with ``root=ubi0:volname`` is currently
-  unsupported.
+  root=ubi0:volname
+
+The alternative ubi rootfs format with ``ubi0:volname`` is supported.
+The volume ID and like it the plain device path is dependent on volume creation order.
+RAUC converts the value to the actual device path by resolving it through sysfs.
 
 ::
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -185,6 +185,7 @@ G_GNUC_WARN_UNUSED_RESULT;
  * - PARTLABEL=mylabel -> /dev/disk/by-partlabel/mylabel
  * - PARTUUID=4f8bb419-01 -> /dev/disk/by-partuuid/4f8bb419-01
  * - UUID=9e8b0c3e-e20f-4119-b419-ec20a132aa94 -> /dev/disk/by-uuid/9e8b0c3e-e20f-4119-b419-ec20a132aa94
+ * - ubi0:rootfs1 -> /dev/ubi0_3
  *
  * @param dev "device" string
  *

--- a/include/utils.h
+++ b/include/utils.h
@@ -191,3 +191,25 @@ G_GNUC_WARN_UNUSED_RESULT;
  * @return Resolved device part (newly allocated string) or NULL in case of an error.
  */
 gchar *r_resolve_device(const gchar *dev);
+
+/**
+ * Parse UBI device name string the same way the kernel does and return
+ * sysfs path of that volume.
+ *
+ * Those names are used in kernel cmdline for mounting rootfs, e.g. like
+ * 'root=ubi0:volname', possible names are:
+ *
+ * - ubiX_Y	UBI device number X, volume Y
+ * - ubiY	UBI device number 0, volume Y
+ * - ubiX:NAME	UBI device X, volume with name NAME
+ * - ubi:NAME	UBI device 0, volume with name NAME
+ *
+ * The kernel allows '!' as an alternative separator instead of ':'
+ * (because some shells like busybox may interpret ':' as an NFS host
+ * name separator).
+ *
+ * @param name string, one of format "ubiX_Y", "ubiY", "ubiX:NAME", "ubi:NAME".
+ *
+ * @return sysfs path like "/sys/class/ubi/ubiX/ubiX_Y" (newly-allocated string) or NULL.
+ */
+gchar *r_ubi_name_to_sysfs_path(const gchar *name);

--- a/include/utils.h
+++ b/include/utils.h
@@ -177,3 +177,17 @@ guint8 *r_hex_decode(const gchar *hex, size_t len)
 G_GNUC_WARN_UNUSED_RESULT;
 gchar *r_hex_encode(const guint8 *raw, size_t len)
 G_GNUC_WARN_UNUSED_RESULT;
+
+/**
+ * Take the value of a root= cmdline argument and resolve it to a
+ * device path, for example:
+ *
+ * - PARTLABEL=mylabel -> /dev/disk/by-partlabel/mylabel
+ * - PARTUUID=4f8bb419-01 -> /dev/disk/by-partuuid/4f8bb419-01
+ * - UUID=9e8b0c3e-e20f-4119-b419-ec20a132aa94 -> /dev/disk/by-uuid/9e8b0c3e-e20f-4119-b419-ec20a132aa94
+ *
+ * @param dev "device" string
+ *
+ * @return Resolved device part (newly allocated string) or NULL in case of an error.
+ */
+gchar *r_resolve_device(const gchar *dev);

--- a/src/context.c
+++ b/src/context.c
@@ -29,6 +29,7 @@ static const gchar* get_cmdline_bootname(void)
 	g_autofree gchar *contents = NULL;
 	g_autofree gchar *realdev = NULL;
 	const char *bootname = NULL;
+	gchar *devpath = NULL;
 
 	if (context->mock.proc_cmdline)
 		contents = g_strdup(context->mock.proc_cmdline);
@@ -59,37 +60,10 @@ static const gchar* get_cmdline_bootname(void)
 	if (!bootname)
 		return NULL;
 
-	if (strncmp(bootname, "PARTLABEL=", 10) == 0) {
-		gchar *partlabelpath = g_build_filename(
-				"/dev/disk/by-partlabel/",
-				&bootname[10],
-				NULL);
-		if (partlabelpath) {
-			g_free((gchar*) bootname);
-			bootname = partlabelpath;
-		}
-	}
-
-	if (strncmp(bootname, "PARTUUID=", 9) == 0) {
-		gchar *partuuidpath = g_build_filename(
-				"/dev/disk/by-partuuid/",
-				&bootname[9],
-				NULL);
-		if (partuuidpath) {
-			g_free((gchar*) bootname);
-			bootname = partuuidpath;
-		}
-	}
-
-	if (strncmp(bootname, "UUID=", 5) == 0) {
-		gchar *uuidpath = g_build_filename(
-				"/dev/disk/by-uuid/",
-				&bootname[5],
-				NULL);
-		if (uuidpath) {
-			g_free((gchar*) bootname);
-			bootname = uuidpath;
-		}
+	devpath = r_resolve_device(bootname);
+	if (devpath) {
+		g_free((gchar*) bootname);
+		bootname = devpath;
 	}
 
 	realdev = r_realpath(bootname);

--- a/src/utils.c
+++ b/src/utils.c
@@ -340,3 +340,24 @@ gchar *r_hex_encode(const guint8 *raw, size_t len)
 
 	return hex;
 }
+
+gchar *r_resolve_device(const gchar *dev)
+{
+	gchar *idev = NULL;
+
+	if (!dev)
+		return NULL;
+
+	if (strncmp(dev, "PARTLABEL=", 10) == 0) {
+		idev = g_build_filename("/dev/disk/by-partlabel/",
+				&dev[10], NULL);
+	} else if (strncmp(dev, "PARTUUID=", 9) == 0) {
+		idev = g_build_filename("/dev/disk/by-partuuid/",
+				&dev[9], NULL);
+	} else if (strncmp(dev, "UUID=", 5) == 0) {
+		idev = g_build_filename("/dev/disk/by-uuid/",
+				&dev[5], NULL);
+	}
+
+	return idev;
+}

--- a/test/utils.c
+++ b/test/utils.c
@@ -23,6 +23,38 @@ static void resolve_device_test(void)
 	g_free(rdev);
 }
 
+static void ubi_name_to_sysfs_path_test(void)
+{
+	gchar *spath;
+
+	g_assert_null(r_ubi_name_to_sysfs_path(NULL));
+
+	/* too short */
+	g_assert_null(r_ubi_name_to_sysfs_path("ubi"));
+
+	/* simply wrong */
+	g_assert_null(r_ubi_name_to_sysfs_path("/dev/sda7"));
+
+	/* "ubi" followed by no separator and no digit */
+	g_assert_null(r_ubi_name_to_sysfs_path("ubiY"));
+
+	/* "ubiY" */
+	spath = r_ubi_name_to_sysfs_path("ubi3");
+	g_assert_cmpstr(spath, ==, "/sys/class/ubi/ubi0/ubi0_3");
+	g_free(spath);
+
+	/* "ubiX_Y" */
+	spath = r_ubi_name_to_sysfs_path("ubi1_2");
+	g_assert_cmpstr(spath, ==, "/sys/class/ubi/ubi1/ubi1_2");
+	g_free(spath);
+
+	/* "ubiX_" followed by non numeric garbage */
+	g_assert_null(r_ubi_name_to_sysfs_path("ubi0_Y"));
+
+	/* Missing more bad cases and NAME resolving, the latter would
+	 * need either a reproducible test setup or mocking. */
+}
+
 static void whitespace_removed_test(void)
 {
 	gchar *str;
@@ -60,6 +92,7 @@ int main(int argc, char *argv[])
 	g_test_init(&argc, &argv, NULL);
 
 	g_test_add_func("/utils/resolve_device", resolve_device_test);
+	g_test_add_func("/utils/ubi_name_to_sysfs_path", ubi_name_to_sysfs_path_test);
 	g_test_add_func("/utils/whitespace_removed", whitespace_removed_test);
 
 	return g_test_run();

--- a/test/utils.c
+++ b/test/utils.c
@@ -3,6 +3,26 @@
 
 #include "utils.h"
 
+static void resolve_device_test(void)
+{
+	gchar *rdev;
+
+	g_assert_null(r_resolve_device(NULL));
+
+	rdev = r_resolve_device("PARTLABEL=mylabel");
+	g_assert_cmpstr(rdev, ==, "/dev/disk/by-partlabel/mylabel");
+	g_free(rdev);
+
+	rdev = r_resolve_device("PARTUUID=4f8bb419-01");
+	g_assert_cmpstr(rdev, ==, "/dev/disk/by-partuuid/4f8bb419-01");
+	g_free(rdev);
+
+	rdev = r_resolve_device("UUID=9e8b0c3e-e20f-4119-b419-ec20a132aa94");
+	g_assert_cmpstr(rdev, ==,
+			"/dev/disk/by-uuid/9e8b0c3e-e20f-4119-b419-ec20a132aa94");
+	g_free(rdev);
+}
+
 static void whitespace_removed_test(void)
 {
 	gchar *str;
@@ -39,6 +59,7 @@ int main(int argc, char *argv[])
 
 	g_test_init(&argc, &argv, NULL);
 
+	g_test_add_func("/utils/resolve_device", resolve_device_test);
 	g_test_add_func("/utils/whitespace_removed", whitespace_removed_test);
 
 	return g_test_run();


### PR DESCRIPTION
The documentation currently has this note in section *6.6.1.1. Identification via Kernel Commandline*:

> The alternative ubi rootfs format with `root=ubi0:volname` is currently unsupported.

This patch series tries to solve that issue by resolving that format through sysfs poking for both cmdline parameter detection and configuration file parsing.

Expected issues:

- lack of tests (mostly because it would need a system with actual ubi device and ubifs volumes, and I don't know how to provide that)
- few logging or error code passing in case of errors (returns NULL in error cases)
- support of `device=UUID=…` in config file completely untested and maybe not without side effects