### PR TITLE
src/mbr: skip empty partitions in is_region_free() check

### DIFF
--- a/src/mbr.c
+++ b/src/mbr.c
@@ -159,6 +159,10 @@ static gboolean is_region_free(guint64 region_start, guint64 region_size,
 		if (i == BOOT_PARTITION_ENTRY)
 			continue;
 
+		/* skip empty partitions */
+		if (partition_tbl[i].partition_size_le == 0)
+			continue;
+
 		p_start = (guint64)GUINT32_FROM_LE(partition_tbl[i].partition_start_le) * sector_size;
 		p_end = (guint64)GUINT32_FROM_LE(partition_tbl[i].partition_size_le) * sector_size +
 		        p_start - 1;

--- a/test/boot_switch.c
+++ b/test/boot_switch.c
@@ -424,7 +424,6 @@ int main(int argc, char *argv[])
 			"start=        2048, size=        6144, type=ef, bootable\n"
 			"start=       14336, size=       65536, type=83\n"
 			"start=       79872, size=           1, type=5\n"
-			"start=       81920, size=       49152, type=82\n"
 		,
 		.sfdisk_expect = R_QUOTE({
 			/* *INDENT-OFF* */
@@ -448,11 +447,6 @@ int main(int argc, char *argv[])
 					"start" : 79872,
 					"size" : 1,
 					"type" : "5"
-				},
-				{
-					"start" : 81920,
-					"size" : 49152,
-					"type" : "82"
 				}
 				]
 			}


### PR DESCRIPTION
Otherwise `partition_size_le` will be 0 and region calculation will be invalid and fail with something like:

> Failed updating slot bootloader.0: Region start address 0x40000 is in area of partition 3 (0x0 - 0xffffffffffffffff)

Checking for the partition size to be 0 is exactly what util-linux does in this case, too:

https://github.com/util-linux/util-linux/blob/364de8f4f5625d17094a4d6e9b5fb49cb19c20a4/libfdisk/src/dos.c#L158

To have test coverage for this, simply remove the fourth partition in corresponding test case.

Fixes: #665

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>