### PR TITLE
fix stable CI builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,7 +138,7 @@ jobs:
 
     - name: Configure
       run: |
-        docker exec -i stable ./configure --disable-gpt CFLAGS=-Werror
+        docker exec -i stable ./configure --disable-gpt CFLAGS='-Werror -Wno-error=deprecated-declarations'
 
     - name: Build
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
         release:
         - "18.04"
         - "20.04"
-        - "21.10"
+        - "22.04"
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
The Ubuntu mirrors no longer provide 21.10, so we have to move to 22.04.

As 22.04. uses OpenSSL 3.0.0, we need to accept some deprecation warnings.
