### PR TITLE
src/service: add missing line break in g_printerr() call

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -550,7 +550,7 @@ gboolean r_service_run(void)
 	                    ? G_BUS_TYPE_SESSION : G_BUS_TYPE_SYSTEM;
 
 	if (!r_context_configure(&ierror)) {
-		g_printerr("Failed to initialize context: %s", ierror->message);
+		g_printerr("Failed to initialize context: %s\n", ierror->message);
 		g_clear_error(&ierror);
 		return FALSE;
 	}


### PR DESCRIPTION
`g_printerr()` does not add a line break itself, thus we should add it in the message string.

Fixes: 88ace592 ("src: make r_context_configure() public to allow calling explicitly")

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>