### PR TITLE
explicitly handle config file requirements per command

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -16,12 +16,19 @@ typedef struct {
 	RaucBundle *mounted_bundle;
 } RContextInstallationInfo;
 
+typedef enum {
+	R_CONTEXT_CONFIG_MODE_NONE, /* use default config values */
+	R_CONTEXT_CONFIG_MODE_AUTO, /* load config file if it exists */
+	R_CONTEXT_CONFIG_MODE_REQUIRED, /* require config file */
+} RContextConfigMode;
+
 typedef struct {
 	/* a busy context must not be reconfigured */
 	gboolean busy;
 	gboolean pending;
 
 	/* system configuration data */
+	RContextConfigMode configmode;
 	gchar *configpath;
 	RaucConfig *config;
 

--- a/src/main.c
+++ b/src/main.c
@@ -2143,6 +2143,12 @@ static void cmdline_handler(int argc, char **argv)
 	if (!r_context_get_busy()) {
 		r_context_conf();
 		r_context_conf()->configmode = rcommand->configmode;
+		if (ENABLE_SERVICE) {
+			/* these commands are handled by the service and need no client config */
+			if (rcommand->type == INSTALL ||
+			    rcommand->type == STATUS)
+				r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_NONE;
+		}
 		if (confpath)
 			r_context_conf()->configpath = confpath;
 		if (certpath)

--- a/src/main.c
+++ b/src/main.c
@@ -213,13 +213,6 @@ static gboolean install_start(int argc, char **argv)
 
 	r_exit_status = 1;
 
-	if (!ENABLE_SERVICE) {
-		if (!r_context_conf()->configpath) {
-			g_debug("Using default system config path '/etc/rauc/system.conf'");
-			r_context_conf()->configpath = g_strdup("/etc/rauc/system.conf");
-		}
-	}
-
 	if (argc < 3) {
 		g_printerr("A bundle filename name must be provided\n");
 		goto out;
@@ -1658,13 +1651,6 @@ static gboolean status_start(int argc, char **argv)
 	r_exit_status = 0;
 
 	if (!ENABLE_SERVICE) {
-		if (!r_context_conf()->configpath) {
-			g_debug("Using default system config path '/etc/rauc/system.conf'");
-			r_context_conf()->configpath = g_strdup("/etc/rauc/system.conf");
-		}
-	}
-
-	if (!ENABLE_SERVICE) {
 		res = determine_slot_states(&ierror);
 		if (!res) {
 			g_printerr("Failed to determine slot states: %s\n", ierror->message);
@@ -1774,11 +1760,6 @@ static gboolean service_start(int argc, char **argv)
 {
 	g_debug("service start");
 
-	if (!r_context_conf()->configpath) {
-		g_debug("Using default system config path '/etc/rauc/system.conf'");
-		r_context_conf()->configpath = g_strdup("/etc/rauc/system.conf");
-	}
-
 	r_exit_status = r_service_run() ? 0 : 1;
 
 	return TRUE;
@@ -1867,6 +1848,7 @@ typedef struct {
 	const gchar* summary;
 	gboolean (*cmd_handler)(int argc, char **argv);
 	GOptionGroup* options;
+	RContextConfigMode configmode;
 	gboolean while_busy;
 } RaucCommand;
 
@@ -1994,29 +1976,53 @@ static void cmdline_handler(int argc, char **argv)
 	g_autofree gchar *text = NULL;
 
 	RaucCommand rcommands[] = {
-		{UNKNOWN, "help", "<COMMAND>", "Print help", unknown_start, NULL, TRUE},
-		{INSTALL, "install", "install <BUNDLE>", "Install a bundle", install_start, install_group, FALSE},
+		{UNKNOWN, "help", "<COMMAND>",
+		 "Print help",
+		 unknown_start, NULL, R_CONTEXT_CONFIG_MODE_NONE, TRUE},
+		{INSTALL, "install", "install <BUNDLE>",
+		 "Install a bundle",
+		 install_start, install_group, R_CONTEXT_CONFIG_MODE_REQUIRED, FALSE},
 #if ENABLE_CREATE == 1
-		{BUNDLE, "bundle", "bundle <INPUTDIR> <BUNDLENAME>", "Create a bundle from a content directory", bundle_start, bundle_group, FALSE},
-		{RESIGN, "resign", "resign <INBUNDLE> <OUTBUNDLE>", "Resign an already signed bundle", resign_start, resign_group, FALSE},
-		{CONVERT, "convert", "convert <INBUNDLE> <OUTBUNDLE>", "Convert to casync index bundle and store", convert_start, convert_group, FALSE},
-		{REPLACE_SIG, "replace-signature", "replace-signature <INBUMDLE> <INPUTSIG> <OUTBUNDLE>", "Replaces the signature of an already signed bundle", replace_signature_start, replace_group, FALSE},
-		{EXTRACT_SIG, "extract-signature", "extract-signature <BUNDLENAME> <OUTPUTSIG>", "Extract the bundle signature", extract_signature_start, NULL, FALSE},
+		{BUNDLE, "bundle", "bundle <INPUTDIR> <BUNDLENAME>",
+		 "Create a bundle from a content directory",
+		 bundle_start, bundle_group, R_CONTEXT_CONFIG_MODE_NONE, FALSE},
+		{RESIGN, "resign", "resign <INBUNDLE> <OUTBUNDLE>",
+		 "Resign an already signed bundle",
+		 resign_start, resign_group, R_CONTEXT_CONFIG_MODE_NONE, FALSE},
+		{CONVERT, "convert", "convert <INBUNDLE> <OUTBUNDLE>",
+		 "Convert to casync index bundle and store",
+		 convert_start, convert_group, R_CONTEXT_CONFIG_MODE_NONE, FALSE},
+		{REPLACE_SIG, "replace-signature", "replace-signature <INBUMDLE> <INPUTSIG> <OUTBUNDLE>",
+		 "Replaces the signature of an already signed bundle",
+		 replace_signature_start, replace_group, R_CONTEXT_CONFIG_MODE_NONE, FALSE},
+		{EXTRACT_SIG, "extract-signature", "extract-signature <BUNDLENAME> <OUTPUTSIG>",
+		 "Extract the bundle signature",
+		 extract_signature_start, NULL, R_CONTEXT_CONFIG_MODE_NONE, FALSE},
 #endif
-		{EXTRACT, "extract", "extract <BUNDLENAME> <OUTPUTDIR>", "Extract the bundle content", extract_start, NULL, FALSE},
-		{INFO, "info", "info <FILE>", "Print bundle info", info_start, info_group, FALSE},
+		{EXTRACT, "extract", "extract <BUNDLENAME> <OUTPUTDIR>",
+		 "Extract the bundle content",
+		 extract_start, NULL, R_CONTEXT_CONFIG_MODE_AUTO, FALSE},
+		{INFO, "info", "info <FILE>",
+		 "Print bundle info",
+		 info_start, info_group, R_CONTEXT_CONFIG_MODE_AUTO, FALSE},
 		{STATUS, "status", "status",
 		 "Show system status\n\n"
 		 "List of status commands (default slot is the currently booted slot):\n"
 		 "  mark-good [booted | other | <SLOT_NAME>] \tMark the slot as good\n"
 		 "  mark-bad [booted | other | <SLOT_NAME>] \tMark the slot as bad\n"
 		 "  mark-active [booted | other | <SLOT_NAME>] \tMark the slot as active",
-		 status_start, status_group, TRUE},
-		{WRITE_SLOT, "write-slot", "write-slot <SLOTNAME> <IMAGE>", "Write image to slot and bypass all update logic", write_slot_start, NULL, FALSE},
+		 status_start, status_group, R_CONTEXT_CONFIG_MODE_REQUIRED, TRUE},
+		{WRITE_SLOT, "write-slot", "write-slot <SLOTNAME> <IMAGE>",
+		 "Write image to slot and bypass all update logic",
+		 write_slot_start, NULL, R_CONTEXT_CONFIG_MODE_REQUIRED, FALSE},
 #if ENABLE_SERVICE == 1
-		{SERVICE, "service", "service", "Start RAUC service", service_start, service_group, TRUE},
+		{SERVICE, "service", "service",
+		 "Start RAUC service",
+		 service_start, service_group, R_CONTEXT_CONFIG_MODE_REQUIRED, TRUE},
 #endif
-		{MOUNT, "mount", "mount <BUNDLENAME>", "Mount a bundle (for development purposes)", mount_start, NULL, TRUE},
+		{MOUNT, "mount", "mount <BUNDLENAME>",
+		 "Mount a bundle (for development purposes)",
+		 mount_start, NULL, R_CONTEXT_CONFIG_MODE_REQUIRED, TRUE},
 		{0}
 	};
 	RaucCommand *rc;
@@ -2136,6 +2142,7 @@ static void cmdline_handler(int argc, char **argv)
 	/* configuration updates are handled here */
 	if (!r_context_get_busy()) {
 		r_context_conf();
+		r_context_conf()->configmode = rcommand->configmode;
 		if (confpath)
 			r_context_conf()->configpath = confpath;
 		if (certpath)
@@ -2170,6 +2177,13 @@ static void cmdline_handler(int argc, char **argv)
 
 	if (r_context_get_busy() && !rcommand->while_busy) {
 		g_printerr("rauc busy: cannot run %s\n", rcommand->name);
+		r_exit_status = 1;
+		return;
+	}
+
+	if (!r_context_configure(&error)) {
+		g_printerr("Failed to initialize context: %s\n", error->message);
+		g_clear_error(&error);
 		r_exit_status = 1;
 		return;
 	}

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -318,7 +318,8 @@ test_expect_success ROOT "rauc mount" "
   test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&
   test_when_finished umount /mnt/rauc/bundle &&
   ls ${TEST_TMPDIR} &&
-  rauc --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+  rauc \
+    --conf=${SHARNESS_TEST_DIRECTORY}/test.conf \
     mount ${TEST_TMPDIR}/good-bundle.raucb &&
   mount &&
   test -f /mnt/rauc/bundle/manifest.raucm &&

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -210,6 +210,14 @@ test_expect_success "rauc info" "
     info ${TEST_TMPDIR}/good-bundle.raucb
 "
 
+test_expect_success "rauc info with config" "
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&
+  rauc \
+    --conf=${SHARNESS_TEST_DIRECTORY}/test.conf \
+    info ${TEST_TMPDIR}/good-bundle.raucb
+"
+
 test_expect_success "rauc info verification failure" "
   cp -L ${SHARNESS_TEST_DIRECTORY}/invalid-sig-bundle.raucb ${TEST_TMPDIR}/ &&
   test_when_finished rm -f ${TEST_TMPDIR}/invalid-sig-bundle.raucb &&


### PR DESCRIPTION
This is an alternative to #836 and avoids the code duplication in https://github.com/rauc/rauc/pull/836/commits/e867ce96c5761d3e86cc139c2456c8d40aa3afc2.

Instead, it adds a config mode enum to the context. This allows the context setup code to choose the appropriate method to load the system configuration.

Commands which are intended to be used on the target (`install`, `status`, `write-slot`, `service` and `mount`) need to know the intended security configuration and will now require a config file. If none is given on the command line, they will use ``/etc/rauc/system.conf``.

Commands which are used during development (`bundle`, `resign`, `convert`, `replace-sig`, `extract-sig`) are mainly configured via the command line. If a config is given using ``--conf=``, it's still used, though.

The remaining commands `extract` and `info` will automatically load `/etc/rauc/system.conf` if it exists, otherwise they need to be configured via the commandline.