### PR TITLE
manifest: ignore meta.<label> sections in the manifest

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -604,6 +604,17 @@ A valid RAUC manifest file must be named ``manifest.raucm``.
 
   * ``block-hash-index``
 
+.. _meta.label-section:
+
+**[meta.<label>] sections**
+
+``<key>``
+  The ``meta.<label>`` sections are intended to provide a forwards-compatible
+  way to add data to the manifest which is not interpreted by RAUC in any way.
+  Currently, they are just ignored when reading a manifest.
+  In future releases, they will be accessible via ``rauc info``, the D-Bus API
+  and in hooks/handlers.
+
 .. _sec_ref_formats:
 
 Bundle Formats

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -189,9 +189,9 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 	}
 	g_key_file_remove_group(key_file, "hooks", NULL);
 
-	/* parse [image.<slotclass>] sections */
 	groups = g_key_file_get_groups(key_file, &group_count);
 	for (gsize i = 0; i < group_count; i++) {
+		/* parse [image.<slotclass>] sections */
 		if (g_str_has_prefix(groups[i], RAUC_IMAGE_PREFIX ".")) {
 			RaucImage *image = NULL;
 
@@ -201,6 +201,10 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 			}
 
 			raucm->images = g_list_append(raucm->images, image);
+		}
+		/* ignore [meta.<label>] sections */
+		if (g_str_has_prefix(groups[i], "meta.")) {
+			g_key_file_remove_group(key_file, groups[i], NULL);
 		}
 	}
 

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -334,6 +334,51 @@ incremental=invalid-method;another-invalid-method\n\
 	free_manifest(rm);
 }
 
+static void test_manifest_load_meta(void)
+{
+	gchar *tmpdir;
+	RaucManifest *rm = NULL;
+	gchar* manifestpath = NULL;
+	gboolean res;
+	GError *error = NULL;
+	RaucImage *test_img = NULL;
+	const gchar *mffile = "\
+[update]\n\
+compatible=FooCorp Super BarBazzer\n\
+version=2015.04-1\n\
+\n\
+[image.rootfs]\n\
+filename=rootfs-default.ext4\n\
+\n\
+[meta.foocorp]\n\
+release-type=beta\n\
+release-notes=https://foocorp.example/releases/release-notes-2015.04-1.rst\n\
+\n\
+[meta.example]\n\
+counter=42\n\
+";
+
+	tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+	g_assert_nonnull(tmpdir);
+
+	manifestpath = write_tmp_file(tmpdir, "manifest.raucm", mffile, NULL);
+	g_assert_nonnull(manifestpath);
+
+	g_free(tmpdir);
+
+	res = load_manifest_file(manifestpath, &rm, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	g_clear_error(&error);
+	g_free(manifestpath);
+
+	test_img = (RaucImage*)g_list_nth_data(rm->images, 0);
+	g_assert_nonnull(test_img);
+
+	free_manifest(rm);
+}
+
 static void test_manifest_invalid_hook_name(void)
 {
 	g_autofree gchar *tmpdir;
@@ -568,6 +613,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/manifest/load_mem", test_load_manifest_mem);
 	g_test_add_func("/manifest/load_variants", test_manifest_load_variants);
 	g_test_add_func("/manifest/load_incremental", test_manifest_load_incremental);
+	g_test_add_func("/manifest/load_meta", test_manifest_load_meta);
 	g_test_add_func("/manifest/invalid_hook_name", test_manifest_invalid_hook_name);
 	g_test_add_func("/manifest/missing_hook_name", test_manifest_missing_hook_name);
 	g_test_add_func("/manifest/missing_image_size", test_manifest_missing_image_size);


### PR DESCRIPTION
The `meta.<label>` sections are intended to provide a forwards-compatible way to
add data to the manifest which is not interpreted by RAUC in any way.
Currently, they are just ignored when reading a manifest. In future releases,
they will be accessible via `rauc info`, the D-Bus API and in hooks/handlers.