### PR TITLE
src/bundle: fix rauc convert for empty filename

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -826,7 +826,7 @@ static gboolean convert_to_casync_bundle(RaucBundle *bundle, const gchar *outbun
 	}
 
 	if (g_file_test(storepath, G_FILE_TEST_EXISTS)) {
-		g_warning("Store path '%s' already exists, appending new chunks", outbundle);
+		g_warning("Store path '%s' already exists, appending new chunks", storepath);
 	}
 
 	/* Set up tmp dir for conversion */

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -786,6 +786,9 @@ out:
 
 static gboolean image_is_archive(RaucImage* image)
 {
+	g_return_val_if_fail(image, FALSE);
+	g_return_val_if_fail(image->filename, FALSE);
+
 	if (g_pattern_match_simple("*.tar*", image->filename) ||
 	    g_pattern_match_simple("*.catar", image->filename)) {
 		return TRUE;
@@ -864,6 +867,9 @@ static gboolean convert_to_casync_bundle(RaucBundle *bundle, const gchar *outbun
 		g_autofree gchar *idxpath = NULL;
 
 		imgpath = g_build_filename(contentdir, image->filename, NULL);
+
+		if (!image->filename)
+			continue;
 
 		if (image_is_archive(image)) {
 			idxfile = g_strconcat(image->filename, ".caidx", NULL);


### PR DESCRIPTION
Commit 8a9c9213 introduced the ability to not provide any image file at all in case an 'install' slot hook is used.

But, when trying to convert such a bundle (to a casync bundle), the method `convert_to_casync_bundle()` will call `image_is_archive()` to determine if a blob or a directory index needs to be created.

So far, this method silently assumed that `image->filename` is always set, which it is not anymore.

Fix this by explicitly skipping image entries with no 'filename' set and additionally add `g_return_val_if_fail()` guards in `image_is_archive()` to prevent from using it wrongly.

Fixes: 8a9c9213 ("src: support omitting filename when 'install' slot hook is used")