### PR TITLE
Collection of Various Fixes 

### DIFF
--- a/data/rauc.service.in
+++ b/data/rauc.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Rauc Update Service
+Description=RAUC Update Service
 Documentation=https://rauc.readthedocs.io
 After=dbus.service
 

--- a/src/main.c
+++ b/src/main.c
@@ -544,6 +544,7 @@ out:
 	return TRUE;
 }
 
+G_GNUC_UNUSED
 static gboolean replace_signature_start(int argc, char **argv)
 {
 	CheckBundleParams check_bundle_params = CHECK_BUNDLE_DEFAULT;
@@ -602,6 +603,7 @@ out:
 	return TRUE;
 }
 
+G_GNUC_UNUSED
 static gboolean extract_signature_start(int argc, char **argv)
 {
 	RaucBundle *bundle = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -481,7 +481,7 @@ static gboolean write_slot_start(int argc, char **argv)
 		goto out;
 	}
 
-	g_message("Slot written successfully");
+	g_print("Slot written successfully\n");
 
 out:
 	return TRUE;
@@ -2265,7 +2265,7 @@ static void cmdline_handler(int argc, char **argv)
 
 	if (rcommand == NULL) {
 		/* INVALID COMMAND given */
-		g_message("Invalid command '%s' given", cmdarg);
+		g_print("Invalid command '%s' given\n", cmdarg);
 		r_exit_status = 1;
 		goto print_help;
 	}

--- a/src/mount.c
+++ b/src/mount.c
@@ -19,6 +19,10 @@ gboolean r_mount_bundle(const gchar *source, const gchar *mountpoint, GError **e
 {
 	const unsigned long flags = MS_NODEV | MS_NOSUID | MS_RDONLY;
 
+	g_return_val_if_fail(source != NULL, FALSE);
+	g_return_val_if_fail(mountpoint != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
 	if (mount(source, mountpoint, "squashfs", flags, NULL)) {
 		int err = errno;
 		g_set_error(error,
@@ -34,6 +38,9 @@ gboolean r_mount_bundle(const gchar *source, const gchar *mountpoint, GError **e
 gboolean r_umount_bundle(const gchar *mountpoint, GError **error)
 {
 	const int flags = UMOUNT_NOFOLLOW;
+
+	g_return_val_if_fail(mountpoint != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	if (umount2(mountpoint, flags)) {
 		int err = errno;

--- a/src/mount.c
+++ b/src/mount.c
@@ -145,8 +145,10 @@ gboolean r_setup_loop(gint fd, gint *loopfd_out, gchar **loopname_out, goffset s
 		gint loopidx;
 
 		g_clear_pointer(&loopname, g_free);
-		if (loopfd >= 0)
+		if (loopfd >= 0) {
 			g_close(loopfd, NULL);
+			loopfd = -1;
+		}
 
 		loopidx = ioctl(controlfd, LOOP_CTL_GET_FREE);
 		if (loopidx < 0) {

--- a/src/signature.c
+++ b/src/signature.c
@@ -1635,7 +1635,6 @@ GBytes *cms_decrypt(GBytes *content, const gchar *certfile, const gchar *keyfile
 	g_autoptr(CMS_ContentInfo) icms = NULL;
 	g_autoptr(X509) decrypt_cert = NULL;
 	g_autoptr(EVP_PKEY) privkey = NULL;
-	gint decrypted;
 	BIO *outdecrypt = BIO_new(BIO_s_mem());
 	BIO *inenc = NULL;
 	GBytes *res = NULL;
@@ -1684,8 +1683,7 @@ GBytes *cms_decrypt(GBytes *content, const gchar *certfile, const gchar *keyfile
 		goto out;
 	}
 
-	decrypted = CMS_decrypt(icms, privkey, decrypt_cert, NULL, outdecrypt, 0);
-	if (!decrypted) {
+	if (!CMS_decrypt(icms, privkey, decrypt_cert, NULL, outdecrypt, 0)) {
 		unsigned long err;
 		const gchar *data;
 		int errflags;

--- a/src/signature.c
+++ b/src/signature.c
@@ -1653,7 +1653,7 @@ GBytes *cms_decrypt(GBytes *content, const gchar *certfile, const gchar *keyfile
 		decrypt_cert = load_cert(certfile, &ierror);
 		if (decrypt_cert == NULL) {
 			g_propagate_error(error, ierror);
-			res = FALSE;
+			res = NULL;
 			goto out;
 		}
 	}
@@ -1661,7 +1661,7 @@ GBytes *cms_decrypt(GBytes *content, const gchar *certfile, const gchar *keyfile
 	privkey = load_key(keyfile, &ierror);
 	if (privkey == NULL) {
 		g_propagate_error(error, ierror);
-		res = FALSE;
+		res = NULL;
 		goto out;
 	}
 
@@ -1673,14 +1673,14 @@ GBytes *cms_decrypt(GBytes *content, const gchar *certfile, const gchar *keyfile
 				R_SIGNATURE_ERROR,
 				R_SIGNATURE_ERROR_PARSE,
 				"Failed to parse CMS");
-		res = FALSE;
+		res = NULL;
 		goto out;
 	}
 
 	/* assert we receied envelopedData */
 	if (OBJ_obj2nid(CMS_get0_type(icms)) != NID_pkcs7_enveloped) {
 		g_set_error(error, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID, "Expected CMS of type '%s' but got '%s'", OBJ_nid2sn(NID_pkcs7_enveloped), OBJ_nid2sn(OBJ_obj2nid(CMS_get0_type(icms))));
-		res = FALSE;
+		res = NULL;
 		goto out;
 	}
 
@@ -1690,6 +1690,7 @@ GBytes *cms_decrypt(GBytes *content, const gchar *certfile, const gchar *keyfile
 		const gchar *data;
 		int errflags;
 		err = ERR_get_error_line_data(NULL, NULL, &data, &errflags);
+		res = NULL;
 		g_set_error(
 				error,
 				R_SIGNATURE_ERROR,


### PR DESCRIPTION
* fixes potential double-close in `r_setup_loop()`
* adds missing `G_GNUC_UNUSED` markers
* fixes error return value in `cms_decrypt()`
* replaces `g_message()` for 'frontent' output
* adds method args input guards
* removes superfluous variable
* fixes case of "RAUC" in service description