### PR TITLE
src/bundle: remove unused function extract_file_from_bundle()

### DIFF
--- a/include/bundle.h
+++ b/include/bundle.h
@@ -176,24 +176,6 @@ gboolean extract_bundle(RaucBundle *bundle, const gchar *outputdir, GError **err
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
- * Extract a single file from a bundle.
- *
- * This will extract a single file into a given directory.
- *
- * Note that check_bundle() must be called prior to this, to obtain a
- * RaucBundle struct.
- *
- * @param bundle RaucBundle struct as returned by check_bundle()
- * @param outputdir directory to extract the file into
- * @param file filename of file to extract from bundle
- * @param error Return location for a GError
- *
- * @return TRUE on success, FALSE if an error occurred
- */
-gboolean extract_file_from_bundle(RaucBundle *bundle, const gchar *outputdir, const gchar *file, GError **error)
-G_GNUC_WARN_UNUSED_RESULT;
-
-/**
  * Extract and load the manifest from a bundle.
  *
  * This is mainly useful for plain bundles, as the manifest is already contained in

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1866,30 +1866,6 @@ out:
 	return res;
 }
 
-gboolean extract_file_from_bundle(RaucBundle *bundle, const gchar *outputdir, const gchar *file, GError **error)
-{
-	GError *ierror = NULL;
-	gboolean res = FALSE;
-
-	g_return_val_if_fail(bundle != NULL, FALSE);
-
-	res = check_bundle_payload(bundle, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
-	}
-
-	res = unsquashfs(g_file_descriptor_based_get_fd(G_FILE_DESCRIPTOR_BASED(bundle->stream)), outputdir, file, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
-	}
-
-	res = TRUE;
-out:
-	return res;
-}
-
 gboolean load_manifest_from_bundle(RaucBundle *bundle, RaucManifest **manifest, GError **error)
 {
 	g_autofree gchar* tmpdir = NULL;

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -225,40 +225,6 @@ static void bundle_test_create_mount_extract(BundleFixture *fixture,
 	g_assert_true(res);
 }
 
-static void bundle_test_extract_manifest(BundleFixture *fixture,
-		gconstpointer user_data)
-{
-	g_autofree gchar *outputdir = NULL;
-	g_autofree gchar *filepath = NULL;
-	g_autoptr(RaucBundle) bundle = NULL;
-	g_autoptr(GError) ierror = NULL;
-	gboolean res = FALSE;
-
-	outputdir = g_build_filename(fixture->tmpdir, "output", NULL);
-	g_assert_nonnull(outputdir);
-
-	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, &ierror);
-	g_assert_no_error(ierror);
-	g_assert_true(res);
-	g_assert_nonnull(bundle);
-
-	res = extract_file_from_bundle(bundle, outputdir, "manifest.raucm", &ierror);
-	g_assert_no_error(ierror);
-	g_assert_true(res);
-
-	filepath = g_build_filename(outputdir, "manifest.raucm", NULL);
-	g_assert_true(g_file_test(filepath, G_FILE_TEST_IS_REGULAR));
-	g_clear_pointer(&filepath, g_free);
-
-	filepath = g_build_filename(outputdir, "rootfs.ext4", NULL);
-	g_assert_false(g_file_test(filepath, G_FILE_TEST_EXISTS));
-	g_clear_pointer(&filepath, g_free);
-
-	filepath = g_build_filename(outputdir, "appfs.ext4", NULL);
-	g_assert_false(g_file_test(filepath, G_FILE_TEST_EXISTS));
-	g_clear_pointer(&filepath, g_free);
-}
-
 static void bundle_test_extract_signature(BundleFixture *fixture,
 		gconstpointer user_data)
 {
@@ -766,11 +732,6 @@ int main(int argc, char *argv[])
 		g_test_add(g_strdup_printf("/bundle/extract_signature/%s", format_name),
 				BundleFixture, bundle_data,
 				bundle_fixture_set_up_bundle, bundle_test_extract_signature,
-				bundle_fixture_tear_down);
-
-		g_test_add(g_strdup_printf("/bundle/extract_manifest/%s", format_name),
-				BundleFixture, bundle_data,
-				bundle_fixture_set_up_bundle, bundle_test_extract_manifest,
 				bundle_fixture_tear_down);
 
 		g_test_add(g_strdup_printf("/bundle/resign/%s", format_name),


### PR DESCRIPTION
Usage of this method was removed in cc8c6252 ("main: refactor info command to use new helpers") and 535ceca5 ("service: use the new load_manifest_bundle helper").

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>