### PR TITLE
Add scan-build Actions workflow

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -1,0 +1,32 @@
+name: scan-build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:unstable
+      options: --user=root
+    steps:
+    - name: Install dependencies
+      run: |
+        apt-get update
+        DEBIAN_FRONTEND='noninteractive' apt-get install -qy automake make libtool libglib2.0-dev libcurl3-dev libssl-dev libdbus-1-dev libjson-glib-dev libfdisk-dev libnl-genl-3-dev dbus-x11 clang-tools
+
+    - name: Inspect environment
+      run: |
+        whoami
+        gcc --version
+        ls -la /usr/bin/clang*
+
+    - uses: actions/checkout@v2
+
+    - name: Run autogen.sh
+      run: |
+        ./autogen.sh
+
+    - name: Run scan-build
+      run: |
+        scan-build --status-bugs ./configure --disable-dependency-tracking
+        scan-build --status-bugs -disable-checker unix.Malloc make

--- a/src/context.c
+++ b/src/context.c
@@ -186,6 +186,8 @@ static gchar* get_system_dtb_compatible(GError **error)
 		return NULL;
 	}
 
+	g_assert_nonnull(contents); /* fixes scan-build false positive */
+
 	return contents;
 }
 
@@ -202,6 +204,8 @@ static gchar* get_variant_from_file(const gchar* filename, GError **error)
 		g_propagate_error(error, ierror);
 		return NULL;
 	}
+
+	g_assert_nonnull(contents); /* fixes scan-build false positive */
 
 	/*
 	 * We'll discard surrounding whitespace later anyway, but as it's


### PR DESCRIPTION
Issues like https://github.com/rauc/rauc/pull/844/files would have been detected by running llvm's 'scan-build' analyzer on the code.

This does not deal well with autofree functionality of glib this, thus memory checks are disabled. But we can already use it for the rest.