### PR TITLE
src/network: fix max bundle size not always being checked

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -99,6 +99,7 @@ static gboolean transfer(RaucTransfer *xfer, GError **error)
 	//curl_easy_setopt(curl,  CURLOPT_LOW_SPEED_TIME, 60L);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, xfer);
+	curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0); /* allow XFERINFOFUNCTION callbacks */
 	curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, xfer_cb);
 	curl_easy_setopt(curl, CURLOPT_XFERINFODATA, xfer);
 	curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);


### PR DESCRIPTION
When the download size is not known before the transfer, we check the
transferred size in the `XFERINFOFUNCTION` callback. This function is
only called when the `NOPROGRESS` option is set to 0. Do that now.

Signed-off-by: Christoph Steiger <c.steiger@lemonage.de>