### PR TITLE
stats: add g_autoptr support, label property and some testing helpers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -162,7 +162,8 @@ check_PROGRAMS = \
 	test/service.test \
 	test/bundle.test \
 	test/progress.test \
-	test/slot.test
+	test/slot.test \
+	test/stats.test
 
 if WANT_NETWORK
 check_PROGRAMS += test/network.test
@@ -270,6 +271,9 @@ test_progress_test_LDADD = librauctest.la
 
 test_slot_test_SOURCES = test/slot.c
 test_slot_test_LDADD = librauctest.la
+
+test_stats_test_SOURCES = test/stats.c
+test_stats_test_LDADD = librauctest.la
 
 SED_REPLACE = $(SED) \
        -e 's|[@]bindir[@]|$(bindir)|g' \

--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,7 @@ librauc_la_SOURCES = \
 	src/service.c \
 	src/signature.c \
 	src/slot.c \
+	src/stats.c \
 	src/utils.c \
 	src/update_handler.c \
 	src/verity_hash.c \
@@ -72,6 +73,7 @@ librauc_la_SOURCES = \
 	include/service.h \
 	include/signature.h \
 	include/slot.h \
+	include/stats.h \
 	include/update_handler.h \
 	include/utils.h \
 	include/verity_hash.h
@@ -89,7 +91,7 @@ librauc_la_SOURCES += src/gpt.c
 endif
 
 if ENABLE_STREAMING
-librauc_la_SOURCES += src/nbd.c include/nbd.h src/stats.c include/stats.h
+librauc_la_SOURCES += src/nbd.c include/nbd.h
 endif
 
 nodist_librauc_la_SOURCES = \

--- a/include/stats.h
+++ b/include/stats.h
@@ -22,3 +22,8 @@ void r_stats_show(const RaucStats *stats, const gchar *prefix);
 
 void r_stats_free(RaucStats *stats);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucStats, r_stats_free);
+
+/* additional functions for testing */
+void r_test_stats_start(void);
+void r_test_stats_stop(void);
+RaucStats *r_test_stats_next(void);

--- a/include/stats.h
+++ b/include/stats.h
@@ -2,19 +2,22 @@
 
 #include <glib.h>
 
-struct RaucStats {
+typedef struct {
 	gdouble values[64];
 	guint64 count, next;
 	gdouble sum;
 	gdouble min, max;
-};
+} RaucStats;
 
-void r_stats_init(struct RaucStats *stats);
+RaucStats *r_stats_new(void);
 
-void r_stats_add(struct RaucStats *stats, gdouble value);
+void r_stats_add(RaucStats *stats, gdouble value);
 
-gdouble r_stats_get_avg(const struct RaucStats *stats);
+gdouble r_stats_get_avg(const RaucStats *stats);
 
-gdouble r_stats_get_recent_avg(const struct RaucStats *stats);
+gdouble r_stats_get_recent_avg(const RaucStats *stats);
 
-void r_stats_show(const struct RaucStats *stats, const gchar *prefix);
+void r_stats_show(const RaucStats *stats, const gchar *prefix);
+
+void r_stats_free(RaucStats *stats);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucStats, r_stats_free);

--- a/include/stats.h
+++ b/include/stats.h
@@ -3,13 +3,14 @@
 #include <glib.h>
 
 typedef struct {
+	gchar *label;
 	gdouble values[64];
 	guint64 count, next;
 	gdouble sum;
 	gdouble min, max;
 } RaucStats;
 
-RaucStats *r_stats_new(void);
+RaucStats *r_stats_new(const gchar *label);
 
 void r_stats_add(RaucStats *stats, gdouble value);
 

--- a/src/nbd.c
+++ b/src/nbd.c
@@ -789,12 +789,12 @@ gboolean r_nbd_run_server(gint sock, GError **error)
 
 	g_message("running as UID %d, GID %d", getuid(), getgid());
 
-	ctx.dl_size = r_stats_new();
-	ctx.dl_speed = r_stats_new();
-	ctx.namelookup = r_stats_new();
-	ctx.connect = r_stats_new();
-	ctx.starttransfer = r_stats_new();
-	ctx.total = r_stats_new();
+	ctx.dl_size = r_stats_new("nbd dl_size");
+	ctx.dl_speed = r_stats_new("nbd dl_speed");
+	ctx.namelookup = r_stats_new("nbd namelookup");
+	ctx.connect = r_stats_new("nbd connect");
+	ctx.starttransfer = r_stats_new("nbd starttransfer");
+	ctx.total = r_stats_new("nbd total");
 
 	ctx.sock = sock;
 	ctx.multi = curl_multi_init();

--- a/src/stats.c
+++ b/src/stats.c
@@ -1,9 +1,10 @@
 #include "stats.h"
 
-RaucStats *r_stats_new(void)
+RaucStats *r_stats_new(const gchar *label)
 {
 	RaucStats *stats = g_new0(RaucStats, 1);
 
+	stats->label = g_strdup(label);
 	stats->min = G_MAXDOUBLE;
 	stats->max = G_MINDOUBLE;
 
@@ -75,6 +76,8 @@ void r_stats_free(RaucStats *stats)
 {
 	if (!stats)
 		return;
+
+	g_free(stats->label);
 
 	g_free(stats);
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -1,16 +1,16 @@
 #include "stats.h"
 
-void r_stats_init(struct RaucStats *stats)
+RaucStats *r_stats_new(void)
 {
-	g_return_if_fail(stats);
-
-	memset(stats, 0, sizeof(*stats));
+	RaucStats *stats = g_new0(RaucStats, 1);
 
 	stats->min = G_MAXDOUBLE;
 	stats->max = G_MINDOUBLE;
+
+	return stats;
 }
 
-void r_stats_add(struct RaucStats *stats, gdouble value)
+void r_stats_add(RaucStats *stats, gdouble value)
 {
 	g_return_if_fail(stats);
 
@@ -26,7 +26,7 @@ void r_stats_add(struct RaucStats *stats, gdouble value)
 		stats->max = value;
 }
 
-gdouble r_stats_get_avg(const struct RaucStats *stats)
+gdouble r_stats_get_avg(const RaucStats *stats)
 {
 	g_return_val_if_fail(stats, 0.0);
 
@@ -36,7 +36,7 @@ gdouble r_stats_get_avg(const struct RaucStats *stats)
 		return 0.0;
 }
 
-gdouble r_stats_get_recent_avg(const struct RaucStats *stats)
+gdouble r_stats_get_recent_avg(const RaucStats *stats)
 {
 	gdouble sum = 0.0;
 	guint64 count = stats->count;
@@ -55,7 +55,7 @@ gdouble r_stats_get_recent_avg(const struct RaucStats *stats)
 		return 0.0;
 }
 
-void r_stats_show(const struct RaucStats *stats, const gchar *prefix)
+void r_stats_show(const RaucStats *stats, const gchar *prefix)
 {
 	g_autoptr(GString) msg = g_string_sized_new(128);
 
@@ -69,4 +69,12 @@ void r_stats_show(const struct RaucStats *stats, const gchar *prefix)
 			stats->sum, stats->min, stats->max, r_stats_get_avg(stats));
 	g_string_append_printf(msg, " recent-avg=%.3f", r_stats_get_recent_avg(stats));
 	g_message("%s", msg->str);
+}
+
+void r_stats_free(RaucStats *stats)
+{
+	if (!stats)
+		return;
+
+	g_free(stats);
 }

--- a/test/stats.c
+++ b/test/stats.c
@@ -1,0 +1,67 @@
+#include <locale.h>
+#include <glib.h>
+
+#include "stats.h"
+
+static void test_basic(void)
+{
+	g_autoptr(RaucStats) stats = NULL;
+
+	stats = r_stats_new("test");
+	g_assert_nonnull(stats);
+	g_assert_cmpstr(stats->label, ==, "test");
+
+	r_stats_add(stats, 1.0);
+	r_stats_add(stats, 2.0);
+
+	g_assert_cmpuint(stats->count, ==, 2);
+	g_assert_cmpfloat(r_stats_get_avg(stats), ==, 1.5);
+	g_assert_cmpfloat(r_stats_get_recent_avg(stats), ==, 1.5);
+
+	for (guint i = 0; i < 128; i++) {
+		r_stats_add(stats, i);
+	}
+
+	g_assert_cmpuint(stats->count, ==, 130);
+	g_assert_cmpfloat(r_stats_get_avg(stats), ==, 62.54615384615385);
+	g_assert_cmpfloat(r_stats_get_recent_avg(stats), ==, 95.5);
+	g_assert_cmpfloat(stats->sum, ==, 8131.0);
+	g_assert_cmpfloat(stats->min, ==, 0.0);
+	g_assert_cmpfloat(stats->max, ==, 127.0);
+}
+
+static void test_queue(void)
+{
+	g_autoptr(RaucStats) stats = NULL;
+
+	r_test_stats_start();
+	test_basic();
+	stats = r_stats_new("test 2");
+	g_clear_pointer(&stats, r_stats_free);
+	r_test_stats_stop();
+
+	stats = r_test_stats_next();
+	g_assert_nonnull(stats);
+	g_assert_cmpstr(stats->label, ==, "test");
+	g_clear_pointer(&stats, r_stats_free);
+
+	stats = r_test_stats_next();
+	g_assert_nonnull(stats);
+	g_assert_cmpstr(stats->label, ==, "test 2");
+	g_clear_pointer(&stats, r_stats_free);
+
+	r_test_stats_start();
+	r_test_stats_stop();
+}
+
+int main(int argc, char *argv[])
+{
+	setlocale(LC_ALL, "C");
+
+	g_test_init(&argc, &argv, NULL);
+
+	g_test_add_func("/stats/basic", test_basic);
+	g_test_add_func("/stats/queue", test_queue);
+
+	return g_test_run();
+}


### PR DESCRIPTION
This is preparation for additional testing infrastructure. By adding a label to
the RaucStats, we can queue completed (freed) stats for later checks in unit
tests. This also allows us to support `g_autoptr(RaucStats)`.