### PR TITLE
src/update_handler: support verity to raw

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1900,6 +1900,7 @@ RaucUpdatePair updatepairs[] = {
 	{"*.ext4", "raw", img_to_raw_handler},
 	{"*.vfat", "raw", img_to_raw_handler},
 	{"*.squashfs", "raw", img_to_raw_handler},
+	{"*.verity", "raw", img_to_raw_handler},
 	{"*.vfat", "vfat", img_to_fs_handler},
 	{"*.tar*", "ext4", archive_to_ext4_handler},
 	{"*.catar", "ext4", archive_to_ext4_handler},


### PR DESCRIPTION
The Yocto meta-security layer can produce dm-verity images, which will
be created using the .verity extension. Add support to write verity
images to raw slots.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>