### PR TITLE
Fixes for context setup and error handling

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -232,8 +232,17 @@ gboolean r_context_configure(GError **error)
 			return FALSE;
 		}
 	} else {
-		/* This is a hack as we cannot get rid of config easily */
-		default_config(&context->config);
+		/* Fallback: Always try loading config from default path */
+		if (load_config("/etc/rauc/system.conf", &context->config, &ierror)) {
+			g_message("valid system config found, using it");
+		} else {
+			if (ierror->domain != G_FILE_ERROR) {
+				g_propagate_prefixed_error(error, ierror, "Failed to load system config (/etc/rauc/system.conf): ");
+				return FALSE;
+			}
+			/* This is a hack as we cannot get rid of config easily */
+			default_config(&context->config);
+		}
 	}
 
 	if (context->config->system_variant_type == R_CONFIG_SYS_VARIANT_DTB) {

--- a/src/main.c
+++ b/src/main.c
@@ -220,6 +220,13 @@ static gboolean install_start(int argc, char **argv)
 		}
 	}
 
+	if (!r_context_configure(&error)) {
+		g_printerr("Failed to initialize context: %s\n", error->message);
+		g_clear_error(&error);
+		r_exit_status = 1;
+		goto out;
+	}
+
 	if (argc < 3) {
 		g_printerr("A bundle filename name must be provided\n");
 		goto out;
@@ -323,6 +330,13 @@ static gboolean bundle_start(int argc, char **argv)
 	g_autofree gchar *outdir = NULL;
 	g_debug("bundle start");
 
+	if (!r_context_configure(&ierror)) {
+		g_printerr("Failed to initialize context: %s\n", ierror->message);
+		g_clear_error(&ierror);
+		r_exit_status = 1;
+		goto out;
+	}
+
 	if (argc < 3) {
 		g_printerr("An input directory name must be provided\n");
 		r_exit_status = 1;
@@ -394,6 +408,13 @@ static gboolean write_slot_start(int argc, char **argv)
 	img_to_slot_handler update_handler = NULL;
 
 	g_debug("write_slot_start");
+
+	if (!r_context_configure(&ierror)) {
+		g_printerr("Failed to initialize context: %s\n", ierror->message);
+		g_clear_error(&ierror);
+		r_exit_status = 1;
+		goto out;
+	}
 
 	if (argc < 3) {
 		g_printerr("A target slot name must be provided\n");
@@ -479,6 +500,13 @@ static gboolean resign_start(int argc, char **argv)
 	GError *ierror = NULL;
 	g_debug("resign start");
 
+	if (!r_context_configure(&ierror)) {
+		g_printerr("Failed to initialize context: %s\n", ierror->message);
+		g_clear_error(&ierror);
+		r_exit_status = 1;
+		goto out;
+	}
+
 	if (argc < 3) {
 		g_printerr("An input bundle must be provided\n");
 		r_exit_status = 1;
@@ -534,6 +562,13 @@ static gboolean replace_signature_start(int argc, char **argv)
 	RaucBundle *bundle = NULL;
 	GError *ierror = NULL;
 	g_debug("replace signature start");
+
+	if (!r_context_configure(&ierror)) {
+		g_printerr("Failed to initialize context: %s\n", ierror->message);
+		g_clear_error(&ierror);
+		r_exit_status = 1;
+		goto out;
+	}
 
 	if (argc < 3) {
 		g_printerr("An input bundle must be provided\n");
@@ -592,6 +627,13 @@ static gboolean extract_signature_start(int argc, char **argv)
 	GError *ierror = NULL;
 	g_debug("extract signature start");
 
+	if (!r_context_configure(&ierror)) {
+		g_printerr("Failed to initialize context: %s\n", ierror->message);
+		g_clear_error(&ierror);
+		r_exit_status = 1;
+		goto out;
+	}
+
 	if (argc < 3) {
 		g_printerr("An input bundle must be provided\n");
 		r_exit_status = 1;
@@ -636,6 +678,13 @@ static gboolean extract_start(int argc, char **argv)
 	RaucBundle *bundle = NULL;
 	GError *ierror = NULL;
 	g_debug("extract start");
+
+	if (!r_context_configure(&ierror)) {
+		g_printerr("Failed to initialize context: %s\n", ierror->message);
+		g_clear_error(&ierror);
+		r_exit_status = 1;
+		goto out;
+	}
 
 	if (argc < 3) {
 		g_printerr("An input bundle must be provided\n");
@@ -683,6 +732,13 @@ static gboolean convert_start(int argc, char **argv)
 	RaucBundle *bundle = NULL;
 	GError *ierror = NULL;
 	g_debug("convert start");
+
+	if (!r_context_configure(&ierror)) {
+		g_printerr("Failed to initialize context: %s\n", ierror->message);
+		g_clear_error(&ierror);
+		r_exit_status = 1;
+		goto out;
+	}
 
 	if (r_context()->certpath == NULL ||
 	    r_context()->keypath == NULL) {
@@ -988,6 +1044,13 @@ static gboolean info_start(int argc, char **argv)
 	gchar* (*formatter)(RaucManifest *manifest) = NULL;
 	gchar *text;
 	CheckBundleParams check_bundle_params = CHECK_BUNDLE_DEFAULT;
+
+	if (!r_context_configure(&error)) {
+		g_printerr("Failed to initialize context: %s\n", error->message);
+		g_clear_error(&error);
+		r_exit_status = 1;
+		return FALSE;
+	}
 
 	if (argc < 3) {
 		g_printerr("A file name must be provided\n");
@@ -1664,6 +1727,13 @@ static gboolean status_start(int argc, char **argv)
 		}
 	}
 
+	if (!r_context_configure(&ierror)) {
+		g_printerr("Failed to initialize context: %s\n", ierror->message);
+		g_clear_error(&ierror);
+		r_exit_status = 1;
+		goto out;
+	}
+
 	if (!ENABLE_SERVICE) {
 		res = determine_slot_states(&ierror);
 		if (!res) {
@@ -1772,11 +1842,20 @@ out:
 G_GNUC_UNUSED
 static gboolean service_start(int argc, char **argv)
 {
+	GError *error = NULL;
+
 	g_debug("service start");
 
 	if (!r_context_conf()->configpath) {
 		g_debug("Using default system config path '/etc/rauc/system.conf'");
 		r_context_conf()->configpath = g_strdup("/etc/rauc/system.conf");
+	}
+
+	if (!r_context_configure(&error)) {
+		g_printerr("Failed to initialize context: %s\n", error->message);
+		g_clear_error(&error);
+		r_exit_status = 1;
+		return TRUE;
 	}
 
 	r_exit_status = r_service_run() ? 0 : 1;
@@ -1790,6 +1869,12 @@ static gboolean mount_start(int argc, char **argv)
 	g_autoptr(RaucBundle) bundle = NULL;
 	GError *error = NULL;
 	gboolean res = FALSE;
+
+	if (!r_context_configure(&error)) {
+		g_printerr("Failed to initialize context: %s\n", error->message);
+		g_clear_error(&error);
+		goto out;
+	}
 
 	if (argc < 3) {
 		g_printerr("A file name must be provided\n");

--- a/src/service.c
+++ b/src/service.c
@@ -544,16 +544,9 @@ static gboolean r_on_signal(gpointer user_data)
 
 gboolean r_service_run(void)
 {
-	GError *ierror = NULL;
 	gboolean service_return = TRUE;
 	GBusType bus_type = (!g_strcmp0(g_getenv("DBUS_STARTER_BUS_TYPE"), "session"))
 	                    ? G_BUS_TYPE_SESSION : G_BUS_TYPE_SYSTEM;
-
-	if (!r_context_configure(&ierror)) {
-		g_printerr("Failed to initialize context: %s\n", ierror->message);
-		g_clear_error(&ierror);
-		return FALSE;
-	}
 
 	service_loop = g_main_loop_new(NULL, FALSE);
 	g_unix_signal_add(SIGTERM, r_on_signal, NULL);


### PR DESCRIPTION
* always back fallback to `/etc/rauc/system.conf` when being available (but error if its broken)
* graceful context error printout for all rauc commands