### PR TITLE
fix unused variables and a missing field initializer

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1487,7 +1487,6 @@ static gboolean custom_backend_set(const gchar *cmd, const gchar *bootname, cons
 {
 	g_autoptr(GSubprocess) sub = NULL;
 	GError *ierror = NULL;
-	g_autoptr(GBytes) stdout_buf = NULL;
 	gchar *backend_name = r_context()->config->custom_bootloader_backend;
 
 	g_return_val_if_fail(cmd, FALSE);

--- a/src/service.c
+++ b/src/service.c
@@ -127,7 +127,6 @@ static gboolean r_on_handle_info(RInstaller *interface,
 		GDBusMethodInvocation  *invocation,
 		const gchar *arg_bundle)
 {
-	g_autofree gchar* tmpdir = NULL;
 	g_autoptr(RaucManifest) manifest = NULL;
 	g_autoptr(RaucBundle) bundle = NULL;
 	GError *error = NULL;

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -421,7 +421,7 @@ int main(int argc, char *argv[])
 
 		{"raw", "img", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
 		{"ext4", "img", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
-		{"ext4", "tar.bz2", TEST_UPDATE_HANDLER_DEFAULT, 0},
+		{"ext4", "tar.bz2", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
 		{"raw", "ext4", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
 
 		{"ext4", "tar.bz2", TEST_UPDATE_HANDLER_NO_IMAGE_FILE | TEST_UPDATE_HANDLER_EXPECT_FAIL, G_SPAWN_EXIT_ERROR, 2},


### PR DESCRIPTION
These are harmless, but are reported by clang/ccls.