### PR TITLE
improve stats messages

### DIFF
--- a/src/nbd.c
+++ b/src/nbd.c
@@ -900,12 +900,12 @@ gboolean r_nbd_run_server(gint sock, GError **error)
 		};
 	}
 
-	r_stats_show(ctx.dl_size, "dl size");
-	r_stats_show(ctx.dl_speed, "dlspeed");
-	r_stats_show(ctx.namelookup, "name lookup");
-	r_stats_show(ctx.connect, "connect");
-	r_stats_show(ctx.starttransfer, "start transfer");
-	r_stats_show(ctx.total, "total");
+	r_stats_show(ctx.dl_size, NULL);
+	r_stats_show(ctx.dl_speed, NULL);
+	r_stats_show(ctx.namelookup, NULL);
+	r_stats_show(ctx.connect, NULL);
+	r_stats_show(ctx.starttransfer, NULL);
+	r_stats_show(ctx.total, NULL);
 
 	res = TRUE;
 out:

--- a/src/stats.c
+++ b/src/stats.c
@@ -74,10 +74,12 @@ void r_stats_show(const RaucStats *stats, const gchar *prefix)
 
 	g_string_append_printf(msg, "%s: count=%"G_GUINT64_FORMAT, prefix_label, stats->count);
 	if (!stats->count)
-		return;
+		goto out;
 	g_string_append_printf(msg, " sum=%.3f min=%.3f max=%.3f avg=%.3f",
 			stats->sum, stats->min, stats->max, r_stats_get_avg(stats));
 	g_string_append_printf(msg, " recent-avg=%.3f", r_stats_get_recent_avg(stats));
+
+out:
 	g_message("%s", msg->str);
 }
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -61,12 +61,18 @@ gdouble r_stats_get_recent_avg(const RaucStats *stats)
 
 void r_stats_show(const RaucStats *stats, const gchar *prefix)
 {
+	g_autofree gchar *prefix_label = NULL;
 	g_autoptr(GString) msg = g_string_sized_new(128);
 
 	g_return_if_fail(stats);
-	g_return_if_fail(prefix);
 
-	g_string_append_printf(msg, "%s: count=%"G_GUINT64_FORMAT, prefix, stats->count);
+	if (prefix) {
+		prefix_label = g_strdup_printf("%s %s", prefix, stats->label);
+	} else {
+		prefix_label = g_strdup(stats->label);
+	}
+
+	g_string_append_printf(msg, "%s: count=%"G_GUINT64_FORMAT, prefix_label, stats->count);
 	if (!stats->count)
 		return;
 	g_string_append_printf(msg, " sum=%.3f min=%.3f max=%.3f avg=%.3f",

--- a/src/stats.c
+++ b/src/stats.c
@@ -111,7 +111,9 @@ RaucStats *r_test_stats_next(void)
 	RaucStats *stats = NULL;
 
 	g_assert_false(test_stats_enabled);
-	g_assert_nonnull(test_stats_queue);
+
+	if (!test_stats_queue)
+		return NULL;
 
 	stats = test_stats_queue->data;
 	test_stats_queue = g_list_delete_link(test_stats_queue, test_stats_queue);


### PR DESCRIPTION
We can now set a label when we create a stats struct and a prefix when we print it.
Combine both in `r_stats_show()` and adjust the code in `nbd.c` accordingly.