### PR TITLE
rename incremental mode updates to adaptive mode updates

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,14 +3,14 @@ Release 1.8 (development)
 
 .. rubric:: Enhancements
 
-* Implement incremental image updates based on block hash indices.
+* Implement adaptive image updates based on block hash indices.
   This works by adding an index file containing the hashes of each 4kiB image
   block in the image to the bundle and then using this to check whether a block
   is available locally during installation.
   If that's the case, RAUC doesn't need to download this block.
   Together with streaming, this means that only a small part of the bundle needs
   to be downloaded as long as the changes are localized.
-  See the :ref:`documentation for details <sec-incremental-updates>`.
+  See the :ref:`documentation for details <sec-adaptive-updates>`.
 * Add a slot type which provides atomic bootloader updates for SoCs (like the
   Rockchip RK3568) which search for a valid image at multiple fixed offsets. (by
   Matthias Fend)
@@ -65,7 +65,7 @@ Release 1.7 (released Jun 3, 2022)
 * Add support for streaming installation from a HTTP(S) server for bundles in
   ``verity`` and ``crypt`` formats.
   This avoids the need for a temporary bundle storage location and prepares for
-  more efficient incremental updates.
+  more efficient *adaptive* (originally *incremental*) updates.
   See the :ref:`documentation for details <http-streaming>`.
 * Add support for bundle encryption (``crypt`` format).
   This is useful when bundles contain confidential data and are not otherwise
@@ -111,6 +111,12 @@ Release 1.7 (released Jun 3, 2022)
 * Use more specific error codes for device mapper error reporting.
 * Prepare for incremental methods by adding an optional per-image manifest
   option.
+
+.. note::
+  Since the release of 1.7, it turned out that the name 'incremental' for this
+  functionality is confusing.
+  Accordingly, we decided to rename it to 'adaptive' for 1.8 and accept the
+  downside of not being able to benefit from compatibility with 1.7.
 
 .. rubric:: Documentation
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -463,9 +463,9 @@ For example, when installing a 190MiB bundle on a STM32MP1 SoC (dual ARM
 Cortex-A7) with an eMMC, streaming took 1m43s, while downloading followed by
 local installation took 1m42s (13s+1m29s).
 
-As each chunk of compressed data is only requested incrementally when needed by
-the installation processes, you should expect that network connections with
-higher round-trip-time (RTT) lead to longer installation times.
+As each chunk of compressed data is only requested when needed by the
+installation processes, you should expect that network connections with higher
+round-trip-time (RTT) lead to longer installation times.
 This can be compensated somewhat by using a HTTP/2 server, as this supports
 multiplexing and better connection reuse.
 
@@ -738,38 +738,38 @@ returned ``1`` as its output.
 
 With this you can always mount ``/dev/data`` and get the correct data slot.
 
-.. _sec-incremental-updates:
+.. _sec-adaptive-updates:
 
-Incremental Updates
--------------------
+Adaptive Updates
+----------------
 
-We use the term *incremental* updates explicitly to distinguish this approach from
+We use the term *adaptive* updates explicitly to distinguish this approach from
 *delta* updates.
 Delta updates contain the data necessary to move from one specific version the
 new version.
-Incremental updates do not need to be installed on a specific previous version.
-Instead they contain information that allows opportunistic use of data that is
-already available on the target system, either from any previous version of from
-an interrupted installation attempt.
+Adaptive updates do not need to be installed on a specific previous version.
+Instead, they contain information that allows *adaptive* selection of one of
+multiple methods, using data that is already available on the target system,
+either from any previous version or from an interrupted installation attempt.
 
-Incremental updates are intended to be used together with :ref:`http-streaming`,
+Adaptive updates are intended to be used together with :ref:`http-streaming`,
 as this allows RAUC to download only the parts of the bundle that are actually
 needed.
 
-As the bundle itself still contains the full information, using incremental
+As the bundle itself still contains the full information, using adaptive
 updates does not change the normal flow of creating, distributing and installing
 bundles.
 It can be considered only an optimization of download size for bundle streaming.
 
-To enable incremental updates during bundle creation, add
-``incremental=<method>`` to the relevant ``[[image.<slot class>]]`` sections of
+To enable adaptive updates during bundle creation, add
+``adaptive=<method>`` to the relevant ``[[image.<slot class>]]`` sections of
 your manifest and configure the :ref:`shared data directory <data-directory>` in
 your ``system.conf``.
 
-Currently, the only supported incremental method is ``block-hash-index``.
+Currently, the only supported adaptive method is ``block-hash-index``.
 
-Block-based Incremental Update (``block-hash-index``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Block-based Adaptive Update (``block-hash-index``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This method works by creating an index file consisting of a hash for each data
 block in the image and then using this to check whether the data for each block
@@ -781,7 +781,7 @@ After installation, RAUC also stores the current index for each slot in the
 
 During installation, RAUC accesses both slots (currently active and target) of
 the class to be installed and reads the stored index for each.
-If no index is available for a slot (perhaps because incremental mode was not
+If no index is available for a slot (perhaps because adaptive mode was not
 used for previous updates), it is generated on-demand, which will take
 additional time.
 Then RAUC will iterate over the hash index in the bundle and try to locate a
@@ -799,7 +799,7 @@ of 0.8% of the original image.
 With small changes (such as updating a single package) in an ``ext4`` image, we
 have seen that around 10% of the bundle size needs to be downloaded.
 When indices for all slots are available on the target, the installation
-duration (compared to without incremental mode) is often similar and can be
+duration (compared to without adaptive mode) is often similar and can be
 slightly faster if the changes are small.
 
 .. note::

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -1163,7 +1163,7 @@ For more information on how to use the layer, also see the layer's `README
 <https://github.com/rauc/meta-rauc/blob/master/README.rst>`_ file.
 
 .. note::
-   When using the block hash incremental mode, you may need to set
+   When using the ``block-hash-index`` adaptive mode, you may need to set
    ``IMAGE_ROOTFS_ALIGNMENT = "4"`` in your ``machine.conf`` to ensure that the
    image is padded to full 4 kiB blocks.
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -591,16 +591,16 @@ A valid RAUC manifest file must be named ``manifest.raucm``.
 
   Valid items are: ``pre-install``, ``install``, ``post-install``
 
-``incremental``
-  List of ``;``-separated per-slot incremental update method names.
+``adaptive``
+  List of ``;``-separated per-slot adaptive update method names.
   These methods will add extra information to the bundle, allowing RAUC to
   access only the parts of an image which are not yet available locally.
   Together with streaming, this reduces the amount of downloaded data.
 
   As the full image is still available in the bundle, older RAUC versions can
-  ignore unsupported incremental methods.
+  ignore unsupported adaptive methods.
 
-  Currently implemented incremental methods:
+  Currently implemented adaptive methods:
 
   * ``block-hash-index``
 

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -30,7 +30,7 @@ typedef struct {
 	RaucChecksum checksum;
 	gchar* filename;
 	SlotHooks hooks;
-	GStrv incremental;
+	GStrv adaptive;
 } RaucImage;
 
 typedef enum {

--- a/include/update_handler.h
+++ b/include/update_handler.h
@@ -12,7 +12,7 @@ GQuark r_update_error_quark(void);
 typedef enum {
 	R_UPDATE_ERROR_FAILED,
 	R_UPDATE_ERROR_NO_HANDLER,
-	R_UPDATE_ERROR_UNSUPPORTED_INCREMENTAL_MODE,
+	R_UPDATE_ERROR_UNSUPPORTED_ADAPTIVE_MODE,
 } RUpdateError;
 
 typedef gboolean (*img_to_slot_handler)(RaucImage *image, RaucSlot *dest_slot, const gchar *hook_name, GError **error)

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -404,7 +404,7 @@ out:
 	return res;
 }
 
-static gboolean generate_incremental_data(RaucManifest *manifest, const gchar *dir, GError **error)
+static gboolean generate_adaptive_data(RaucManifest *manifest, const gchar *dir, GError **error)
 {
 	GError *ierror = NULL;
 
@@ -416,11 +416,11 @@ static gboolean generate_incremental_data(RaucManifest *manifest, const gchar *d
 		RaucImage *image = elem->data;
 		g_autofree gchar *imagepath = g_build_filename(dir, image->filename, NULL);
 
-		if (!image->incremental)
+		if (!image->adaptive)
 			continue;
 
-		for (gchar **inc_method = image->incremental; *inc_method != NULL; inc_method++) {
-			if (g_str_equal(*inc_method, "block-hash-index")) {
+		for (gchar **method = image->adaptive; *method != NULL; method++) {
+			if (g_str_equal(*method, "block-hash-index")) {
 				/* Use a filename of bundle/<image-name>.block-hash-index. */
 				g_autofree gchar *indexname = g_strconcat(image->filename, ".block-hash-index", NULL);
 				g_autofree gchar *indexpath = g_build_filename(dir, indexname, NULL);
@@ -456,14 +456,14 @@ static gboolean generate_incremental_data(RaucManifest *manifest, const gchar *d
 				}
 
 				g_debug("Created block-hash-index for image %s", image->filename);
-			} else if (g_str_equal(*inc_method, "incremental-test-method")) {
-				g_debug("Ignoring incremental-test-method for image %s", image->filename);
+			} else if (g_str_equal(*method, "adaptive-test-method")) {
+				g_debug("Ignoring adaptive-test-method for image %s", image->filename);
 			} else {
 				g_set_error(
 						error,
 						R_BUNDLE_ERROR,
 						R_BUNDLE_ERROR_PAYLOAD,
-						"Unsupported incremental method: %s", *inc_method);
+						"Unsupported adaptive method: %s", *method);
 				return FALSE;
 			}
 		}
@@ -863,7 +863,7 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 		goto out;
 	}
 
-	res = generate_incremental_data(manifest, contentdir, &ierror);
+	res = generate_adaptive_data(manifest, contentdir, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;

--- a/src/main.c
+++ b/src/main.c
@@ -897,9 +897,9 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 
 		g_ptr_array_unref(hooks);
 
-		if (img->incremental) {
-			temp_string = g_strjoinv(" ", (gchar**) img->incremental);
-			formatter_shell_append_n(text, "RAUC_IMAGE_INCREMENTAL", cnt, temp_string);
+		if (img->adaptive) {
+			temp_string = g_strjoinv(" ", (gchar**) img->adaptive);
+			formatter_shell_append_n(text, "RAUC_IMAGE_ADAPTIVE", cnt, temp_string);
 			g_free(temp_string);
 		}
 
@@ -986,9 +986,9 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 
 		g_ptr_array_unref(hooks);
 
-		if (img->incremental) {
-			temp_string = g_strjoinv(" ", (gchar**) img->incremental);
-			g_string_append_printf(text, "\tIncremental: %s\n", temp_string);
+		if (img->adaptive) {
+			temp_string = g_strjoinv(" ", (gchar**) img->adaptive);
+			g_string_append_printf(text, "\tAdaptive:    %s\n", temp_string);
 			g_free(temp_string);
 		}
 
@@ -1056,10 +1056,10 @@ static gchar* info_formatter_json_base(RaucManifest *manifest, gboolean pretty)
 			json_builder_add_string_value(builder, "post-install");
 		}
 		json_builder_end_array(builder);
-		json_builder_set_member_name(builder, "incremental");
+		json_builder_set_member_name(builder, "adaptive");
 		json_builder_begin_array(builder);
-		if (img->incremental) {
-			for (gchar **m = img->incremental; *m != NULL; m++) {
+		if (img->adaptive) {
+			for (gchar **m = img->adaptive; *m != NULL; m++) {
 				json_builder_add_string_value(builder, *m);
 			}
 		}

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -78,8 +78,8 @@ static gboolean parse_image(GKeyFile *key_file, const gchar *group, RaucImage **
 		goto out;
 	}
 
-	iimage->incremental = g_key_file_get_string_list(key_file, group, "incremental", NULL, NULL);
-	g_key_file_remove_key(key_file, group, "incremental", NULL);
+	iimage->adaptive = g_key_file_get_string_list(key_file, group, "adaptive", NULL, NULL);
+	g_key_file_remove_key(key_file, group, "adaptive", NULL);
 
 	if (!check_remaining_keys(key_file, group, &ierror)) {
 		g_propagate_error(error, ierror);
@@ -597,9 +597,9 @@ static GKeyFile *prepare_manifest(const RaucManifest *mf)
 					(const gchar **)hooklist->pdata, hooklist->len);
 		}
 
-		if (image->incremental)
-			g_key_file_set_string_list(key_file, group, "incremental",
-					(const gchar * const *)image->incremental, g_strv_length(image->incremental));
+		if (image->adaptive)
+			g_key_file_set_string_list(key_file, group, "adaptive",
+					(const gchar * const *)image->adaptive, g_strv_length(image->adaptive));
 	}
 
 	return g_steal_pointer(&key_file);
@@ -652,7 +652,7 @@ void r_free_image(gpointer data)
 	g_free(image->variant);
 	g_free(image->checksum.digest);
 	g_free(image->filename);
-	g_strfreev(image->incremental);
+	g_strfreev(image->adaptive);
 	g_free(image);
 }
 

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -749,7 +749,7 @@ out:
 	return res;
 }
 
-static gboolean copy_incremental_image_to_dev(RaucImage *image, RaucSlot *slot, GError **error)
+static gboolean copy_adaptive_image_to_dev(RaucImage *image, RaucSlot *slot, GError **error)
 {
 	GError *ierror = NULL;
 	g_autofree gchar* temp_string = NULL;
@@ -758,7 +758,7 @@ static gboolean copy_incremental_image_to_dev(RaucImage *image, RaucSlot *slot, 
 	g_return_val_if_fail(slot, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (g_strv_contains((const gchar * const*)image->incremental, "block-hash-index")) {
+	if (g_strv_contains((const gchar * const*)image->adaptive, "block-hash-index")) {
 		if (!copy_block_hash_index_image_to_dev(image, slot, &ierror)) {
 			g_propagate_error(error, ierror);
 			return FALSE;
@@ -766,9 +766,9 @@ static gboolean copy_incremental_image_to_dev(RaucImage *image, RaucSlot *slot, 
 		return TRUE;
 	}
 
-	temp_string = g_strjoinv(" ", (gchar**) image->incremental);
-	g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_UNSUPPORTED_INCREMENTAL_MODE,
-			"No compatible incremental mode found in '%s'", temp_string);
+	temp_string = g_strjoinv(" ", (gchar**) image->adaptive);
+	g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_UNSUPPORTED_ADAPTIVE_MODE,
+			"No compatible adaptive mode found in '%s'", temp_string);
 	return FALSE;
 }
 
@@ -788,13 +788,13 @@ static gboolean write_image_to_dev(RaucImage *image, RaucSlot *slot, GError **er
 		return TRUE;
 	}
 
-	/* Try incremental mode */
-	if (image->incremental && slot->data_directory) {
-		if (!copy_incremental_image_to_dev(image, slot, &ierror)) {
-			if (g_error_matches(ierror, R_UPDATE_ERROR, R_UPDATE_ERROR_UNSUPPORTED_INCREMENTAL_MODE)) {
+	/* Try adaptive mode */
+	if (image->adaptive && slot->data_directory) {
+		if (!copy_adaptive_image_to_dev(image, slot, &ierror)) {
+			if (g_error_matches(ierror, R_UPDATE_ERROR, R_UPDATE_ERROR_UNSUPPORTED_ADAPTIVE_MODE)) {
 				g_info("%s", ierror->message);
 			} else {
-				g_warning("Continuing after incremental mode error: %s", ierror->message);
+				g_warning("Continuing after adaptive mode error: %s", ierror->message);
 			}
 			g_clear_error(&ierror);
 			/* Continue with full copy */

--- a/test/install.c
+++ b/test/install.c
@@ -157,7 +157,7 @@ hooks=post-install";
 	fixture_helper_set_up_bundle(fixture->tmpdir, manifest_file, &data->manifest_test_options);
 }
 
-static void install_fixture_set_up_bundle_incremental(InstallFixture *fixture,
+static void install_fixture_set_up_bundle_adaptive(InstallFixture *fixture,
 		gconstpointer user_data)
 {
 	InstallData *data = (InstallData*) user_data;
@@ -167,7 +167,7 @@ compatible=Test Config\n\
 \n\
 [image.rootfs]\n\
 filename=rootfs.ext4\n\
-incremental=incremental-test-method;block-hash-index";
+adaptive=adaptive-test-method;block-hash-index";
 
 	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
 
@@ -1461,9 +1461,9 @@ int main(int argc, char *argv[])
 		        .format = R_MANIFEST_FORMAT_VERITY,
 		},
 	}));
-	g_test_add("/install/incremental",
+	g_test_add("/install/adaptive",
 			InstallFixture, install_data,
-			install_fixture_set_up_bundle_incremental, install_test_bundle,
+			install_fixture_set_up_bundle_adaptive, install_test_bundle,
 			install_fixture_tear_down);
 
 	return g_test_run();

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -145,7 +145,7 @@ static void test_save_load_manifest(void)
 	new_image->filename = g_strdup("myrootimg_vareiant1.ext4");
 	new_image->hooks.pre_install = TRUE;
 	new_image->hooks.post_install = TRUE;
-	new_image->incremental = g_strsplit("invalid-method;another-invalid-method", ";", 0);
+	new_image->adaptive = g_strsplit("invalid-method;another-invalid-method", ";", 0);
 	rm->images = g_list_append(rm->images, new_image);
 
 	new_image = g_new0(RaucImage, 1);
@@ -291,7 +291,7 @@ filename=rootfs-var2.ext4\n\
 	free_manifest(rm);
 }
 
-static void test_manifest_load_incremental(void)
+static void test_manifest_load_adaptive(void)
 {
 	gchar *tmpdir;
 	RaucManifest *rm = NULL;
@@ -306,7 +306,7 @@ version=2015.04-1\n\
 \n\
 [image.rootfs]\n\
 filename=rootfs-default.ext4\n\
-incremental=invalid-method;another-invalid-method\n\
+adaptive=invalid-method;another-invalid-method\n\
 ";
 
 	tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
@@ -326,10 +326,10 @@ incremental=invalid-method;another-invalid-method\n\
 
 	test_img = (RaucImage*)g_list_nth_data(rm->images, 0);
 	g_assert_nonnull(test_img);
-	g_assert_nonnull(test_img->incremental);
-	g_assert_cmpint(g_strv_length(test_img->incremental), ==, 2);
-	g_assert_cmpstr(test_img->incremental[0], ==, "invalid-method");
-	g_assert_cmpstr(test_img->incremental[1], ==, "another-invalid-method");
+	g_assert_nonnull(test_img->adaptive);
+	g_assert_cmpint(g_strv_length(test_img->adaptive), ==, 2);
+	g_assert_cmpstr(test_img->adaptive[0], ==, "invalid-method");
+	g_assert_cmpstr(test_img->adaptive[1], ==, "another-invalid-method");
 
 	free_manifest(rm);
 }
@@ -612,7 +612,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/manifest/save/writefail", test_save_manifest_writefail);
 	g_test_add_func("/manifest/load_mem", test_load_manifest_mem);
 	g_test_add_func("/manifest/load_variants", test_manifest_load_variants);
-	g_test_add_func("/manifest/load_incremental", test_manifest_load_incremental);
+	g_test_add_func("/manifest/load_adaptive", test_manifest_load_adaptive);
 	g_test_add_func("/manifest/load_meta", test_manifest_load_meta);
 	g_test_add_func("/manifest/invalid_hook_name", test_manifest_invalid_hook_name);
 	g_test_add_func("/manifest/missing_hook_name", test_manifest_missing_hook_name);

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -280,7 +280,7 @@ static void test_update_handler(UpdateHandlerFixture *fixture,
 		}
 	}
 	if (test_pair->params & TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX) {
-		image->incremental = g_strsplit("block-hash-index", " ", 0);
+		image->adaptive = g_strsplit("block-hash-index", " ", 0);
 	}
 
 	if (test_pair->params & TEST_UPDATE_HANDLER_NO_IMAGE_FILE) {
@@ -533,7 +533,7 @@ int main(int argc, char *argv[])
 		/* nor tests */
 		{"nor", "img", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
 
-		/* incremental tests */
+		/* adaptive tests */
 		{"raw", "img", TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX, 0, 0},
 		{"ext4", "img", TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX, 0, 0},
 		{"raw", "ext4", TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX, 0, 0},
@@ -905,7 +905,7 @@ int main(int argc, char *argv[])
 			test_update_handler,
 			update_handler_fixture_tear_down);
 
-	/* incremental tests */
+	/* adaptive tests */
 	g_test_add("/update_handler/block_hash_index/img_to_raw",
 			UpdateHandlerFixture,
 			&testpair_matrix[56],


### PR DESCRIPTION
Since the release of 1.7, it turned out that the name 'incremental' for this
functionality is confusing.
Accordingly we decided to rename it to 'adaptive' for 1.8 and accept the
downside of not being able to benefit from compatibility with 1.7.