### PR TITLE
docs: improve bootloader update documentation

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,6 +1,10 @@
 Advanced Topics
 ===============
 
+.. contents::
+   :local:
+   :depth: 2
+
 .. _sec-security:
 
 Security

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1115,6 +1115,25 @@ non-bootable system caused by an error or power-loss during the update.
 Whether atomic bootloader updates can be implemented depends on your
 SoC/firmware and storage medium.
 
+.. note::
+
+  Most bootloaders need some space to persistently store the state of the
+  fallback logic.
+  This storage is also normally accessed by RAUC to communicate with the
+  bootloader during update installation and after successful boots.
+  Some bootloaders use an *environment* file or partitions for this (for
+  example GRUB's ``grubenv`` file or U-Boot's ``saveenv`` command), others have
+  specialized mechanisms (Barebox's `state framework
+  <https://barebox.org/doc/latest/user/state.html>`_)
+
+  If the bootloader should be updateable, this storage space **must be outside
+  of the bootloader partition**, as it would otherwise be overwritten by an
+  update.
+  More generally, the bootloader partition should **only** be written to when
+  updating the bootloader, so it should not contain anything else that should
+  be written separately (such as bootloader env, kernel or
+  initramfs).
+
 .. _sec-emmc-boot:
 
 Update Bootloader in eMMC Boot Partitions

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -356,7 +356,9 @@ setup.
 Anyway, you can still define it as a slot if you need to be able to provide
 an update for this, too.
 
-Example BSPs
-------------
-* Yocto
-* PTXdist
+Example Integrations
+--------------------
+
+The `meta-rauc-comminity repository
+<https://github.com/rauc/meta-rauc-community>`_ contains layers for some
+platforms, demonstrating different ways to use RAUC.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,6 +1,10 @@
 Frequently Asked Questions
 ==========================
 
+.. contents::
+   :local:
+   :depth: 1
+
 Why doesn't the installed system use the whole partition?
 ---------------------------------------------------------
 

--- a/docs/scenarios.rst
+++ b/docs/scenarios.rst
@@ -3,6 +3,10 @@
 Scenarios
 =========
 
+.. contents::
+   :local:
+   :depth: 1
+
 Symmetric Root-FS Slots
 -----------------------
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -23,6 +23,10 @@ PTXdist, simply enable RAUC in your configuration.
   When using the RAUC service from your application, the D-Bus interface is
   preferable to using the provided command-line tool.
 
+.. contents::
+   :local:
+   :depth: 1
+
 Creating Bundles
 ----------------
 


### PR DESCRIPTION
It's better to be explicit about what the bootloader partitions are for and what should be stored somewhere else.