### PR TITLE
add support for a list of optional incremental methods

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -547,6 +547,17 @@ A valid RAUC manifest file must be named ``manifest.raucm``.
 
   Valid items are: ``pre-install``, ``install``, ``post-install``
 
+``incremental``
+  List of ``;``-separated per-slot incremental update method names.
+  These methods will add extra information to the bundle, allowing RAUC to
+  access only the parts of an image which are not yet available locally.
+  Together with streaming, this reduces the amount of downloaded data.
+
+  As the full image is still available in the bundle, older RAUC versions can
+  ignore unsupported incremental methods.
+
+  Currently, no incremental methods are implemented.
+
 .. _sec_ref_formats:
 
 Bundle Formats

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -30,6 +30,7 @@ typedef struct {
 	RaucChecksum checksum;
 	gchar* filename;
 	SlotHooks hooks;
+	GStrv incremental;
 } RaucImage;
 
 typedef enum {

--- a/src/main.c
+++ b/src/main.c
@@ -884,6 +884,13 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 		g_free(temp_string);
 
 		g_ptr_array_unref(hooks);
+
+		if (img->incremental) {
+			temp_string = g_strjoinv(" ", (gchar**) img->incremental);
+			formatter_shell_append_n(text, "RAUC_IMAGE_INCREMENTAL", cnt, temp_string);
+			g_free(temp_string);
+		}
+
 		cnt++;
 	}
 
@@ -967,6 +974,12 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 
 		g_ptr_array_unref(hooks);
 
+		if (img->incremental) {
+			temp_string = g_strjoinv(" ", (gchar**) img->incremental);
+			g_string_append_printf(text, "\tIncremental: %s\n", temp_string);
+			g_free(temp_string);
+		}
+
 		cnt++;
 	}
 
@@ -1029,6 +1042,14 @@ static gchar* info_formatter_json_base(RaucManifest *manifest, gboolean pretty)
 		}
 		if (img->hooks.post_install == TRUE) {
 			json_builder_add_string_value(builder, "post-install");
+		}
+		json_builder_end_array(builder);
+		json_builder_set_member_name(builder, "incremental");
+		json_builder_begin_array(builder);
+		if (img->incremental) {
+			for (gchar **m = img->incremental; *m != NULL; m++) {
+				json_builder_add_string_value(builder, *m);
+			}
 		}
 		json_builder_end_array(builder);
 		json_builder_end_object(builder);

--- a/src/main.c
+++ b/src/main.c
@@ -837,7 +837,7 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 {
 	GString *text = g_string_new(NULL);
 	GPtrArray *hooks = NULL;
-	gchar *hookstring = NULL;
+	gchar *temp_string = NULL;
 	gint cnt;
 
 	formatter_shell_append(text, "RAUC_MF_COMPATIBLE", manifest->update_compatible);
@@ -852,9 +852,9 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 	}
 	g_ptr_array_add(hooks, NULL);
 
-	hookstring = g_strjoinv(" ", (gchar**) hooks->pdata);
-	formatter_shell_append(text, "RAUC_MF_HOOKS", hookstring);
-	g_free(hookstring);
+	temp_string = g_strjoinv(" ", (gchar**) hooks->pdata);
+	formatter_shell_append(text, "RAUC_MF_HOOKS", temp_string);
+	g_free(temp_string);
 
 	g_ptr_array_unref(hooks);
 
@@ -879,9 +879,9 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 		}
 		g_ptr_array_add(hooks, NULL);
 
-		hookstring = g_strjoinv(" ", (gchar**) hooks->pdata);
-		formatter_shell_append_n(text, "RAUC_IMAGE_HOOKS", cnt, hookstring);
-		g_free(hookstring);
+		temp_string = g_strjoinv(" ", (gchar**) hooks->pdata);
+		formatter_shell_append_n(text, "RAUC_IMAGE_HOOKS", cnt, temp_string);
+		g_free(temp_string);
 
 		g_ptr_array_unref(hooks);
 		cnt++;
@@ -894,7 +894,7 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 {
 	GString *text = g_string_new(NULL);
 	GPtrArray *hooks = NULL;
-	gchar *hookstring = NULL;
+	gchar *temp_string = NULL;
 	gboolean show_crypt_key = FALSE; /* change to TRUE to display dm-crypt key */
 	gint cnt;
 
@@ -909,9 +909,9 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 	}
 	g_ptr_array_add(hooks, NULL);
 
-	hookstring = g_strjoinv(" ", (gchar**) hooks->pdata);
-	g_string_append_printf(text, "Hooks:      \t'%s'\n", hookstring);
-	g_free(hookstring);
+	temp_string = g_strjoinv(" ", (gchar**) hooks->pdata);
+	g_string_append_printf(text, "Hooks:      \t'%s'\n", temp_string);
+	g_free(temp_string);
 
 	g_string_append_printf(text, "Bundle Format: \t%s", r_manifest_bundle_format_to_str(manifest->bundle_format));
 	if (manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT) {
@@ -961,9 +961,9 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 		}
 		g_ptr_array_add(hooks, NULL);
 
-		hookstring = g_strjoinv(" ", (gchar**) hooks->pdata);
-		g_string_append_printf(text, "\tHooks:     %s\n", hookstring);
-		g_free(hookstring);
+		temp_string = g_strjoinv(" ", (gchar**) hooks->pdata);
+		g_string_append_printf(text, "\tHooks:     %s\n", temp_string);
+		g_free(temp_string);
 
 		g_ptr_array_unref(hooks);
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -78,6 +78,9 @@ static gboolean parse_image(GKeyFile *key_file, const gchar *group, RaucImage **
 		goto out;
 	}
 
+	iimage->incremental = g_key_file_get_string_list(key_file, group, "incremental", NULL, NULL);
+	g_key_file_remove_key(key_file, group, "incremental", NULL);
+
 	if (!check_remaining_keys(key_file, group, &ierror)) {
 		g_propagate_error(error, ierror);
 		goto out;
@@ -589,6 +592,10 @@ static GKeyFile *prepare_manifest(const RaucManifest *mf)
 			g_key_file_set_string_list(key_file, group, "hooks",
 					(const gchar **)hooklist->pdata, hooklist->len);
 		}
+
+		if (image->incremental)
+			g_key_file_set_string_list(key_file, group, "incremental",
+					(const gchar * const *)image->incremental, g_strv_length(image->incremental));
 	}
 
 	return g_steal_pointer(&key_file);
@@ -641,6 +648,7 @@ void r_free_image(gpointer data)
 	g_free(image->variant);
 	g_free(image->checksum.digest);
 	g_free(image->filename);
+	g_strfreev(image->incremental);
 	g_free(image);
 }
 

--- a/test/install.c
+++ b/test/install.c
@@ -1107,13 +1107,13 @@ static void install_test_bundle_thread(InstallFixture *fixture,
 	/* Set mount path to current temp dir */
 	mountdir = g_build_filename(fixture->tmpdir, "mount", NULL);
 	g_assert_nonnull(mountdir);
-	r_context_conf()->mountprefix = mountdir;
+	r_context_conf()->mountprefix = g_steal_pointer(&mountdir);
 	r_context();
 
 	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
 	g_assert_nonnull(bundlepath);
 
-	args->name = g_strdup(bundlepath);
+	args->name = g_steal_pointer(&bundlepath);
 	args->notify = install_notify;
 	args->cleanup = install_cleanup;
 
@@ -1138,14 +1138,14 @@ static void install_test_bundle_hook_install_check(InstallFixture *fixture,
 	/* Set mount path to current temp dir */
 	mountdir = g_build_filename(fixture->tmpdir, "mount", NULL);
 	g_assert_nonnull(mountdir);
-	r_context_conf()->mountprefix = mountdir;
+	r_context_conf()->mountprefix = g_steal_pointer(&mountdir);
 	r_context();
 
 	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
 	g_assert_nonnull(bundlepath);
 
 	args = install_args_new();
-	args->name = g_strdup(bundlepath);
+	args->name = g_steal_pointer(&bundlepath);
 	args->notify = install_notify;
 	args->cleanup = install_cleanup;
 	g_assert_false(do_install_bundle(args, &ierror));
@@ -1173,14 +1173,14 @@ static void install_test_bundle_hook_install(InstallFixture *fixture,
 	/* Set mount path to current temp dir */
 	mountdir = g_build_filename(fixture->tmpdir, "mount", NULL);
 	g_assert_nonnull(mountdir);
-	r_context_conf()->mountprefix = mountdir;
+	r_context_conf()->mountprefix = g_strdup(mountdir);
 	r_context();
 
 	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
 	g_assert_nonnull(bundlepath);
 
 	args = install_args_new();
-	args->name = g_strdup(bundlepath);
+	args->name = g_steal_pointer(&bundlepath);
 	args->notify = install_notify;
 	args->cleanup = install_cleanup;
 	res = do_install_bundle(args, &ierror);
@@ -1223,14 +1223,14 @@ static void install_test_bundle_hook_post_install(InstallFixture *fixture,
 	/* Set mount path to current temp dir */
 	mountdir = g_build_filename(fixture->tmpdir, "mount", NULL);
 	g_assert_nonnull(mountdir);
-	r_context_conf()->mountprefix = mountdir;
+	r_context_conf()->mountprefix = g_strdup(mountdir);
 	r_context();
 
 	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
 	g_assert_nonnull(bundlepath);
 
 	args = install_args_new();
-	args->name = g_strdup(bundlepath);
+	args->name = g_steal_pointer(&bundlepath);
 	args->notify = install_notify;
 	args->cleanup = install_cleanup;
 	g_assert_true(do_install_bundle(args, NULL));
@@ -1272,7 +1272,7 @@ static void install_test_already_mounted(InstallFixture *fixture,
 	/* Set mount path to current temp dir */
 	mountprefix = g_build_filename(fixture->tmpdir, "mount", NULL);
 	g_assert_nonnull(mountprefix);
-	r_context_conf()->mountprefix = mountprefix;
+	r_context_conf()->mountprefix = g_steal_pointer(&mountprefix);
 	r_context();
 
 	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
@@ -1283,7 +1283,7 @@ static void install_test_already_mounted(InstallFixture *fixture,
 	g_assert_false(g_file_test(hookfilepath, G_FILE_TEST_EXISTS));
 
 	args = install_args_new();
-	args->name = g_strdup(bundlepath);
+	args->name = g_steal_pointer(&bundlepath);
 	args->notify = install_notify;
 	args->cleanup = install_cleanup;
 	res = do_install_bundle(args, &ierror);

--- a/test/install.c
+++ b/test/install.c
@@ -157,6 +157,24 @@ hooks=post-install";
 	fixture_helper_set_up_bundle(fixture->tmpdir, manifest_file, &data->manifest_test_options);
 }
 
+static void install_fixture_set_up_bundle_incremental(InstallFixture *fixture,
+		gconstpointer user_data)
+{
+	InstallData *data = (InstallData*) user_data;
+	const gchar *manifest_file = "\
+[update]\n\
+compatible=Test Config\n\
+\n\
+[image.rootfs]\n\
+filename=rootfs.ext4\n\
+incremental=invalid-method;another-invalid-method";
+
+	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+
+	fixture_helper_set_up_system(fixture->tmpdir, NULL);
+	fixture_helper_set_up_bundle(fixture->tmpdir, manifest_file, &data->manifest_test_options);
+}
+
 static void install_fixture_set_up_system_conf(InstallFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1437,6 +1455,16 @@ int main(int argc, char *argv[])
 				install_fixture_set_up_bundle_already_mounted, install_test_already_mounted,
 				install_fixture_tear_down);
 	}
+
+	install_data = memdup((&(InstallData) {
+		.manifest_test_options = {
+		        .format = R_MANIFEST_FORMAT_VERITY,
+		},
+	}));
+	g_test_add("/install/incremental",
+			InstallFixture, install_data,
+			install_fixture_set_up_bundle_incremental, install_test_bundle,
+			install_fixture_tear_down);
 
 	return g_test_run();
 }

--- a/test/install.c
+++ b/test/install.c
@@ -1371,14 +1371,14 @@ int main(int argc, char *argv[])
 				install_fixture_tear_down);
 
 		install_data = memdup((&(InstallData) {
-			.message_needles = (const gchar *[]) {
-			        "Checking and mounting bundle...",
-			        "Debug: --dummy1 --dummy2",
-			        "Handler status: [STARTED]",
-			        "Bootloader status: [DONE]",
-			        "Handler status: [DONE]",
-			        NULL,
-			},
+			.message_needles = memdup((&(const gchar *[]) {
+				"Checking and mounting bundle...",
+				"Debug: --dummy1 --dummy2",
+				"Handler status: [STARTED]",
+				"Bootloader status: [DONE]",
+				"Handler status: [DONE]",
+				NULL,
+			})),
 			.manifest_test_options = {
 			        .custom_handler = TRUE,
 			        .hooks = FALSE,


### PR DESCRIPTION
These methods will add extra information to the bundle, allowing RAUC to
access only the parts of an image which are not yet available locally.
Together with streaming, this reduces the amount of downloaded data.

As the full image is still available in the bundle, older RAUC versions can
ignore unsupported incremental methods and we don't need to check the list for
explicit values. Currently, no methods are implemented.

Note that because we reject any manifest with unknown keys, bundles
which use incremental methods will be rejected by versions up to v1.6. By
integrating this change early (without actually implementing any methods), we
can add new methods that will be ignored by older versions. This way, users
can generate bundles with incremental methods without compatibility problems as
soon as a version with this minimal change is deployed on all devices.