### PR TITLE
Revert "test/common.h: replace deprecated g_memdup by g_memdup2 for recent glib

### DIFF
--- a/test/common.h
+++ b/test/common.h
@@ -4,11 +4,7 @@
 
 #include "manifest.h"
 
-#ifndef GLIB_VERSION_2_68
 #define memdup(x) (g_memdup(x, sizeof(*x)))
-#else
-#define memdup(x) (g_memdup2(x, sizeof(*x)))
-#endif
 
 typedef struct {
 	gboolean custom_handler;


### PR DESCRIPTION
This reverts commit c7d40a6e88ed48cb44c740dd3d1b0f3eddc4c80d.

The mentioned commit was wrong in its submitted version (which one can
already see when reading the warning message noted there).

The usage of g_memdup2() would require to bump GLIB_VERSION_MAX_ALLOWED
to not run into 'deprecation' warning saying that g_memdup2() is not
supported, yet.

However, this would drastically increase the latest supported glib
version of RAUC and result in a very wide range of versions to
potentially support with fallback macros, etc.

Such a change is only reasonable if we intend to use a new API that is
worth the bump.

The use of g_memdup() in RAUC however is limited to test cases only and
thus using g_memdup2() instead of g_memdup() has no security
implications for the rauc binary.

Thus, instead of bumping GLIB_VERSION_MAX_ALLOWED, revert the original
commit.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>

Fixes #850 