### PR TITLE
.github: workflows: coverity: use meson build command

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -21,7 +21,7 @@ jobs:
         export TOOL_ARCHIVE="/tmp/cov-analysis-${PLATFORM}.tgz"
         export COVERITY_SCAN_PROJECT_NAME="${{ github.repository }}"
         export COVERITY_SCAN_NOTIFICATION_EMAIL="jlu@pengutronix.de"
-        export COVERITY_SCAN_BUILD_COMMAND="make"
+        export COVERITY_SCAN_BUILD_COMMAND="meson compile -C build"
         export COVERITY_SCAN_TOKEN="${{ secrets.COVERITY_SCAN_TOKEN }}"
 
         test/get-coverity.sh


### PR DESCRIPTION
Since we moved to meson here, invoking 'make' will let coverity fail.

Tested on my github profile.