### PR TITLE
add build test on ubuntu 21.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,8 +116,8 @@ jobs:
     strategy:
       matrix:
         release:
-        - 18.04
-        - 20.04
+        - "18.04"
+        - "20.04"
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,8 +141,7 @@ jobs:
 
     - name: Build
       run: |
-        docker exec -i stable make
-        #docker exec -i stable make check
+        docker exec -i stable make TESTS= check
 
     - name: Show logs
       if: ${{ failure() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,6 +118,7 @@ jobs:
         release:
         - "18.04"
         - "20.04"
+        - "21.10"
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
This uses glib 2.68, which will allow us to test the glib version checks.