### PR TITLE
test/common.h: replace deprecated g_memdup by g_memdup2 for recent glib

### DIFF
--- a/test/common.h
+++ b/test/common.h
@@ -4,7 +4,11 @@
 
 #include "manifest.h"
 
+#ifndef GLIB_VERSION_2_68
 #define memdup(x) (g_memdup(x, sizeof(*x)))
+#else
+#define memdup(x) (g_memdup2(x, sizeof(*x)))
+#endif
 
 typedef struct {
 	gboolean custom_handler;


### PR DESCRIPTION
Glib documentation notes about this:

> g_memdup has been deprecated since version 2.68 and should not be used
> in newly-written code.
> Use g_memdup2() instead, as it accepts a gsize argument for byte_size,
> avoiding the possibility of overflow in a gsize → guint conversion

Thus, when compiling against glib version >= 2.68, use g_memdup2()
instead of g_memdup() to avoid warnings like

``` 
test/install.c:1343:17: warning: ‘g_memdup2’ is deprecated: Not available before 2.68 [-Wdeprecated-declarations]
 1343 |                 install_data = memdup((&(InstallData) {
      |                 ^~~~~~~~~~~~
```

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>