### PR TITLE
src: obtain error from errno if g_mkdir_with_parents() fails

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -336,12 +336,14 @@ static gboolean casync_make_blob(const gchar *idxpath, const gchar *contentpath,
 			ret_mkdir = g_mkdir_with_parents(desync_store, 0755);
 
 			if (ret_mkdir != 0) {
+				int err = errno;
 				g_set_error(
 						error,
 						G_FILE_ERROR,
-						G_FILE_ERROR_FAILED,
-						"Failed creating Desync store directory '%s'",
-						desync_store);
+						g_file_error_from_errno(err),
+						"Failed creating Desync store directory '%s': %s",
+						desync_store,
+						g_strerror(err));
 				res = FALSE;
 				goto out;
 			}

--- a/src/context.c
+++ b/src/context.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <gio/gio.h>
 #include <string.h>
 
@@ -273,12 +274,14 @@ gboolean r_context_configure(GError **error)
 
 	if (context->config->data_directory) {
 		if (g_mkdir_with_parents(context->config->data_directory, 0700) != 0) {
+			int err = errno;
 			g_set_error(
 					error,
 					G_FILE_ERROR,
-					G_FILE_ERROR_FAILED,
-					"Failed to create data directory '%s'",
-					context->config->data_directory);
+					g_file_error_from_errno(err),
+					"Failed to create data directory '%s': %s",
+					context->config->data_directory,
+					g_strerror(err));
 			return FALSE;
 		}
 	}

--- a/src/mount.c
+++ b/src/mount.c
@@ -294,12 +294,14 @@ gchar* r_create_mount_point(const gchar *name, GError **error)
 		ret = g_mkdir_with_parents(mountpoint, 0700);
 
 		if (ret != 0) {
+			int err = errno;
 			g_set_error(
 					error,
 					G_FILE_ERROR,
-					G_FILE_ERROR_FAILED,
-					"Failed creating mount path '%s'",
-					mountpoint);
+					g_file_error_from_errno(err),
+					"Failed creating mount path '%s': %s",
+					mountpoint,
+					g_strerror(err));
 			g_free(mountpoint);
 			mountpoint = NULL;
 			goto out;

--- a/src/slot.c
+++ b/src/slot.c
@@ -1,3 +1,5 @@
+#include <errno.h>
+
 #include "slot.h"
 
 #include "utils.h"
@@ -198,12 +200,14 @@ gchar *r_slot_get_checksum_data_directory(const RaucSlot *slot, const RaucChecks
 
 	path = g_build_filename(slot->data_directory, sub_directory, NULL);
 	if (g_mkdir_with_parents(path, 0700) != 0) {
+		int err = errno;
 		g_set_error(
 				error,
 				G_FILE_ERROR,
-				G_FILE_ERROR_FAILED,
-				"Failed to create slot data directory '%s'",
-				path);
+				g_file_error_from_errno(err),
+				"Failed to create slot data directory '%s': %s",
+				path,
+				g_strerror(err));
 		return NULL;
 	}
 


### PR DESCRIPTION
The `g_mkdir_with_parents()` documentation notes:

> Returns -1 if an error occurred, with errno set.

Since We should not silently drop the cause if we could present it to the user, use `errno` to create a more precise `GError` code and message.

Based on #958 
