### PR TITLE
src/context: always set context configpath when config is used

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -244,6 +244,8 @@ gboolean r_context_configure(GError **error)
 		case R_CONTEXT_CONFIG_MODE_AUTO:
 			if (load_config(configpath, &context->config, &ierror)) {
 				g_message("valid %s found, using it", configpath);
+				if (!context->configpath)
+					context->configpath = g_strdup(configpath);
 			} else if (ierror->domain != G_FILE_ERROR) {
 				g_propagate_prefixed_error(error, ierror, "Failed to load system config (%s): ", configpath);
 				return FALSE;
@@ -257,6 +259,8 @@ gboolean r_context_configure(GError **error)
 				g_propagate_prefixed_error(error, ierror, "Failed to load system config (%s): ", configpath);
 				return FALSE;
 			}
+			if (!context->configpath)
+				context->configpath = g_strdup(configpath);
 			break;
 		default:
 			g_error("invalid context config mode %d", configmode);


### PR DESCRIPTION
Code expects context's configpath to be set if config file is required.

This is an issue for example during installation when it is used to set
the environment variable RAUC_SYSTEM_CONFIG for pre-install handlers.
With current handling, as introduced by a61bb4e0, this causes the rauc
service to die with:

> g_environ_setenv: assertion 'value != NULL' failed

For consistency, simply always set the configpath variable when a config
file was loaded from any location.

Fixes: a61bb4e0 ("main: specifiy configuration mode per command")

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>