### PR TITLE
manifest: parse and store metadata

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -610,8 +610,9 @@ A valid RAUC manifest file must be named ``manifest.raucm``.
 
 ``<key>``
   The ``meta.<label>`` sections are intended to provide a forwards-compatible
-  way to add data to the manifest which is not interpreted by RAUC in any way.
-  Currently, they are just ignored when reading a manifest.
+  way to add metadata to the manifest which is not interpreted by RAUC in any
+  way.
+  Currently, they are only stored in the bundle.
   In future releases, they will be accessible via ``rauc info``, the D-Bus API
   and in hooks/handlers.
 

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -40,6 +40,12 @@ typedef enum {
 } RManifestBundleFormat;
 
 typedef struct {
+	gchar *group;
+	gchar *key;
+	gchar *value;
+} RManifestMetaEntry;
+
+typedef struct {
 	gchar *update_compatible;
 	gchar *update_version;
 	gchar *update_description;
@@ -59,6 +65,9 @@ typedef struct {
 	InstallHooks hooks;
 
 	GList *images;
+
+	/* list of RManifestMetaEntry */
+	GList *meta;
 
 	/* internal marker that this was encrypted */
 	gboolean was_encrypted;
@@ -187,3 +196,10 @@ static inline const gchar *r_manifest_bundle_format_to_str(RManifestBundleFormat
 			return "invalid";
 	}
 }
+
+/**
+ * Frees the memory allocated by a RManifestMetaEntry.
+ */
+void free_manifest_entry(RManifestMetaEntry *entry);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RManifestMetaEntry, free_manifest_entry);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -648,6 +648,12 @@ static GKeyFile *prepare_manifest(const RaucManifest *mf)
 					(const gchar * const *)image->adaptive, g_strv_length(image->adaptive));
 	}
 
+	for (GList *l = mf->meta; l != NULL; l = l->next) {
+		RManifestMetaEntry *entry = l->data;
+		g_autofree gchar *group = g_strdup_printf("meta.%s", entry->group);
+		g_key_file_set_string(key_file, group, entry->key, entry->value);
+	}
+
 	return g_steal_pointer(&key_file);
 }
 

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -342,6 +342,7 @@ static void test_manifest_load_meta(void)
 	gboolean res;
 	GError *error = NULL;
 	RaucImage *test_img = NULL;
+	RManifestMetaEntry *entry = NULL;
 	const gchar *mffile = "\
 [update]\n\
 compatible=FooCorp Super BarBazzer\n\
@@ -375,6 +376,23 @@ counter=42\n\
 
 	test_img = (RaucImage*)g_list_nth_data(rm->images, 0);
 	g_assert_nonnull(test_img);
+
+	g_assert_cmpuint(g_list_length(rm->meta), ==, 3);
+
+	entry = g_list_nth_data(rm->meta, 0);
+	g_assert_cmpstr(entry->group, ==, "foocorp");
+	g_assert_cmpstr(entry->key, ==, "release-type");
+	g_assert_cmpstr(entry->value, ==, "beta");
+
+	entry = g_list_nth_data(rm->meta, 1);
+	g_assert_cmpstr(entry->group, ==, "foocorp");
+	g_assert_cmpstr(entry->key, ==, "release-notes");
+	g_assert_cmpstr(entry->value, ==, "https://foocorp.example/releases/release-notes-2015.04-1.rst");
+
+	entry = g_list_nth_data(rm->meta, 2);
+	g_assert_cmpstr(entry->group, ==, "example");
+	g_assert_cmpstr(entry->key, ==, "counter");
+	g_assert_cmpstr(entry->value, ==, "42");
 
 	free_manifest(rm);
 }


### PR DESCRIPTION
Since 3cc11ecd34a1e03e99c8798fd1e9bd1a976cbf94, RAUC ignores `[meta.*]` sections in the manifest. With this PR, the metadata entries are parsed and written back to the manifest during bundle creation.

Still missing is support for passing the entries to `rauc info`, the D-Bus API and hook/handlers.