### PR TITLE
add GitHub configuration for issues, pull requests and general support 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a bug report
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Background information**
+Describe which RAUC version and build system you are using.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. …
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, add console output or logs from the RAUC service to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "Community Chat"
+    url: "https://matrix.to/#/#rauc:matrix.org"
+    about: >
+       You can use the chat to ask support questions and for general system
+       design discussions.
+       The Matrix channel is bridged to the IRC channel #rauc on libera.chat.
+  - name: "Community Discussions on GitHub"
+    url: "https://github.com/rauc/rauc/discussions/categories/q-a"
+    about: >
+       You can use GitHub discussions for support questions which need more
+       background information.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/SUPPORT.rst
+++ b/.github/SUPPORT.rst
@@ -1,0 +1,12 @@
+Getting Support
+===============
+
+**Please do not open GitHub issues for support questions.** We use issues for
+tracking bugs and feature requests.
+
+Better ways to get support are:
+
+* Join the `Matrix channel #rauc:matrix.org
+  <https://matrix.to/#/#rauc:matrix.org>`_ (bridged to the IRC channel
+  ``#rauc`` on libera.chat).
+* Create a new `discussion <https://github.com/rauc/rauc/discussions/categories/q-a>`_.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!--
+Thank you for your pull request!
+
+If this is your first pull request for RAUC, please read:
+https://rauc.readthedocs.io/en/latest/contributing.html
+
+Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…
+
+If you add a feature, please answer these questions:
+- What do you use the feature for?
+- How does RAUC benefit from the feature?
+- How did you verify the feature works?
+- If hardware is needed for the feature, which hardware is supported and which
+  hardware did you test with?
+
+Please also allow edits by maintainers, so we can apply minor fixes directly.
+-->
+
+<!--
+In case your PR fixes an issue, please reference it in the next line, i.e.
+Fixes: #[insert number without brackets here]
+-->


### PR DESCRIPTION
This should help point users to the Matrix/IRC channel and GitHub discussions instead of opening issues.

Also add some hints in a pull request template and information on how to get support.