### PR TITLE
data: allow skipping service files installation

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,3 +1,7 @@
+if not get_option('service')
+  subdir_done()
+endif
+
 rauc_service = configure_file(
   input : 'rauc.service.in',
   output : 'rauc.service',

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -59,15 +59,17 @@ mkfs.ext4 /tmp/rootdev
 truncate --size=64M /tmp/appdev
 mkfs.ext4 /tmp/appdev
 
-# dbus daemon
-cp -a /etc/dbus-1/system.d /tmp
-cp -a $BUILD_DIR/data/de.pengutronix.rauc.conf /tmp/system.d
-chown root:root /tmp/system.d/de.pengutronix.rauc.conf
-chmod 644 /tmp/system.d/de.pengutronix.rauc.conf
-mount --bind /tmp/system.d /etc/dbus-1/system.d
-mount -t tmpfs none /var/run
-mkdir -p /var/run/dbus
-time dbus-daemon --system --fork --nopidfile --nosyslog --print-address
+# dbus daemon if service is enabled
+if grep -q "ENABLE_SERVICE 1" $BUILD_DIR/config.h; then
+  cp -a /etc/dbus-1/system.d /tmp
+  cp -a $BUILD_DIR/data/de.pengutronix.rauc.conf /tmp/system.d
+  chown root:root /tmp/system.d/de.pengutronix.rauc.conf
+  chmod 644 /tmp/system.d/de.pengutronix.rauc.conf
+  mount --bind /tmp/system.d /etc/dbus-1/system.d
+  mount -t tmpfs none /var/run
+  mkdir -p /var/run/dbus
+  time dbus-daemon --system --fork --nopidfile --nosyslog --print-address
+fi
 
 # rauc binary in PATH
 if [ -n "$SHELL" ]; then


### PR DESCRIPTION
When 'service' option is disabled, there is no point in installing service files.
Since currently all files installed from data/ are service-related, simply use subdir_done() here.

This is something that is wrong in autotools, too. But since we intend to remove autotools support in the near future, fix this for meson only.