### PR TITLE
README.rst in building instructions autoupdate added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,6 +179,7 @@ Building from Sources
 
     git clone https://github.com/rauc/rauc
     cd rauc
+    autoupdate
     ./autogen.sh
     ./configure
     make


### PR DESCRIPTION
In 'Building from Sources' section 'autoupdate' command before all has been added in such a way autogen.sh will be updated accordingly with the autotools installed into the system.

Signed-off-by: Roberto A. Foglietta <roberto.foglietta@gmail.com>
