### PR TITLE
Add --trust-environment for 'extract' and 'extract-signature'

### DIFF
--- a/rauc.1
+++ b/rauc.1
@@ -155,6 +155,14 @@ verification keyring file
 .RS 4
 Extract the bundle content to a directory.
 
+\fBOptions:\fR
+
+.RS 4
+
+.TP
+\fB\-\-trust\-environment\fR
+trust environment and skip bundle access checks
+
 .RE
 .RE
 .PP

--- a/rauc.1
+++ b/rauc.1
@@ -171,6 +171,14 @@ trust environment and skip bundle access checks
 .RS 4
 Extract the bundle signature.
 
+\fBOptions:\fR
+
+.RS 4
+
+.TP
+\fB\-\-trust\-environment\fR
+trust environment and skip bundle access checks
+
 .RE
 .RE
 .PP

--- a/src/main.c
+++ b/src/main.c
@@ -651,6 +651,7 @@ out:
 
 static gboolean extract_start(int argc, char **argv)
 {
+	CheckBundleParams check_bundle_params = CHECK_BUNDLE_DEFAULT;
 	RaucBundle *bundle = NULL;
 	GError *ierror = NULL;
 	g_debug("extract start");
@@ -676,7 +677,10 @@ static gboolean extract_start(int argc, char **argv)
 	g_debug("input bundle: %s", argv[2]);
 	g_debug("output dir: %s", argv[3]);
 
-	if (!check_bundle(argv[2], &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror)) {
+	if (trust_environment)
+		check_bundle_params |= CHECK_BUNDLE_TRUST_ENV;
+
+	if (!check_bundle(argv[2], &bundle, check_bundle_params, NULL, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -2019,6 +2023,11 @@ static GOptionEntry entries_convert[] = {
 	{0}
 };
 
+static GOptionEntry entries_extract[] = {
+	{"trust-environment", '\0', 0, G_OPTION_ARG_NONE, &trust_environment, "trust environment and skip bundle access checks", NULL},
+	{0}
+};
+
 static GOptionEntry entries_info[] = {
 	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
 	{"no-check-time", '\0', 0, G_OPTION_ARG_NONE, &no_check_time, "don't check validity period of certificates against current time", NULL},
@@ -2063,6 +2072,7 @@ static GOptionGroup *resign_group;
 static GOptionGroup *replace_group;
 static GOptionGroup *convert_group;
 static GOptionGroup *encrypt_group;
+static GOptionGroup *extract_group;
 static GOptionGroup *info_group;
 static GOptionGroup *status_group;
 static GOptionGroup *service_group;
@@ -2090,6 +2100,9 @@ static void create_option_groups(void)
 		encrypt_group = g_option_group_new("encrypt", "Encryption options:", "help dummy", NULL, NULL);
 		g_option_group_add_entries(encrypt_group, entries_encryption);
 	}
+
+	extract_group = g_option_group_new("extract", "Extract options:", "help dummy", NULL, NULL);
+	g_option_group_add_entries(extract_group, entries_extract);
 
 	info_group    = g_option_group_new("info", "Info options:", "help dummy", NULL, NULL);
 	g_option_group_add_entries(info_group, entries_info);
@@ -2153,7 +2166,7 @@ static void cmdline_handler(int argc, char **argv)
 #endif
 		{EXTRACT, "extract", "extract <BUNDLENAME> <OUTPUTDIR>",
 		 "Extract the bundle content",
-		 extract_start, NULL, R_CONTEXT_CONFIG_MODE_AUTO, FALSE},
+		 extract_start, extract_group, R_CONTEXT_CONFIG_MODE_AUTO, FALSE},
 		{INFO, "info", "info <FILE>",
 		 "Print bundle info",
 		 info_start, info_group, R_CONTEXT_CONFIG_MODE_AUTO, FALSE},


### PR DESCRIPTION
This option was already available for other commands, like
'rauc convert'.

Sometimes a bundle needs to be extracted but it may not be possible, or
desirable, to perform the standard bundle access checks.

For example if RAUC is executed from a controlled environment where the
ownership of a bundle is not an issue. Or when obtaining the underlying
device is not possible at all, e.g. when inside an unprivileged Docker
container.

----

I didn't add `--no-verify` because that's potentially more risky, and usually `--trust-environment` should be enough to cover nearly all use cases.