### PR TITLE
src/update_handler: remove debug message in vfat_label_generator

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -713,7 +713,6 @@ static gchar* vfat_label_generator(const gchar *name)
 			*c = g_ascii_toupper(*c);
 		/* replace invalid chars */
 		for (size_t i = 0; i < strlen(invalid_chars); i++) {
-			g_message("r: %c", invalid_chars[i]);
 			if (*c == invalid_chars[i]) {
 				*c = '_';
 				break;


### PR DESCRIPTION
Previously, this printed each invalid character one-by-one during checking.
As this is derived from the slot name, we don't need to complain about invalid
characters.