### PR TITLE
README.rst: testing: remove instruction to run make check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,6 @@ Running the Test Suite
     sudo apt-get install qemu-system-x86 time squashfs-tools
     # Optional to run all tests:
     # sudo apt-get install faketime casync grub-common softhsm2 opensc opensc-pkcs11 libengine-pkcs11-openssl mtd-utils
-    make check
     ./qemu-test
 
 Creating a Bundle (Host)


### PR DESCRIPTION
Some parts of the test suite require root access and access block devices, so
it should be avoided to run it on the host system directly. We therefore remove
that instruction from the README.

Signed-off-by: Holger Assmann <h.assmann@pengutronix.de>