### PR TITLE
Makefile.am: add another few files to the dist tar.xz

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -138,7 +138,8 @@ EXTRA_DIST += data/rauc.service.in \
 	      .uncrustify.cfg \
 	      uncrustify.sh \
 	      rauc_logo.png \
-	      rauc_logo_small.png
+	      rauc_logo_small.png \
+	      scan-build
 
 dist_man_MANS = rauc.1
 
@@ -202,6 +203,7 @@ EXTRA_DIST += tap-t \
 	      $(wildcard test/*.raucm) \
 	      test/dummy.verity \
 	      test/dummy.verity.info \
+	      test/minimal-desync-test.conf \
 	      test/minimal-test.conf \
 	      test/nginx.conf \
 	      test/nginx.htpasswd \


### PR DESCRIPTION
test/minimal-desync-test.conf was added in commit 700f3afe77d8 ("add initial support for desync") but wasn't added to the release tar ball.

scan-build was added in commit 62d343e5c5fd ("scan-build: add convenience script to run clang's scan-build").

This was found when creating a Debian package for rauc 1.8; to catch problems like these, the following command is suitable:

	git ls-tree -r --name-only @ | grep -vx -f <(tar tf ../rauc-1.8.tar.xz | sed s,^[^/]*/,,) | grep -vE '^.lgtm.yml|(.*/)?(autogen.sh|.git)'

This lists all files in the git tree that are not included in the tarball apart from a few exceptions that are expected to not be included.

Signed-off-by: Uwe Kleine-König <u.kleine-koenig@pengutronix.de>