### PR TITLE
src/bundle: explicitly reject remote bundles in check_bundle_payload()

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1958,6 +1958,13 @@ gboolean check_bundle_payload(RaucBundle *bundle, GError **error)
 
 	g_message("Verifying bundle payload... ");
 
+	if (!bundle->stream) {
+		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_UNSAFE,
+				"Refused to verify remote bundle. Provide a local bundle instead.");
+		res = FALSE;
+		goto out;
+	}
+
 	if (!bundle->exclusive_verified) {
 		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_UNSAFE,
 				"cannot check bundle payload without exclusive access: %s", bundle->exclusive_check_error);


### PR DESCRIPTION
The exclusive_verified flag is set only for local bundles.
Checking this for remote (streaming) bundles will result in exclusive_check_error being unset:

> Failed to extract bundle: cannot check bundle payload without exclusive access: (null)

Instead, explicitly reject remote bundles in check_bundle_payload() by checking if bundle->stream is unset. The resulting error is then:

> Failed to extract bundle: Refused to verify remote bundle. Provide a local bundle instead.

This affects rauc methods like 'extract', 'resign', etc. that conceptually do not work with remote bundles at the moment.