### PR TITLE
Improve boot selection error messages and scoping

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1454,6 +1454,15 @@ static gboolean custom_backend_get(const gchar *cmd, const gchar *bootname, gcha
 		return FALSE;
 	}
 
+	if (!g_subprocess_get_if_exited(sub)) {
+		g_set_error(
+				error,
+				G_SPAWN_ERROR,
+				G_SPAWN_ERROR_FAILED,
+				"%s did not exit normally", backend_name);
+		return FALSE;
+	}
+
 	ret = g_subprocess_get_exit_status(sub);
 	if (ret != 0) {
 		g_set_error(

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1633,6 +1633,9 @@ gboolean r_boot_get_state(RaucSlot* slot, gboolean *good, GError **error)
 	g_return_val_if_fail(good, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
+	/* Function must not be called for slots without a bootname! */
+	g_assert_nonnull(slot->bootname);
+
 	if (g_strcmp0(r_context()->config->system_bootloader, "barebox") == 0) {
 		res = barebox_get_state(slot, good, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "grub") == 0) {

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1556,11 +1556,11 @@ static RaucSlot* custom_get_primary(GError **error)
 	}
 
 	if (!primary) {
-		g_set_error_literal(
+		g_set_error(
 				error,
 				R_BOOTCHOOSER_ERROR,
 				R_BOOTCHOOSER_ERROR_PARSE_FAILED,
-				"Unable to obtain primary slot");
+				"'%s' does not match any configured bootname", ret_str);
 	}
 
 	return primary;

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1696,10 +1696,7 @@ gboolean r_boot_set_state(RaucSlot *slot, gboolean good, GError **error)
 	}
 
 	if (!res) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed marking '%s' as %s: ", slot->name, good ? "good" : "bad");
+		g_propagate_error(error, ierror);
 	}
 
 	return res;

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1709,12 +1709,8 @@ RaucSlot* r_boot_get_primary(GError **error)
 		return NULL;
 	}
 
-	if (!slot) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed getting primary slot: ");
-	}
+	if (!slot)
+		g_propagate_error(error, ierror);
 
 	return slot;
 }

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1762,10 +1762,7 @@ gboolean r_boot_set_primary(RaucSlot *slot, GError **error)
 	}
 
 	if (!res) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed marking '%s' as primary: ", slot->name);
+		g_propagate_error(error, ierror);
 	}
 
 	return res;

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1453,12 +1453,6 @@ static gboolean custom_backend_get(const gchar *cmd, const gchar *bootname, gcha
 				"Failed to run %s: ", backend_name);
 		return FALSE;
 	}
-	data = g_bytes_get_data(stdout_buf, &size);
-	*ret_str = g_strndup(data, size);
-
-	/* Cleanup string for newlines */
-	if (size > 0)
-		g_strstrip(*ret_str);
 
 	ret = g_subprocess_get_exit_status(sub);
 	if (ret != 0) {
@@ -1469,6 +1463,13 @@ static gboolean custom_backend_get(const gchar *cmd, const gchar *bootname, gcha
 				"%s failed with wrong exit code", backend_name);
 		return FALSE;
 	}
+
+	data = g_bytes_get_data(stdout_buf, &size);
+	*ret_str = g_strndup(data, size);
+
+	/* Cleanup string for newlines */
+	if (size > 0)
+		g_strstrip(*ret_str);
 
 	return TRUE;
 }

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1656,7 +1656,10 @@ gboolean r_boot_get_state(RaucSlot* slot, gboolean *good, GError **error)
 	}
 
 	if (!res) {
-		g_propagate_error(error, ierror);
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"%s backend: ", r_context()->config->system_bootloader);
 	}
 
 	return res;
@@ -1693,7 +1696,10 @@ gboolean r_boot_set_state(RaucSlot *slot, gboolean good, GError **error)
 	}
 
 	if (!res) {
-		g_propagate_error(error, ierror);
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"%s backend: ", r_context()->config->system_bootloader);
 	}
 
 	return res;
@@ -1725,8 +1731,12 @@ RaucSlot* r_boot_get_primary(GError **error)
 		return NULL;
 	}
 
-	if (!slot)
-		g_propagate_error(error, ierror);
+	if (!slot) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"%s backend: ", r_context()->config->system_bootloader);
+	}
 
 	return slot;
 }
@@ -1762,7 +1772,10 @@ gboolean r_boot_set_primary(RaucSlot *slot, GError **error)
 	}
 
 	if (!res) {
-		g_propagate_error(error, ierror);
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"%s backend: ", r_context()->config->system_bootloader);
 	}
 
 	return res;

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -568,6 +568,15 @@ static RaucSlot* grub_get_primary(GError **error)
 		return NULL;
 	}
 
+	if (!order->len) {
+		g_set_error_literal(
+				error,
+				R_BOOTCHOOSER_ERROR,
+				R_BOOTCHOOSER_ERROR_PARSE_FAILED,
+				"Variable ORDER is empty");
+		return NULL;
+	}
+
 	/* Iterate over current boot order */
 	bootnames = g_strsplit(order->str, " ", -1);
 	for (gchar **bootname = bootnames; *bootname; bootname++) {

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1656,10 +1656,7 @@ gboolean r_boot_get_state(RaucSlot* slot, gboolean *good, GError **error)
 	}
 
 	if (!res) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed to get state of %s: ", slot->name);
+		g_propagate_error(error, ierror);
 	}
 
 	return res;

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1589,7 +1589,7 @@ static gboolean custom_get_state(RaucSlot *slot, gboolean *good, GError **error)
 				error,
 				R_BOOTCHOOSER_ERROR,
 				R_BOOTCHOOSER_ERROR_FAILED,
-				"Invalid string obtained from custom bootloader backend: '%s'", ret_str);
+				"Obtained string does not match \"good\" or \"bad\": '%s'", ret_str);
 		return FALSE;
 	}
 

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1460,7 +1460,7 @@ static gboolean custom_backend_get(const gchar *cmd, const gchar *bootname, gcha
 				error,
 				G_SPAWN_EXIT_ERROR,
 				ret,
-				"%s failed with wrong exit code", backend_name);
+				"%s failed with exit code %d", backend_name, ret);
 		return FALSE;
 	}
 

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -609,11 +609,11 @@ static RaucSlot* grub_get_primary(GError **error)
 	}
 
 	if (!primary) {
-		g_set_error_literal(
+		g_set_error(
 				error,
 				R_BOOTCHOOSER_ERROR,
 				R_BOOTCHOOSER_ERROR_PARSE_FAILED,
-				"Unable to detect primary slot");
+				"No bootable slot found in ORDER '%s'", order->str);
 	}
 
 	return primary;

--- a/src/main.c
+++ b/src/main.c
@@ -1809,7 +1809,7 @@ static gboolean status_start(int argc, char **argv)
 
 		status_print->primary = r_boot_get_primary(&ierror);
 		if (!status_print->primary) {
-			g_printerr("%s\n", ierror->message);
+			g_printerr("Failed getting primary slot: %s\n", ierror->message);
 			g_clear_error(&ierror);
 		}
 

--- a/src/mark.c
+++ b/src/mark.c
@@ -130,10 +130,10 @@ gboolean mark_run(const gchar *state,
 
 	if (!g_strcmp0(state, "good")) {
 		res = r_boot_set_state(slot, TRUE, &ierror);
-		*message = res ? g_strdup_printf("marked slot %s as good", slot->name) : g_strdup(ierror->message);
+		*message = res ? g_strdup_printf("marked slot %s as good", slot->name) : g_strdup_printf("Failed marking slot %s as good: %s", slot->name, ierror->message);
 	} else if (!g_strcmp0(state, "bad")) {
 		res = r_boot_set_state(slot, FALSE, &ierror);
-		*message = res ? g_strdup_printf("marked slot %s as bad", slot->name) : g_strdup(ierror->message);
+		*message = res ? g_strdup_printf("marked slot %s as bad", slot->name) : g_strdup_printf("Failed marking slot %s as bad: %s", slot->name, ierror->message);
 	} else if (!g_strcmp0(state, "active")) {
 		mark_active(slot, &ierror);
 		if (!ierror) {


### PR DESCRIPTION
This series aims to fix a number of redundant error message printouts in the context of boot selection handling.

By introducing a clearer scoping when a function should add which information (and, more important: which not), we should be able to better prevent these annoying redundancies which likely confuse the reader.

The series also rewrites some useless or imprecise error messages to be more concrete with telling what actually failed and thus to ease identifying issues.