### PR TITLE
test/update_handler: be less strict with sum_source

### DIFF
--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -416,7 +416,7 @@ no_image:
 			g_assert_cmpint(sum_zero, >=, IMAGE_SIZE/4096 - 29);
 			g_assert_cmpint(sum_target_written, >=, 0);
 			g_assert_cmpint(sum_target, ==, 0);
-			g_assert_cmpint(sum_source, <=, 28);
+			g_assert_cmpint(sum_source, <=, 29);
 		}
 
 		/* Number of total lookups must not increase in lookup order */


### PR DESCRIPTION
When running CI from GitHub Actions, sum_source can obviously be 29 in some cases. Since this is no exact science anyway, be less strict here to prevent false-positive test suite failures.