### PR TITLE
CI: fix (armel) cross build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,8 @@ jobs:
 
     - name: Prepare ${{ matrix.architecture }} container
       run: |
-        docker run --rm --privileged multiarch/qemu-user-static:register --reset
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND='noninteractive' apt-get install -qy qemu-user-static
         docker run --name cross -di -v "$PWD":/home -w /home multiarch/debian-debootstrap:${{ matrix.architecture }}-buster bash
         docker exec -i cross uname -a
         docker exec -i cross apt-get update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo DEBIAN_FRONTEND='noninteractive' apt-get install -qy qemu-user-static
-        docker run --name cross -di -v "$PWD":/home -w /home multiarch/debian-debootstrap:${{ matrix.architecture }}-buster bash
+        docker run --name cross -di -v "$PWD":/home -w /home multiarch/debian-debootstrap:${{ matrix.architecture }}-bullseye bash
         docker exec -i cross uname -a
         docker exec -i cross apt-get update
         docker exec -e DEBIAN_FRONTEND='noninteractive' -i cross apt-get install -qy build-essential automake libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev libfdisk-dev libnl-genl-3-dev squashfs-tools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,7 @@ jobs:
         sudo apt-get update
         sudo DEBIAN_FRONTEND='noninteractive' apt-get install -qy qemu-user-static
         docker run --name cross -di -v "$PWD":/home -w /home multiarch/debian-debootstrap:${{ matrix.architecture }}-bullseye bash
+        docker logs cross
         docker exec -i cross uname -a
         docker exec -i cross apt-get update
         docker exec -e DEBIAN_FRONTEND='noninteractive' -i cross apt-get install -qy build-essential automake libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev libfdisk-dev libnl-genl-3-dev squashfs-tools


### PR DESCRIPTION
The armel arch cross build currently fails: https://github.com/rauc/rauc/actions/runs/3828804526/jobs/6514792764

Fix this by replacing qemu-user-static docker image with the corresponding ubuntu package.

While at it, update to bullseye and add a bit more logging output.