### PR TITLE
README, docs/integration: be explicit that kernel modules are sufficient

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,14 +148,14 @@ If you intend to use json-support you also need
 Target Prerequisites
 ~~~~~~~~~~~~~~~~~~~~
 
-Required kernel options:
+Required kernel options (either ``y`` or ``m``):
 
--  ``CONFIG_MD=y``
--  ``CONFIG_BLK_DEV_DM=y``
--  ``CONFIG_BLK_DEV_LOOP=y``
--  ``CONFIG_DM_VERITY=y``
--  ``CONFIG_SQUASHFS=y``
--  ``CONFIG_CRYPTO_SHA256=y``
+-  ``CONFIG_MD``
+-  ``CONFIG_BLK_DEV_DM``
+-  ``CONFIG_BLK_DEV_LOOP``
+-  ``CONFIG_DM_VERITY``
+-  ``CONFIG_SQUASHFS``
+-  ``CONFIG_CRYPTO_SHA256``
 -  ``CONFIG_BLK_DEV_NBD`` (for streaming support)
 -  ``CONFIG_DM_CRYPT`` (for encryption support)
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -184,16 +184,17 @@ SquashFS file system to allow installing RAUC bundles. For the recommended
 ``verity`` :ref:`bundle format<sec_ref_formats>`, dm-verity must be supported as
 well.
 
-In kernel Kconfig you have to enable the following options:
+In kernel Kconfig you have to enable the following options as either built-in
+(``y``) or module (``m``):
 
 .. code-block:: cfg
 
-  CONFIG_MD=y
-  CONFIG_BLK_DEV_DM=y
-  CONFIG_BLK_DEV_LOOP=y
-  CONFIG_DM_VERITY=y
-  CONFIG_SQUASHFS=y
-  CONFIG_CRYPTO_SHA256=y
+  CONFIG_MD
+  CONFIG_BLK_DEV_DM
+  CONFIG_BLK_DEV_LOOP
+  CONFIG_DM_VERITY
+  CONFIG_SQUASHFS
+  CONFIG_CRYPTO_SHA256
 
 For streaming support, you have to add ``CONFIG_BLK_DEV_NBD``.
 For encryption support, you have to add ``CONFIG_DM_CRYPT``.


### PR DESCRIPTION
Just mentioning =y can be confusing, so mention that =m is fine, too.