### PR TITLE
Check image size before starting installation

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -3,6 +3,14 @@
 #include <gio/gio.h>
 #include <glib.h>
 
+#define R_UTILS_ERROR r_utils_error_quark()
+
+GQuark r_utils_error_quark(void);
+
+typedef enum {
+	R_UTILS_ERROR_FAILED,
+} RUtilsError;
+
 #define BIT(nr) (1UL << (nr))
 
 /* Evaluate EXPRESSION, and repeat as long as it returns -1 with `errno'

--- a/include/utils.h
+++ b/include/utils.h
@@ -9,6 +9,7 @@ GQuark r_utils_error_quark(void);
 
 typedef enum {
 	R_UTILS_ERROR_FAILED,
+	R_UTILS_ERROR_INAPPROPRIATE_IOCTL,
 } RUtilsError;
 
 #define BIT(nr) (1UL << (nr))
@@ -230,4 +231,7 @@ gboolean r_pwrite_lazy(const int fd, const guint8 *data, size_t size, off_t offs
 G_GNUC_WARN_UNUSED_RESULT;
 
 guint get_sectorsize(gint fd)
+G_GNUC_WARN_UNUSED_RESULT;
+
+goffset get_device_size(gint fd, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -30,6 +30,34 @@ GQuark r_update_error_quark(void)
 	return g_quark_from_static_string("r_update_error_quark");
 }
 
+static gboolean check_image_size(int fd, const RaucImage *image, GError **error)
+{
+	GError *ierror = NULL;
+	goffset dev_size;
+
+	g_return_val_if_fail(image, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	dev_size = get_device_size(fd, &ierror);
+	if (g_error_matches(ierror, R_UTILS_ERROR, R_UTILS_ERROR_INAPPROPRIATE_IOCTL)) {
+		g_info("Slot is not a block device, skipping size check");
+		return TRUE;
+	}
+
+	if (dev_size < image->checksum.size) {
+		if (ierror) {
+			g_propagate_error(error, ierror);
+		} else {
+			g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+					"Slot (%"G_GOFFSET_FORMAT " bytes) is too small for image (%"G_GOFFSET_FORMAT " bytes).",
+					dev_size, image->checksum.size);
+		}
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
 /* the fd will only live as long as the returned output stream */
 static GUnixOutputStream* open_slot_device(RaucSlot *slot, int *fd, GError **error)
 {
@@ -548,6 +576,13 @@ static gboolean copy_raw_image_to_dev(RaucImage *image, RaucSlot *slot, GError *
 		goto out;
 	}
 
+	/* check size */
+	if (!check_image_size(g_unix_output_stream_get_fd(outstream), image, &ierror)) {
+		res = FALSE;
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
 	/* copy */
 	g_message("writing data to device %s", slot->device);
 	res = copy_raw_image(image, outstream, 0, &ierror);
@@ -596,6 +631,12 @@ static gboolean copy_block_hash_index_image_to_dev(RaucImage *image, RaucSlot *s
 		res = FALSE;
 		goto out;
 	}
+	if (!check_image_size(tmp->data_fd, image, &ierror)) {
+		g_propagate_error(error, ierror);
+		res = FALSE;
+		goto out;
+	}
+
 	g_ptr_array_add(sources, g_steal_pointer(&tmp));
 
 	/* Open and append seed slot. */

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -773,7 +773,7 @@ static gboolean copy_adaptive_image_to_dev(RaucImage *image, RaucSlot *slot, GEr
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	if (g_strv_contains((const gchar * const*)image->adaptive, "block-hash-index")) {
-		g_info("Selected adaptive update method 'block-hash-index");
+		g_info("Selected adaptive update method 'block-hash-index'");
 
 		if (!copy_block_hash_index_image_to_dev(image, slot, &ierror)) {
 			g_propagate_error(error, ierror);

--- a/src/utils.c
+++ b/src/utils.c
@@ -504,3 +504,30 @@ guint get_sectorsize(gint fd)
 
 	return sector_size;
 }
+
+goffset get_device_size(gint fd, GError **error)
+{
+	guint64 size = 0;
+
+	g_return_val_if_fail(error == NULL || *error == NULL, 0);
+
+	if (ioctl(fd, BLKGETSIZE64, &size) != 0) {
+		int err = errno;
+		if (err == ENOTTY) {
+			g_set_error(error,
+					R_UTILS_ERROR,
+					R_UTILS_ERROR_INAPPROPRIATE_IOCTL,
+					"Failed to get device size: Not a block device");
+		} else {
+			g_set_error(error,
+					G_FILE_ERROR,
+					g_file_error_from_errno(err),
+					"Failed to get device size: %s", g_strerror(err));
+		}
+		return 0;
+	}
+
+	g_assert(size <= G_MAXOFFSET);
+
+	return size;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -12,6 +12,11 @@
 
 #include "utils.h"
 
+GQuark r_utils_error_quark(void)
+{
+	return g_quark_from_static_string("r_utils_error_quark");
+}
+
 GSubprocess *r_subprocess_new(GSubprocessFlags flags, GError **error, const gchar *argv0, ...)
 {
 	GSubprocess *result;

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -27,6 +27,7 @@ typedef enum {
 	TEST_UPDATE_HANDLER_NO_HOOK_FILE                                  = BIT(7),
 	TEST_UPDATE_HANDLER_HOOK_FAIL                                     = BIT(8),
 	TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX                           = BIT(9),
+	TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE                               = BIT(10),
 } TestUpdateHandlerParams;
 
 typedef struct {
@@ -119,6 +120,20 @@ static void update_handler_fixture_set_up(UpdateHandlerFixture *fixture,
 			g_assert(test_make_filesystem(fixture->tmpdir, "rootfs-0"));
 		}
 	}
+
+	if ((test_pair->params & TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE) &&
+	    (test_pair->params & TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX)) {
+		g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
+				"Checking image type for slot type: *");
+		g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
+				"Image detected as type: *");
+		g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_INFO,
+				"Selected adaptive update method *");
+		g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_INFO,
+				"building*");
+		g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+				"Continuing after adaptive mode error: Slot * is too small for image *");
+	}
 }
 
 static void update_handler_fixture_tear_down(UpdateHandlerFixture *fixture,
@@ -135,6 +150,10 @@ static void update_handler_fixture_tear_down(UpdateHandlerFixture *fixture,
 		test_rm_tree(fixture->tmpdir, "rootfs-0-datadir");
 	}
 	g_assert(test_rmdir(fixture->tmpdir, "") == 0);
+
+	if (!g_test_failed()) {
+		g_test_assert_expected_messages();
+	}
 }
 
 static gboolean tar_image(const gchar *dest, const gchar *dir, GError **error)
@@ -343,7 +362,18 @@ static void test_update_handler(UpdateHandlerFixture *fixture,
 			return;
 		}
 	} else {
-		slotpath = g_build_filename(fixture->tmpdir, "rootfs-0", NULL);
+		if (test_pair->params & TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE) {
+			/* Try to use loop block device for this test. */
+			slotpath = g_strdup(g_getenv("RAUC_TEST_BLOCK_LOOP"));
+			if (!slotpath) {
+				g_test_message("no block device for testing found (define RAUC_TEST_BLOCK_LOOP)");
+				g_test_skip("RAUC_TEST_BLOCK_LOOP undefined");
+				return;
+			}
+			image_size = 65*1024*1024; /* loop dev is only 64 MiB */
+		} else {
+			slotpath = g_build_filename(fixture->tmpdir, "rootfs-0", NULL);
+		}
 	}
 	imagepath = g_build_filename(fixture->tmpdir, imagename, NULL);
 
@@ -658,6 +688,10 @@ int main(int argc, char *argv[])
 		/* casync directory index tests */
 		{"ext4", "caidx", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
 		{"vfat", "caidx", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
+
+		/* image too large */
+		{"ext4", "ext4", TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE | TEST_UPDATE_HANDLER_EXPECT_FAIL, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED},
+		{"ext4", "ext4", TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX | TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE | TEST_UPDATE_HANDLER_EXPECT_FAIL, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED},
 
 		{0}
 	};
@@ -1074,6 +1108,20 @@ int main(int argc, char *argv[])
 	                test_update_handler,
 	                update_handler_fixture_tear_down);
 	 */
+
+	/* too large */
+	g_test_add("/update_handler/too_large/normal",
+			UpdateHandlerFixture,
+			&testpair_matrix[63],
+			update_handler_fixture_set_up,
+			test_update_handler,
+			update_handler_fixture_tear_down);
+	g_test_add("/update_handler/too_large/adaptive",
+			UpdateHandlerFixture,
+			&testpair_matrix[64],
+			update_handler_fixture_set_up,
+			test_update_handler,
+			update_handler_fixture_tear_down);
 
 	return g_test_run();
 }

--- a/test/utils.c
+++ b/test/utils.c
@@ -37,6 +37,28 @@ static void whitespace_removed_test(void)
 	g_free(str);
 }
 
+static void get_sectorsize_test(void)
+{
+	const gchar *device = g_getenv("RAUC_TEST_BLOCK_LOOP");
+	int fd = -1;
+	guint size = 0;
+
+	if (!device) {
+		g_test_message("no block device for testing found (define RAUC_TEST_BLOCK_LOOP)");
+		g_test_skip("RAUC_TEST_BLOCK_LOOP undefined");
+		return;
+	}
+
+	fd = g_open(device, O_RDONLY|O_CLOEXEC, 0);
+	g_assert_cmphex(fd, >=, 0);
+
+	size = get_sectorsize(fd);
+	g_assert_cmpint(size, ==, 512);
+
+	if (fd >= 0)
+		g_close(fd, NULL);
+}
+
 static void get_device_size_test(void)
 {
 	GError *error = NULL;
@@ -68,6 +90,7 @@ int main(int argc, char *argv[])
 	g_test_init(&argc, &argv, NULL);
 
 	g_test_add_func("/utils/whitespace_removed", whitespace_removed_test);
+	g_test_add_func("/utils/get_sectorsize", get_sectorsize_test);
 	g_test_add_func("/utils/get_device_size", get_device_size_test);
 
 	return g_test_run();

--- a/test/utils.c
+++ b/test/utils.c
@@ -1,5 +1,9 @@
 #include <locale.h>
 #include <glib.h>
+#include <glib/gstdio.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #include "utils.h"
 
@@ -33,6 +37,30 @@ static void whitespace_removed_test(void)
 	g_free(str);
 }
 
+static void get_device_size_test(void)
+{
+	GError *error = NULL;
+	const gchar *device = g_getenv("RAUC_TEST_BLOCK_LOOP");
+	int fd = -1;
+	goffset size = 0;
+
+	if (!device) {
+		g_test_message("no block device for testing found (define RAUC_TEST_BLOCK_LOOP)");
+		g_test_skip("RAUC_TEST_BLOCK_LOOP undefined");
+		return;
+	}
+
+	fd = g_open(device, O_RDONLY|O_CLOEXEC, 0);
+	g_assert_cmphex(fd, >=, 0);
+
+	size = get_device_size(fd, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(size, ==, 64<<20); /* 64MiB */
+
+	if (fd >= 0)
+		g_close(fd, NULL);
+}
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -40,6 +68,7 @@ int main(int argc, char *argv[])
 	g_test_init(&argc, &argv, NULL);
 
 	g_test_add_func("/utils/whitespace_removed", whitespace_removed_test);
+	g_test_add_func("/utils/get_device_size", get_device_size_test);
 
 	return g_test_run();
 }


### PR DESCRIPTION
In some cases, we can abort early if the image in the bundle is too large for the slot. This is not possible when installing tar archives or when writing images to slot which point to a file.

Fixes: #1008
