### PR TITLE
Fix coverity warning in install.c

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -259,8 +259,8 @@ section for more details.
    :target: https://github.com/rauc/rauc/actions?query=workflow%3Atests
 .. |Codecov_branch| image:: https://codecov.io/gh/rauc/rauc/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/rauc/rauc
-.. |Coverity| image:: https://scan.coverity.com/projects/5085/badge.svg
-   :target: https://scan.coverity.com/projects/5085
+.. |Coverity| image:: https://scan.coverity.com/projects/22299/badge.svg
+   :target: https://scan.coverity.com/projects/22299
 .. |Documentation| image:: https://readthedocs.org/projects/rauc/badge/?version=latest
    :target: http://rauc.readthedocs.org/en/latest/?badge=latest
 .. |Matrix| image:: https://img.shields.io/matrix/rauc:matrix.org?label=matrix%20chat

--- a/src/install.c
+++ b/src/install.c
@@ -744,9 +744,16 @@ static gboolean pre_install_checks(gchar* bundledir, GList *install_images, GHas
 		RaucImage *mfimage = l->data;
 		RaucSlot *dest_slot = g_hash_table_lookup(target_group, mfimage->slotclass);
 
-		/* skip source image checks if filename is not set (install hook) */
-		if (!mfimage->filename && mfimage->hooks.install)
-			goto skip_filename_checks;
+		if (!mfimage->filename) {
+			/* having no filename is valid for install hook only */
+			if (mfimage->hooks.install)
+				goto skip_filename_checks;
+			else
+				/* Should not be reached as the pre-conditions for optional 'filename' are already
+				 * checked during manifest parsing in manifest.c: parse_image() */
+				g_assert_not_reached();
+		}
+
 
 		/* if image filename is relative, make it absolute */
 		if (!g_path_is_absolute(mfimage->filename)) {


### PR DESCRIPTION
src/install: assert not expanding unset manifest filename

During manifest file parsing, we ensure that filename is set and allow an unset filename only for an install hook.
Thus having filename unset after checking this conditition is a programming error here. Check it with `g_assert_nonnull()`.

Fixes coverity warning:

> CID 1465767 (#1 of 1): Dereference after null check (FORWARD_NULL)
> 20. var_deref_model: Passing null pointer mfimage->filename to g_file_test, which dereferences it.

Fixes 8a9c9213 which added this check:

``` patch
+               /* skip source image checks if filename is not set (install hook) */
+               if (!mfimage->filename && mfimage->hooks.install)
+                       goto skip_filename_checks;
+
```

that lets coverity assume we explicitly pass here in case of `mfimage->filename` being null:

> 17. var_compare_op: Comparing mfimage->filename to null implies that mfimage->filename might be null.