### PR TITLE
Only allow the root step to report 100% progress

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -396,6 +396,11 @@ static void r_context_send_progress(gboolean op_finished, gboolean success)
 		iter = g_list_next(iter);
 	}
 
+	/* This step is not 100% itself, so it must not be the root step even though the
+	   previous steps sum to 100. Max out the percentage at 99% in that case. */
+	if (step->percent_done < 100.0f && percentage > 99.0f)
+		percentage = 99.0f;
+
 	g_assert_cmpint(percentage, <=, 100);
 
 	/* call installer callback with percentage and message */

--- a/test/service.c
+++ b/test/service.c
@@ -191,8 +191,8 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  90, "Checking slot appfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  95, "Checking slot appfs.1 done.", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  95, "Copying image to appfs.1", 3));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)", 100, "Copying image to appfs.1 done.", 3));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)", 100, "Updating slots done.", 2));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  99, "Copying image to appfs.1 done.", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  99, "Updating slots done.", 2));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)", 100, "Installing done.", 1));
 
 	installer = r_installer_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,


### PR DESCRIPTION
Later install steps were showing 100% due to the way
sub-step percentages were being summed. Fixed by only
allowing the root install step to report 100% progress.
In the case where other steps want to report 100%, they
are reduced to 99% instead to avoid confusion.

Fixes: #711
Signed-off-by: Steven Rau <steven.rau@vecima.com>