### PR TITLE
docs/scenarios: remove bootname for rescue slot in additinal rescue slot

### DIFF
--- a/docs/scenarios.rst
+++ b/docs/scenarios.rst
@@ -155,7 +155,6 @@ scenarios above, the robustness against some error cases can be improved:
   [slot.rescue.0]
   device=/dev/sda0
   type=raw
-  bootname=rescue
 
   [slot.rootfs.0]
   device=/dev/sda1


### PR DESCRIPTION
Avoid having bootname defined for the rescue slot, as it when updated
would result in RAUC would overwrite bootorder to prefer the rescue slot.

Signed-off-by: Sean Nyekjaer <sean.nyekjaer.ext@siemensgamesa.com>