### PR TITLE
Create test tar image with bz2 compression

### DIFF
--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -156,7 +156,7 @@ static void update_handler_fixture_tear_down(UpdateHandlerFixture *fixture,
 	}
 }
 
-static gboolean tar_image(const gchar *dest, const gchar *dir, GError **error)
+static gboolean tar_bz2_image(const gchar *dest, const gchar *dir, GError **error)
 {
 	GSubprocess *sproc = NULL;
 	GError *ierror = NULL;
@@ -164,7 +164,7 @@ static gboolean tar_image(const gchar *dest, const gchar *dir, GError **error)
 	GPtrArray *args = g_ptr_array_new_full(5, g_free);
 
 	g_ptr_array_add(args, g_strdup("tar"));
-	g_ptr_array_add(args, g_strdup("cf"));
+	g_ptr_array_add(args, g_strdup("cjf"));
 	g_ptr_array_add(args, g_strdup(dest));
 	g_ptr_array_add(args, g_strdup("-C"));
 	g_ptr_array_add(args, g_strdup(dir));
@@ -257,7 +257,7 @@ static gboolean test_prepare_dummy_archive(const gchar *path, const gchar *archn
 			FILE_SIZE, "/dev/zero") == 0);
 
 	/* tar file to pseudo image */
-	res = tar_image(archpath, contentpath, &ierror);
+	res = tar_bz2_image(archpath, contentpath, &ierror);
 	if (!res) {
 		g_warning("%s", ierror->message);
 		goto out;


### PR DESCRIPTION
* This is a change from @poeschel factored out from #811 
* It actually provides a bzip2 compressed image to a test expecting one
    > The test_prepare_dummy_archive creates a tar image for some tests, that pretends to be a .tar.bz2 image (based on file extension) but in reality it was just a .tar image without any compression. It would be good if it actually IS a bz2 image.
* So this change is not strictly required for #811 an easier to chew if bitten off alone