### PR TITLE
qemu-test: remove trailing comma from nandsim.parts commandline parameter

### DIFF
--- a/qemu-test
+++ b/qemu-test
@@ -79,6 +79,6 @@ qemu-system-x86_64 \
   -no-reboot \
   -virtfs local,id=rootfs,path=/,security_model=none,mount_tag=/dev/root \
   -nic user,model=virtio-net-pci \
-  -append "loglevel=6 console=ttyS0 nandsim.id_bytes=0x20,0xa2,0x00,0x15 nandsim.parts=0x100, mtdram.total_size=32768 root=/dev/root rootfstype=9p rw init=$(pwd)/qemu-test-init rauc.slot=$BOOTNAME $*"
+  -append "loglevel=6 console=ttyS0 nandsim.id_bytes=0x20,0xa2,0x00,0x15 nandsim.parts=0x100 mtdram.total_size=32768 root=/dev/root rootfstype=9p rw init=$(pwd)/qemu-test-init rauc.slot=$BOOTNAME $*"
 
 test -f qemu-test-ok


### PR DESCRIPTION
`nandsim.parts` parameter is a comma-separated array, but should not be terminated with a comma.
Otherwise kernel option parser will ignore the parameter with:

    Booting kernel: `0x100' invalid for parameter `nandsim.parts'

However, this is not critical as 0x100 is equal to the default partition size erase.

Fixes 318640ca ("qemu-test: add setup to test MTD and block devices")

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>