### PR TITLE
.github: workflows: move 'distcheck' to separate workflow

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -1,0 +1,37 @@
+name: distcheck
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Inspect environment
+      run: |
+        whoami
+        gcc --version
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install automake libtool libglib2.0-dev libcurl3-dev libssl-dev libdbus-1-dev libjson-glib-dev libfdisk-dev libnl-genl-3-dev dbus-x11
+
+    - uses: actions/checkout@v2
+
+    - name: Run autogen.sh
+      run: |
+        ./autogen.sh
+        ./configure
+
+    - name: Run distcheck
+      run: |
+        sudo make -j4 distcheck
+
+    - name: Show system status and logs
+      if: ${{ failure() }}
+      run: |
+        sudo dmesg | tail -n 100
+        mount || true
+        losetup || true
+        cat config.log || true
+        cat rauc-*/_build/sub/test-suite.log || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,10 +48,6 @@ jobs:
       run: |
         make doc SPHINXOPTS=-W
 
-    - name: Run distcheck
-      run: |
-        make -j4 distcheck
-
     - name: Build CGI example
       run: |
         cd contrib/cgi


### PR DESCRIPTION
Currently, the 'tests' workflow fails almost every time because the 'Run
distcheck' step triggers a test failure.

The underlying failure is not RAUC-specific and related to loodev mount
and cache handling.

Details can be found in https://github.com/rauc/rauc/issues/790

As fixing this issue is not straight forward and the relevance for
real-world scenarios is hardly given, a workaround needs to be
established.

Tests showed, that the distcheck loop mount failure is not triggered (or
significantly less often) when running directly in the GitHub action runner vm
instance (rather than in the rauc testing container).

This commit thus moves the error-prone distcheck from the 'tests'
workflow to a separate 'distcheck' workflow.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>