### PR TITLE
main: Add hint on sub-command specific help

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1909,6 +1909,9 @@ static void cmdline_handler(int argc, char **argv)
 	g_option_context_set_ignore_unknown_options(context, TRUE);
 	g_option_context_add_main_entries(context, entries, NULL);
 	g_option_context_set_description(context,
+			"Command-specific help:\n"
+			"  rauc <COMMAND> --help\n"
+			"\n"
 			"List of rauc commands:\n"
 #if ENABLE_CREATE == 1
 			"  bundle\t\tCreate a bundle\n"


### PR DESCRIPTION
You can get extra help e.g. on command specific options like this:

  rauc --help install

This shows you '--ignore-compatible' for example, which is not listed in
generic help if you call `rauc --help` only.

Guide the user to this sub-command related help texts to avoid at least
some support requests.

Signed-off-by: Alexander Dahl <ada@thorsis.com>