### PR TITLE
Emit fine grained progress to dbus for most update handlers

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1117,22 +1117,70 @@ out:
 	return res;
 }
 
+struct suffix_tar_flag {
+	const char *suffix;
+	const char *tar_flag;
+};
+
+static struct suffix_tar_flag suffixes[] = {
+	{"tar",		NULL},
+	{"gz",		"-z"},
+	{"tgz",		"-z"},
+	{"taz",		"-z"},
+	{"Z",		"-Z"},
+	{"taZ",		"-Z"},
+	{"bz2",		"-j"},
+	{"tbz",		"-j"},
+	{"tbz2",	"-j"},
+	{"tz2",		"-j"},
+	{"lz",		"--lzip"},
+	{"lzma",	"--lzma"},
+	{"tlz",		"--lzma"},
+	{"lzo",		"--lzop"},
+	{"xz",		"-J"},
+	{"txz",		"-J"},
+	{"zst",		"--zstd"},
+	{"tzst",	"--zstd"},
+	{NULL,		NULL}
+};
+
+static const gchar *suffix_to_tar_flag(const gchar *filename)
+{
+	for (int i = 0; suffixes[i].suffix != NULL; i++) {
+		if (g_str_has_suffix(filename, suffixes[i].suffix))
+			return suffixes[i].tar_flag;
+	}
+
+	return NULL;
+}
+
 static gboolean untar_image(RaucImage *image, gchar *dest, GError **error)
 {
 	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(5, g_free);
+	g_autoptr(GFile) image_file;
+	g_autoptr(GFileInfo) image_info;
+	goffset image_size;
+	GFileInputStream *image_stream;
+	GOutputStream *tar_stream;
+	guint8 buffer[4096];
+	gssize in_size = 1;
+	gsize out_size, sum_size = 0;
+	gboolean ret = TRUE;
+	gint last_percent = -1, percent;
 
 	g_ptr_array_add(args, g_strdup("tar"));
 	g_ptr_array_add(args, g_strdup("xf"));
-	g_ptr_array_add(args, g_strdup(image->filename));
+	g_ptr_array_add(args, g_strdup("-"));
 	g_ptr_array_add(args, g_strdup("-C"));
 	g_ptr_array_add(args, g_strdup(dest));
 	g_ptr_array_add(args, g_strdup("--numeric-owner"));
+	g_ptr_array_add(args, g_strdup(suffix_to_tar_flag(image->filename)));
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
+	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_STDIN_PIPE, &ierror);
 	if (sproc == NULL) {
 		g_propagate_prefixed_error(
 				error,
@@ -1141,15 +1189,85 @@ static gboolean untar_image(RaucImage *image, gchar *dest, GError **error)
 		goto out;
 	}
 
+	tar_stream = g_subprocess_get_stdin_pipe(sproc);
+	if (tar_stream == NULL) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed to open tar stdin: ");
+		goto out;
+	}
+
+	image_file = g_file_new_for_path(image->filename);
+	image_info = g_file_query_info(image_file,
+			G_FILE_ATTRIBUTE_STANDARD_SIZE,
+			G_FILE_QUERY_INFO_NONE,
+			NULL,
+			&ierror);
+	if (image_info == NULL) {
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
+	image_size = g_file_info_get_size(image_info);
+	image_stream = g_file_read(image_file, NULL, &ierror);
+	if (image_stream == NULL) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed to read image file for tar extracting");
+		goto out_image_stream;
+	}
+
+	while ((in_size > 0) && ret) {
+		in_size = g_input_stream_read(G_INPUT_STREAM(image_stream),
+				buffer, 4096, NULL, &ierror);
+		ret = g_output_stream_write_all(tar_stream, buffer,
+				in_size, &out_size, NULL, &ierror);
+		sum_size += out_size;
+		percent = sum_size * 100 / image_size;
+		if (percent != last_percent) {
+			last_percent = percent;
+			r_context_set_step_percentage("copy_image", percent);
+		}
+	}
+
+	if ((in_size < 0) || ret == FALSE) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed delivering data to tar: ");
+		goto out_image_stream;
+	}
+
+	if (g_output_stream_close(tar_stream, NULL, &ierror) != TRUE) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed closing pipe to tar: ");
+		goto out_image_stream;
+	}
+
+	if (g_input_stream_close(G_INPUT_STREAM(image_stream), NULL,
+				&ierror) != TRUE) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"failed closing image file: ");
+		goto out_image_stream;
+	}
+
 	res = g_subprocess_wait_check(sproc, NULL, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
 				ierror,
 				"failed to run tar extract: ");
-		goto out;
+		goto out_image_stream;
 	}
 
+out_image_stream:
+	g_object_unref(image_stream);
 out:
 	return res;
 }

--- a/test/boot_raw_fallback.c
+++ b/test/boot_raw_fallback.c
@@ -263,8 +263,12 @@ static void test_boot_raw_fallback(BootRawFallbackFixture *fixture,
 		}
 	}
 
+	r_context_begin_step("test_parent", "Test step dummy parent", 1);
+	r_context_begin_step_formatted("copy_image", 0, "Copying image to %s", targetslot->name);
 	/* Run to perform an update */
 	res = handler(image, targetslot, hookpath, &ierror);
+	r_context_end_step("copy_image", TRUE);
+	r_context_end_step("test_parent", TRUE);
 
 	if (data->options & OPT_EXPECT_FAIL) {
 		g_assert_error(ierror, data->err_domain, data->err_code);

--- a/test/boot_switch.c
+++ b/test/boot_switch.c
@@ -360,8 +360,12 @@ static void test_boot_switch(BootSwitchFixture *fixture,
 	g_assert_no_error(ierror);
 	g_assert_nonnull(handler);
 
+	r_context_begin_step("test_parent", "Test step dummy parent", 1);
+	r_context_begin_step_formatted("copy_image", 0, "Copying image to %s", targetslot->name);
 	/* Run to perform an update */
 	res = handler(image, targetslot, hookpath, &ierror);
+	r_context_end_step("copy_image", TRUE);
+	r_context_end_step("test_parent", TRUE);
 
 	if (data->params & BOOT_SWITCH_EXPECT_FAIL) {
 		g_assert_error(ierror, data->err_domain, data->err_code);

--- a/test/service.c
+++ b/test/service.c
@@ -187,10 +187,18 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  80, "Checking slot rootfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  85, "Checking slot rootfs.1 done.", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  85, "Copying image to rootfs.1", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  86, "Copying image to rootfs.1", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  87, "Copying image to rootfs.1", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  88, "Copying image to rootfs.1", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  89, "Copying image to rootfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  90, "Copying image to rootfs.1 done.", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  90, "Checking slot appfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  95, "Checking slot appfs.1 done.", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  95, "Copying image to appfs.1", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  96, "Copying image to appfs.1", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  97, "Copying image to appfs.1", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  98, "Copying image to appfs.1", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  99, "Copying image to appfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  99, "Copying image to appfs.1 done.", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  99, "Updating slots done.", 2));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)", 100, "Installing done.", 1));

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -429,11 +429,15 @@ no_image:
 	g_assert_no_error(ierror);
 	g_assert_nonnull(handler);
 
+	r_context_begin_step("test_parent", "Test step dummy parent", 1);
+	r_context_begin_step_formatted("copy_image", 0, "Copying image to %s", targetslot->name);
 	/* Run to perform an update */
 	r_test_stats_start();
 	res = handler(image, targetslot, hookpath, &ierror);
 	r_test_stats_stop();
 
+	r_context_end_step("copy_image", TRUE);
+	r_context_end_step("test_parent", TRUE);
 	if (test_pair->params & TEST_UPDATE_HANDLER_EXPECT_FAIL) {
 		g_assert_error(ierror, test_pair->err_domain, test_pair->err_code);
 		g_assert_false(res);
@@ -581,7 +585,7 @@ int main(int argc, char *argv[])
 		{"ext4", "tar.bz2", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
 		{"raw", "ext4", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
 
-		{"ext4", "tar.bz2", TEST_UPDATE_HANDLER_NO_IMAGE_FILE | TEST_UPDATE_HANDLER_EXPECT_FAIL, G_SPAWN_EXIT_ERROR, 2},
+		{"ext4", "tar.bz2", TEST_UPDATE_HANDLER_NO_IMAGE_FILE | TEST_UPDATE_HANDLER_EXPECT_FAIL, G_IO_ERROR, G_IO_ERROR_NOT_FOUND},
 		{"raw", "img", TEST_UPDATE_HANDLER_NO_IMAGE_FILE | TEST_UPDATE_HANDLER_EXPECT_FAIL, G_IO_ERROR, G_IO_ERROR_NOT_FOUND},
 		{"raw", "ext4", TEST_UPDATE_HANDLER_NO_IMAGE_FILE | TEST_UPDATE_HANDLER_EXPECT_FAIL, G_IO_ERROR, G_IO_ERROR_NOT_FOUND},
 		{"ext4", "ext4", TEST_UPDATE_HANDLER_NO_IMAGE_FILE | TEST_UPDATE_HANDLER_EXPECT_FAIL, G_IO_ERROR, G_IO_ERROR_NOT_FOUND},
@@ -626,7 +630,7 @@ int main(int argc, char *argv[])
 		/* vfat tests */
 		{"vfat", "tar.bz2", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
 		{"vfat", "tar.bz2", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
-		{"vfat", "tar.bz2", TEST_UPDATE_HANDLER_NO_IMAGE_FILE | TEST_UPDATE_HANDLER_EXPECT_FAIL, G_SPAWN_EXIT_ERROR, 2},
+		{"vfat", "tar.bz2", TEST_UPDATE_HANDLER_NO_IMAGE_FILE | TEST_UPDATE_HANDLER_EXPECT_FAIL, G_IO_ERROR, G_IO_ERROR_NOT_FOUND},
 		{"vfat", "tar.bz2", TEST_UPDATE_HANDLER_NO_TARGET_DEV | TEST_UPDATE_HANDLER_EXPECT_FAIL, G_SPAWN_EXIT_ERROR, 1},
 		{"vfat", "tar.bz2", TEST_UPDATE_HANDLER_HOOKS | TEST_UPDATE_HANDLER_PRE_HOOK, 0, 0},
 		{"vfat", "tar.bz2", TEST_UPDATE_HANDLER_HOOKS | TEST_UPDATE_HANDLER_POST_HOOK, 0, 0},

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -137,7 +137,7 @@ static void update_handler_fixture_tear_down(UpdateHandlerFixture *fixture,
 	g_assert(test_rmdir(fixture->tmpdir, "") == 0);
 }
 
-static gboolean tar_image(const gchar *dest, const gchar *dir, GError **error)
+static gboolean tar_bz2_image(const gchar *dest, const gchar *dir, GError **error)
 {
 	GSubprocess *sproc = NULL;
 	GError *ierror = NULL;
@@ -145,7 +145,7 @@ static gboolean tar_image(const gchar *dest, const gchar *dir, GError **error)
 	GPtrArray *args = g_ptr_array_new_full(5, g_free);
 
 	g_ptr_array_add(args, g_strdup("tar"));
-	g_ptr_array_add(args, g_strdup("cf"));
+	g_ptr_array_add(args, g_strdup("cjf"));
 	g_ptr_array_add(args, g_strdup(dest));
 	g_ptr_array_add(args, g_strdup("-C"));
 	g_ptr_array_add(args, g_strdup(dir));
@@ -238,7 +238,7 @@ static gboolean test_prepare_dummy_archive(const gchar *path, const gchar *archn
 			FILE_SIZE, "/dev/zero") == 0);
 
 	/* tar file to pseudo image */
-	res = tar_image(archpath, contentpath, &ierror);
+	res = tar_bz2_image(archpath, contentpath, &ierror);
 	if (!res) {
 		g_warning("%s", ierror->message);
 		goto out;


### PR DESCRIPTION
This emits progess through dbus for most update handlers.
The PR begins with add this to only on `untar_image` but then inserts the developed code into more functions. In the end most handlers are covered and should emit a more fine grained progress for them.
As I see it these handlers should now be covered:
* `img_to_fs_handler`
* `img_to_raw_handler`
* `img_to_ubivol_handler`
* `img_to_ubifs_handler`
* `archive_to_ext4_handler`
* `archive_to_ubifs_handler`
* `archive_to_vfat_handler`
* `img_to_nand_handler`

I also tried on `img_to_nor_handler` but it uses `flashcp` and `flashcp` can not read from stdin.
Progress is emitted for the 'main work' that is copying files to the destination slot only. It does not emit progress for other things that happen like filesystem creation.

Dear reviewer, please be kind to me. I never used glib before. glib is really hard for me. Thank you!