### PR TITLE
src/install: ignore slots without bootname for determining booted slot

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -139,6 +139,9 @@ gboolean determine_slot_states(GError **error)
 		RaucSlot *s = g_hash_table_lookup(r_context()->config->slots, l->data);
 		g_assert_nonnull(s);
 
+		if (!s->bootname)
+			continue;
+
 		if (g_strcmp0(s->bootname, r_context()->bootslot) == 0) {
 			booted = s;
 			break;


### PR DESCRIPTION
If we attempt to compare against slots that do not have a bootname set, these must fall back to device comparison.
If the device is not available (for any reason), this will print a bunch of

> Failed to resolve realpath for '/dummy/path'

warnings.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>