### PR TITLE
src/update_handler: unconditionally avoid fallback for boot-emmc

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -2497,8 +2497,8 @@ RaucUpdatePair updatepairs[] = {
 	{"*.squashfs-zst", "ubivol", img_to_ubivol_handler},
 #if ENABLE_EMMC_BOOT_SUPPORT == 1
 	{"*.img", "boot-emmc", img_to_boot_emmc_handler},
-	{"*", "boot-emmc", NULL},
 #endif
+	{"*", "boot-emmc", NULL},
 	{"*.vfat", "boot-mbr-switch", img_to_boot_mbr_switch_handler},
 	{"*.img", "boot-mbr-switch", img_to_boot_mbr_switch_handler},
 	{"*", "boot-mbr-switch", NULL},


### PR DESCRIPTION
We must prevent using the fallback handler match when slot type is
'boot-emmc' regardless of whether eMMC support is enabled or not.

Thus move the corresponding match out of the #if statement.

Fixes: c0f8ad4e