### PR TITLE
add descriptions in dbus api

### DIFF
--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -35,6 +35,7 @@
       <arg name="bundle" type="s" direction="in" />
       <arg name="compatible" type="s" direction="out" />
       <arg name="version" type="s" direction="out" />
+      <arg name="description" type="s" direction="out" />
     </method>
 
     <!--

--- a/src/service.c
+++ b/src/service.c
@@ -172,7 +172,8 @@ out:
 				interface,
 				invocation,
 				manifest->update_compatible,
-				manifest->update_version ? manifest->update_version : "");
+				manifest->update_version ? manifest->update_version : "",
+				manifest->update_description ? manifest->update_description : "");
 	} else {
 		g_dbus_method_invocation_return_error(invocation,
 				G_IO_ERROR,


### PR DESCRIPTION
Add support for reading the description from a rauc bundle over the D-Bus-API.
Enhanced the Info() method with the necessary parameter


