### PR TITLE
docs: fix broken links to GLib/U-Boot docs

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -754,7 +754,7 @@ If you place this on a partition next to U-Boot, it will use it as its boot
 script.
 
 For more details, refer the
-`U-Boot Scripting Capabilities <https://www.denx.de/wiki/DULG/UBootScripts>`_
+`U-Boot Scripting Capabilities <https://www.denx.de/wiki/Knowhow/DULG/UBootScripts>`_
 chapter in the U-Boot user documentation.
 
 The example script uses the names ``A`` and ``B`` as the ``bootname`` for the two
@@ -815,7 +815,7 @@ you need to have:
 * Environment configuration file ``/etc/fw_env.config`` in your target root filesystem.
 
 See the corresponding
-`HowTo <https://www.denx.de/wiki/DULG/HowCanIAccessUBootEnvironmentVariablesInLinux>`_
+`HowTo <https://www.denx.de/wiki/Knowhow/DULG/HowCanIAccessUBootEnvironmentVariablesInLinux>`_
 section from the U-Boot documentation for more details on how to set up the
 environment config file for your device.
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -681,7 +681,7 @@ increase the log level for narrowing down the actual error cause or gaining
 more information about the circumstances when the error occurs.
 
 RAUC uses glib and the
-`glib logging framework <https://developer.gnome.org/programming-guidelines/stable/logging.html.en>`_ with the basic log domain 'rauc'.
+`glib logging framework <https://docs.gtk.org/glib/logging.html>`_ with the basic log domain 'rauc'.
 
 For simple cases, you can activate logging by passing the ``-d`` or ``--debug`` option to either the CLI:
 


### PR DESCRIPTION
Stumbled upon a broken link, so I used [linkchecker](https://linkchecker.github.io/linkchecker/) to check all doc pages.