### PR TITLE
src/main: divert log to stderr

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2370,6 +2370,14 @@ int main(int argc, char **argv)
 {
 	GLogLevelFlags fatal_mask;
 
+#if GLIB_CHECK_VERSION(2, 68, 0)
+	/* To use this function, without bumping the maximum GLib allowed version,
+	 * we temporarily disable the deprecation warnings */
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	g_log_writer_default_set_use_stderr(TRUE);
+	G_GNUC_END_IGNORE_DEPRECATIONS
+#endif
+
 	fatal_mask = g_log_set_always_fatal(G_LOG_FATAL_MASK);
 	fatal_mask |= G_LOG_LEVEL_CRITICAL;
 	g_log_set_always_fatal(fatal_mask);


### PR DESCRIPTION
RAUC stdout can be expected to be machine readable, for example when we
use `rauc status --output-format=json`.

However, by default, Glib sends info and debug log messages to stdout.
This has the side effect of potentially mixing log messages with the
machine readable output.

With `g_log_writer_default_set_use_stderr()` we ensure that all the Glib
log messages we sent to stderr.

Fixes: https://github.com/rauc/rauc/issues/870

---

As mentioned in the related issue, this new glib function requires at least Glib 2.68. However, by using a conditional check, we don't have to raise the minimum supported Glib version.