### PR TITLE
src/install: fix error indicator init in determine_boot_states()

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -223,7 +223,7 @@ gboolean determine_boot_states(GError **error)
 {
 	GHashTableIter iter;
 	RaucSlot *slot;
-	gboolean had_errors;
+	gboolean had_errors = FALSE;
 
 	/* get boot state */
 	g_hash_table_iter_init(&iter, r_context()->config->slots);


### PR DESCRIPTION
When `had_errors` is not initialized to FALSE, function always returns an error and rauc status (or service) prints:

> Failed to determine boot states: Could not determine all boot states

Fixes: c2f1e413 ("src/install: determine_boot_states: do not abort on first failed slot")

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>