### PR TITLE
src/bundle: remove excess newline discovered by uncrustify

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1349,7 +1349,6 @@ static gboolean take_bundle_ownership(int bundle_fd, GError **error)
 
 	/* if it belongs to someone else, try to fchown if we are root */
 	if ((stat.st_uid != 0) && (stat.st_uid != euid)) {
-
 		if (euid != 0) {
 			g_set_error(error,
 					G_FILE_ERROR,


### PR DESCRIPTION
Fixes: #976 (079b97438c6f1d06275bec7e4a8feb1d7e094336)

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>