### PR TITLE
src/context: don't warn about trailing new line in variant file

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -193,14 +193,23 @@ static gchar* get_variant_from_file(const gchar* filename, GError **error)
 {
 	gchar *contents = NULL;
 	GError *ierror = NULL;
+	gsize length;
 
 	g_return_val_if_fail(filename, NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
-	if (!g_file_get_contents(filename, &contents, NULL, &ierror)) {
+	if (!g_file_get_contents(filename, &contents, &length, &ierror)) {
 		g_propagate_error(error, ierror);
 		return NULL;
 	}
+
+	/*
+	 * We'll discard surrounding whitespace later anyway, but as it's
+	 * customary for UNIX files to have a trailing new line, we chomp
+	 * it off here to avoid a runtime warning.
+	 */
+	if (length && contents[length - 1] == '\n')
+		contents[length - 1] = '\0';
 
 	return contents;
 }


### PR DESCRIPTION
Since 60fc2722a820 ("src/context: remove surrounding whitespace from
system variant"), RAUC will warn when it strips away the whitespace.

It's customary however for UNIX files to have a trailing new line,
so skip the warning if that's the only trailing whitespace.