### PR TITLE
Initial desync support

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -303,6 +303,10 @@ For more information about using the casync support of RAUC, refer to
   By default, the temporary directory is left unset by RAUC and casync uses its
   internal default value ``/var/tmp``.
 
+``use-desync=<true/false>``
+  If this boolean value is set to ``true``, RAUC will use desync instead of
+  casync. Desync support is still experimental, use with caution.
+
 **[autoinstall] section**
 
 The auto-install feature allows to configure a path that will be checked upon

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -283,6 +283,11 @@ The ``casync`` section contains casync-related settings.
 For more information about using the casync support of RAUC, refer to
 :ref:`casync-support`.
 
+``install-args``
+  Allows to specify additional arguments that will be passed to casync when
+  installing an update. For example it can be used to include additional
+  seeds or stores.
+
 ``storepath``
   Allows to set the path to use as chunk store path for casync to a fixed one.
   This is useful if your chunk store is on a dedicated server and will be the

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -50,6 +50,7 @@ typedef struct {
 	gchar *mount_prefix;
 	gchar *store_path;
 	gchar *tmp_path;
+	gchar *casync_install_args;
 	gboolean activate_installed;
 	gchar *statusfile_path;
 	gchar *keyring_path;

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -51,6 +51,7 @@ typedef struct {
 	gchar *store_path;
 	gchar *tmp_path;
 	gchar *casync_install_args;
+	gboolean use_desync;
 	gboolean activate_installed;
 	gchar *statusfile_path;
 	gchar *keyring_path;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -462,6 +462,17 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	c->store_path = key_file_consume_string(key_file, "casync", "storepath", NULL);
 	c->tmp_path = key_file_consume_string(key_file, "casync", "tmppath", NULL);
 	c->casync_install_args = key_file_consume_string(key_file, "casync", "install-args", NULL);
+	c->use_desync = g_key_file_get_boolean(key_file, "casync", "use-desync", &ierror);
+	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND) ||
+	    g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_GROUP_NOT_FOUND)) {
+		c->use_desync = FALSE;
+		g_clear_error(&ierror);
+	} else if (ierror) {
+		g_propagate_error(error, ierror);
+		res = FALSE;
+		goto free;
+	}
+	g_key_file_remove_key(key_file, "casync", "use-desync", NULL);
 	if (!check_remaining_keys(key_file, "casync", &ierror)) {
 		g_propagate_error(error, ierror);
 		res = FALSE;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -461,6 +461,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	/* parse [casync] section */
 	c->store_path = key_file_consume_string(key_file, "casync", "storepath", NULL);
 	c->tmp_path = key_file_consume_string(key_file, "casync", "tmppath", NULL);
+	c->casync_install_args = key_file_consume_string(key_file, "casync", "install-args", NULL);
 	if (!check_remaining_keys(key_file, "casync", &ierror)) {
 		g_propagate_error(error, ierror);
 		res = FALSE;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -237,7 +237,11 @@ static gboolean casync_extract(RaucImage *image, gchar *dest, int out_fd, const 
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(5, g_free);
 
-	g_ptr_array_add(args, g_strdup("casync"));
+	if (r_context()->config->use_desync)
+		g_ptr_array_add(args, g_strdup("desync"));
+	else
+		g_ptr_array_add(args, g_strdup("casync"));
+
 	g_ptr_array_add(args, g_strdup("extract"));
 	if (seed) {
 		g_ptr_array_add(args, g_strdup("--seed"));
@@ -247,7 +251,10 @@ static gboolean casync_extract(RaucImage *image, gchar *dest, int out_fd, const 
 		g_ptr_array_add(args, g_strdup("--store"));
 		g_ptr_array_add(args, g_strdup(store));
 	}
-	g_ptr_array_add(args, g_strdup("--seed-output=no"));
+	/* Desync doesn't have the --seed-output option */
+	if (!r_context()->config->use_desync)
+		g_ptr_array_add(args, g_strdup("--seed-output=no"));
+
 	if (r_context()->config->casync_install_args != NULL) {
 		gboolean parse_res = FALSE;
 		parse_res = g_shell_parse_argv(r_context()->config->casync_install_args, NULL, &casync_argvp, &ierror);
@@ -272,6 +279,10 @@ static gboolean casync_extract(RaucImage *image, gchar *dest, int out_fd, const 
 		g_subprocess_launcher_take_stdout_fd(launcher, out_fd);
 	if (tmpdir)
 		g_subprocess_launcher_setenv(launcher, "TMPDIR", tmpdir, TRUE);
+
+	/* Enable Desync parsable progress updates */
+	if (r_context()->config->use_desync)
+		g_subprocess_launcher_setenv(launcher, "DESYNC_ENABLE_PARSABLE_PROGRESS", "1", TRUE);
 
 	sproc = r_subprocess_launcher_spawnv(launcher, args, &ierror);
 	if (sproc == NULL) {
@@ -324,6 +335,11 @@ static gboolean casync_extract_image(RaucImage *image, gchar *dest, int out_fd, 
 	gchar *store = NULL;
 	gchar *tmpdir = NULL;
 	gboolean seed_mounted = FALSE;
+
+	if (r_context()->config->use_desync) {
+		/* TODO: do something clever to locate and/or generate the seed index file */
+		goto extract;
+	}
 
 	/* Prepare Seed */
 	seedslot = get_active_slot_class_member(image->slotclass);

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -68,6 +68,7 @@ path=/etc/rauc/keyring/\n\
 [casync]\n\
 storepath=/var/lib/default.castr/\n\
 tmppath=/tmp/\n\
+install-args=--verbose\n\
 \n\
 [slot.rescue.0]\n\
 description=Rescue partition\n\
@@ -120,6 +121,9 @@ install-same=false\n";
 	g_assert_cmpstr(config->statusfile_path, ==, "/mnt/persistent-rw-fs/system.raucs");
 	g_assert_cmpint(config->max_bundle_download_size, ==, 42);
 	g_assert_cmphex(config->bundle_formats_mask, ==, 0x2);
+	g_assert_cmpstr(config->store_path, ==, "/var/lib/default.castr/");
+	g_assert_cmpstr(config->tmp_path, ==, "/tmp/");
+	g_assert_cmpstr(config->casync_install_args, ==, "--verbose");
 
 	g_assert_nonnull(config->slots);
 	slotlist = g_hash_table_get_keys(config->slots);

--- a/test/minimal-desync-test.conf
+++ b/test/minimal-desync-test.conf
@@ -1,0 +1,10 @@
+# testsuite system configuration
+
+[system]
+compatible=Test Config
+bootloader=grub
+grubenv=grubenv.test
+variant-name=Default Variant
+
+[casync]
+use-desync=true

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -144,6 +144,10 @@ grep -q "ENABLE_STREAMING 1" $SHARNESS_TEST_DIRECTORY/../config.h &&
 casync --version &&
   test_set_prereq CASYNC
 
+# Prerequisite: desync available [DESYNC]
+desync --help &&
+  test_set_prereq DESYNC
+
 # Prerequisite: softhsm2 installed [PKCS11]
 test -f ${SOFTHSM2_MOD} &&
   prepare_softhsm2 &&
@@ -714,6 +718,60 @@ test_expect_success CASYNC "rauc convert casync extra args" "
     --casync-args=\"--chunk-size=64000\" \
     ${TEST_TMPDIR}/good-bundle.raucb casync-extra-args.raucb &&
   test -f casync-extra-args.raucb
+"
+
+test_expect_success DESYNC "rauc convert with desync" "
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&
+  rm -f desync.raucb &&
+  rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+    --conf $SHARNESS_TEST_DIRECTORY/minimal-desync-test.conf \
+    convert ${TEST_TMPDIR}/good-bundle.raucb desync.raucb &&
+  test -f desync.raucb
+"
+
+test_expect_success DESYNC "rauc convert with desync (output exists)" "
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&
+  touch desync.raucb &&
+  test_must_fail rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+    --conf $SHARNESS_TEST_DIRECTORY/minimal-desync-test.conf \
+    convert ${TEST_TMPDIR}/good-bundle.raucb desync.raucb &&
+  test -f desync.raucb
+"
+
+test_expect_success DESYNC "rauc convert with desync (error)" "
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&
+  rm -f desync.raucb &&
+  test_must_fail rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-2018.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-2018.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
+    --conf $SHARNESS_TEST_DIRECTORY/minimal-desync-test.conf \
+    convert ${TEST_TMPDIR}/good-bundle.raucb desync.raucb &&
+  test ! -f desync.raucb
+"
+
+test_expect_success DESYNC "rauc convert desync extra args" "
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&
+  rm -f desync-extra-args.raucb &&
+  rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+    --conf $SHARNESS_TEST_DIRECTORY/minimal-desync-test.conf \
+    convert \
+    --casync-args=\"--chunk-size=32:128:512\" \
+    ${TEST_TMPDIR}/good-bundle.raucb desync-extra-args.raucb &&
+  test -f desync-extra-args.raucb
 "
 
 test_expect_success "rauc resign" "


### PR DESCRIPTION
This PR partially addresses #748 and adds an initial optional support for Desync.

I updated the Debian base version of `test/Dockerfile` to the latest stable release because Desync needs at least Go 1.14 and the old-stable (buster) has Go 1.11 (with the 1.15 in buster-backports).
This change is a pre-requisite for Desync and can be merged separately, if preferred.

While Desync is mostly a drop-in replacement of Casync, some of its launch options are different.
The most notable change is that Desync expects a seed in the form of `.caibx`. This probably requires some additional thinking/discussion to decide what's the best way to handle that (where do we look for this `.caibx`? If it is not available, should we regenerate it on the fly?)

For this reason I left out the seed for now to try keeping this PR as simple as possible so that we would have an initial Desync support that could be use right away (and experiment with the additional `install-args`).

EDIT: with the latest commit revision I enabled the new Desync `DESYNC_ENABLE_PARSABLE_PROGRESS` environment variable so that Desync will print in output its progress percentage and estimated remaining time.