### PR TITLE
mount: remove use of sudo when running as non-root

### DIFF
--- a/include/mount.h
+++ b/include/mount.h
@@ -38,8 +38,6 @@ G_GNUC_WARN_UNUSED_RESULT;
 /**
  * Wrapper for calling systems 'mount' command.
  *
- * If invoked as a user, mount command will be called using 'sudo'.
- *
  * @param source source path for mount
  * @param mountpoint destination path for mount
  * @param type type of image to mount (results in -t option)

--- a/src/mount.c
+++ b/src/mount.c
@@ -65,10 +65,6 @@ gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar*
 	g_return_val_if_fail(mountpoint != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (getuid() != 0) {
-		g_ptr_array_add(args, g_strdup("sudo"));
-		g_ptr_array_add(args, g_strdup("--non-interactive"));
-	}
 	g_ptr_array_add(args, g_strdup("mount"));
 	if (type != NULL) {
 		g_ptr_array_add(args, g_strdup("-t"));
@@ -253,10 +249,6 @@ gboolean r_umount(const gchar *filename, GError **error)
 	g_return_val_if_fail(filename != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (getuid() != 0) {
-		g_ptr_array_add(args, g_strdup("sudo"));
-		g_ptr_array_add(args, g_strdup("--non-interactive"));
-	}
 	g_ptr_array_add(args, g_strdup("umount"));
 	g_ptr_array_add(args, g_strdup(filename));
 	g_ptr_array_add(args, NULL);

--- a/test/common.c
+++ b/test/common.c
@@ -250,10 +250,6 @@ gboolean test_do_chmod(const gchar *path)
 	gboolean res = FALSE;
 	GPtrArray *args = g_ptr_array_new_full(10, g_free);
 
-	if (getuid() != 0) {
-		g_ptr_array_add(args, g_strdup("sudo"));
-		g_ptr_array_add(args, g_strdup("--non-interactive"));
-	}
 	g_ptr_array_add(args, g_strdup("chmod"));
 	g_ptr_array_add(args, g_strdup("777"));
 	g_ptr_array_add(args, g_strdup(path));

--- a/test/install-content/custom_handler.sh
+++ b/test/install-content/custom_handler.sh
@@ -10,11 +10,6 @@ function exit_if_empty {
 	if [ -z "$1" ]; then exit 1; fi
 }
 
-rootrun=""
-if [ "$EUID" != 0 ]; then
-	rootrun="sudo"
-fi
-
 # Sanity check
 for i in $(env | grep "^RAUC_"); do
 	echo $i
@@ -65,11 +60,11 @@ for i in $RAUC_TARGET_SLOTS; do
 	echo "<< image $RAUC_IMAGE_NAME [DONE]"
 
 	# Write slot status file
-	$rootrun mount $RAUC_SLOT_DEVICE $RAUC_MOUNT_PREFIX/image
+	mount $RAUC_SLOT_DEVICE $RAUC_MOUNT_PREFIX/image
 	echo [slot] > $RAUC_MOUNT_PREFIX/image/slot.raucs
 	echo status=ok >> $RAUC_MOUNT_PREFIX/image/slot.raucs
 	echo sha256=$RAUC_IMAGE_DIGEST >> $RAUC_MOUNT_PREFIX/image/slot.raucs
-	$rootrun umount $RAUC_MOUNT_PREFIX/image
+	umount $RAUC_MOUNT_PREFIX/image
 done
 
 # Update boot priority


### PR DESCRIPTION
These were added to simplify testing before we had the qemu test environment.
By now, they are mostly useless, as other things will break without root. Also,
failed sudo accesses can cause annoying audit messages for admins.