### PR TITLE
fix: Add missing XML definition of arguments direction for Install and InstallBundle methods

### DIFF
--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -8,7 +8,7 @@
          Triggers an installation.
     -->
     <method name="Install">
-      <arg name="source" type="s"/>
+      <arg name="source" type="s" direction="in"/>
     </method>
 
     <!--
@@ -19,7 +19,7 @@
          Triggers an installation.
     -->
     <method name="InstallBundle">
-      <arg name="source" type="s"/>
+      <arg name="source" type="s" direction="in"/>
       <arg name="args" type="a{sv}" direction="in"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
     </method>


### PR DESCRIPTION
Added missing definition of direction for source argument in Install and InstallBundle dbus methods. It helps  sdbus-c++ to generate correct stubs. For example:

Before:
```cpp
    void Install()
    {
        proxy_.callMethod("Install").onInterface(INTERFACE_NAME);
    }

    void InstallBundle(const std::map<std::string, sdbus::Variant>& args)
    {
        proxy_.callMethod("InstallBundle").onInterface(INTERFACE_NAME).withArguments(args);
    }
```
After: 
```cpp
    void Install(const std::string& source)
    {
        proxy_.callMethod("Install").onInterface(INTERFACE_NAME).withArguments(source);
    }

    void InstallBundle(const std::string& source, const std::map<std::string, sdbus::Variant>& args)
    {
        proxy_.callMethod("InstallBundle").onInterface(INTERFACE_NAME).withArguments(source, args);
    }
```
