### PR TITLE
src/nbd: do not invoke setgid() and setuid() if we run as non-root user

### DIFF
--- a/src/nbd.c
+++ b/src/nbd.c
@@ -1053,6 +1053,11 @@ static gboolean nbd_server_child_prepare(struct child_setup_args *args, GError *
 	g_return_val_if_fail(args != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
+	/* If we run as non-root (e.g. for 'rauc info'),
+	 * there is no need to drop privileges */
+	if (getuid() != 0 && getgid() != 0)
+		return TRUE;
+
 	user = r_context()->config->streaming_sandbox_user;
 	if (user == NULL)
 		user = STREAMING_USER;


### PR DESCRIPTION
A non-root user will not be allowed to run setuid() or setgid() on the nbd process. And there is also no need to do drop permission if it already runs unprivileged.

This will enable accessing remote bundles with `rauc info` which will otherwise fail with:

    rauc-Message: 11:34:40.001: Remote URI detected, streaming bundle...
    setgid failed
    rauc-nbd-Message: 11:34:40.013: sending: {'url': <'http://localhost:8000/test/good-verity-bundle.raucb'>}

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>