### PR TITLE
Documentation and usage updates around signing parameters (primarily --intermediate)

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -910,30 +910,30 @@ Command Line Tool
 .. code-block:: man
 
   Usage:
-    rauc [OPTION…] <COMMAND>
+    rauc [OPTION?] <COMMAND>
 
   Options:
-    -c, --conf=FILENAME               config file
-    --cert=PEMFILE|PKCS11-URL         cert file or PKCS#11 URL
-    --key=PEMFILE|PKCS11-URL          key file or PKCS#11 URL
-    --keyring=PEMFILE                 keyring file
-    --intermediate=PEMFILE            intermediate CA file name
-    --mount=PATH                      mount prefix
-    --override-boot-slot=BOOTNAME     override auto-detection of booted slot
-    --handler-args=ARGS               extra handler arguments
-    -d, --debug                       enable debug output
-    --version                         display version
-    -h, --help
+    -c, --conf=FILENAME     config file
+    --keyring=PEMFILE       keyring file
+    --mount=PATH            mount prefix
+    -d, --debug             enable debug output
+    --version               display version
+    -h, --help              display help and exit
+
+  Command-specific help:
+    rauc <COMMAND> --help
 
   List of rauc commands:
     bundle                Create a bundle
     resign                Resign an already signed bundle
     convert               Convert classic to casync bundle
+    encrypt               Encrypt a crypt bundle
+    replace-signature     Replaces the signature of an already signed bundle
     extract-signature     Extract the bundle signature
     extract               Extract the bundle content
     install               Install a bundle
-    info                  Show file information
-    mount                 Mount a bundle (for development purposes)
+    info                  Show bundle information
+    mount                 Mount a bundle
     service               Start RAUC service
     status                Show status
     write-slot            Write image to slot and bypass all update logic

--- a/rauc.1
+++ b/rauc.1
@@ -64,20 +64,8 @@ not all combinations make sense.
 use the given config file instead of the one at the compiled-in default path
 
 .TP
-\fB\-\-cert=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
-use given certificate file or the certificate referenced by the given PKCS#11 URL
-
-.TP
-\fB\-\-key=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
-use given private key file or the key referenced by the given PKCS#11 URL
-
-.TP
 \fB\-\-keyring=\fR\fIPEMFILE\fR
 use specific keyring file
-
-.TP
-\fB\-\-intermediate=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
-intermediate CA file or the certificate referenced by the given PKCS#11 URL
 
 .TP
 \fB\-\-mount=\fR\fIPATH\fR
@@ -116,6 +104,18 @@ Create a bundle from a content directory.
 .RS 4
 
 .TP
+\fB\-\-cert=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+use given certificate file or the certificate referenced by the given PKCS#11 URL
+
+.TP
+\fB\-\-key=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+use given private key file or the key referenced by the given PKCS#11 URL
+
+.TP
+\fB\-\-intermediate=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+intermediate CA file or the certificate referenced by the given PKCS#11 URL
+
+.TP
 \fB\-\-signing\-keyring=\fR\fIPEMFILE\fR
 verification keyring file
 
@@ -134,6 +134,18 @@ Resign an already signed bundle.
 \fBOptions:\fR
 
 .RS 4
+
+.TP
+\fB\-\-cert=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+use given certificate file or the certificate referenced by the given PKCS#11 URL
+
+.TP
+\fB\-\-key=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+use given private key file or the key referenced by the given PKCS#11 URL
+
+.TP
+\fB\-\-intermediate=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+intermediate CA file or the certificate referenced by the given PKCS#11 URL
 
 .TP
 \fB\-\-no\-verify\fR
@@ -190,6 +202,18 @@ Convert an existing bundle to casync index bundle and store.
 \fBOptions:\fR
 
 .RS 4
+
+.TP
+\fB\-\-cert=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+use given certificate file or the certificate referenced by the given PKCS#11 URL
+
+.TP
+\fB\-\-key=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+use given private key file or the key referenced by the given PKCS#11 URL
+
+.TP
+\fB\-\-intermediate=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+intermediate CA file or the certificate referenced by the given PKCS#11 URL
 
 .TP
 \fB\-\-trust\-environment\fR

--- a/rauc.1
+++ b/rauc.1
@@ -76,8 +76,8 @@ use given private key file or the key referenced by the given PKCS#11 URL
 use specific keyring file
 
 .TP
-\fB\-\-intermediate=\fR\fIPEMFILE\fR
-intermediate CA file name
+\fB\-\-intermediate=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+intermediate CA file or the certificate referenced by the given PKCS#11 URL
 
 .TP
 \fB\-\-mount=\fR\fIPATH\fR

--- a/src/main.c
+++ b/src/main.c
@@ -2163,7 +2163,7 @@ static void cmdline_handler(int argc, char **argv)
 		{"cert", '\0', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_FILENAME, &certpath, "cert file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 		{"key", '\0', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_FILENAME, &keypath, "key file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 		{"keyring", '\0', 0, G_OPTION_ARG_FILENAME, &keyring, "keyring file", "PEMFILE"},
-		{"intermediate", '\0', 0, G_OPTION_ARG_FILENAME_ARRAY, &intermediate, "intermediate CA file name", "PEMFILE"},
+		{"intermediate", '\0', 0, G_OPTION_ARG_FILENAME_ARRAY, &intermediate, "intermediate CA file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 		{"mount", '\0', 0, G_OPTION_ARG_FILENAME, &mount, "mount prefix", "PATH"},
 		{"debug", 'd', 0, G_OPTION_ARG_NONE, &debug, "enable debug output", NULL},
 		{"version", '\0', 0, G_OPTION_ARG_NONE, &version, "display version", NULL},

--- a/src/main.c
+++ b/src/main.c
@@ -2167,7 +2167,7 @@ static void cmdline_handler(int argc, char **argv)
 		{"mount", '\0', 0, G_OPTION_ARG_FILENAME, &mount, "mount prefix", "PATH"},
 		{"debug", 'd', 0, G_OPTION_ARG_NONE, &debug, "enable debug output", NULL},
 		{"version", '\0', 0, G_OPTION_ARG_NONE, &version, "display version", NULL},
-		{"help", 'h', 0, G_OPTION_ARG_NONE, &help, NULL, NULL},
+		{"help", 'h', 0, G_OPTION_ARG_NONE, &help, "display help and exit", NULL},
 		{0}
 	};
 

--- a/src/main.c
+++ b/src/main.c
@@ -37,6 +37,7 @@ gboolean status_detailed = FALSE;
 gchar *output_format = NULL;
 gchar *keypath = NULL;
 gchar *certpath = NULL;
+gchar **intermediate = NULL;
 gchar *signing_keyring = NULL;
 gchar *mksquashfs_args = NULL;
 gchar *casync_args = NULL;
@@ -2077,6 +2078,7 @@ static GOptionEntry entries_service[] = {
 static GOptionEntry entries_signing[] = {
 	{"cert", '\0', G_OPTION_FLAG_NOALIAS, G_OPTION_ARG_FILENAME, &certpath, "signing cert file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 	{"key", '\0', G_OPTION_FLAG_NOALIAS, G_OPTION_ARG_FILENAME, &keypath, "signing key file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
+	{"intermediate", '\0', G_OPTION_FLAG_NOALIAS, G_OPTION_ARG_FILENAME_ARRAY, &intermediate, "intermediate CA file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 	{0}
 };
 
@@ -2154,7 +2156,7 @@ static void create_option_groups(void)
 static void cmdline_handler(int argc, char **argv)
 {
 	gboolean help = FALSE, debug = FALSE, version = FALSE;
-	gchar *confpath = NULL, *keyring = NULL, **intermediate = NULL, *mount = NULL;
+	gchar *confpath = NULL, *keyring = NULL, *mount = NULL;
 	char *cmdarg = NULL;
 	g_autoptr(GOptionContext) context = NULL;
 	GOptionEntry entries[] = {
@@ -2163,7 +2165,7 @@ static void cmdline_handler(int argc, char **argv)
 		{"cert", '\0', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_FILENAME, &certpath, "cert file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 		{"key", '\0', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_FILENAME, &keypath, "key file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 		{"keyring", '\0', 0, G_OPTION_ARG_FILENAME, &keyring, "keyring file", "PEMFILE"},
-		{"intermediate", '\0', 0, G_OPTION_ARG_FILENAME_ARRAY, &intermediate, "intermediate CA file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
+		{"intermediate", '\0', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_FILENAME_ARRAY, &intermediate, "intermediate CA file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 		{"mount", '\0', 0, G_OPTION_ARG_FILENAME, &mount, "mount prefix", "PATH"},
 		{"debug", 'd', 0, G_OPTION_ARG_NONE, &debug, "enable debug output", NULL},
 		{"version", '\0', 0, G_OPTION_ARG_NONE, &version, "display version", NULL},

--- a/src/main.c
+++ b/src/main.c
@@ -2257,6 +2257,7 @@ static void cmdline_handler(int argc, char **argv)
 			"  write-slot\t\tWrite image to slot and bypass all update logic\n"
 			"\n"
 			"Environment variables:\n"
+			"  RAUC_KEY_PASSPHRASE Passphrase to use for accessing key files (signing only)\n"
 			"  RAUC_PKCS11_MODULE  Library filename for PKCS#11 module (signing only)\n"
 			"  RAUC_PKCS11_PIN     PIN to use for accessing PKCS#11 keys (signing only)");
 


### PR DESCRIPTION
* Notes that `--intermediate` supports PKCS#11
* Makes `--intermediate` command-specific
* Adds help arg text
* Adds missing note of `RAUC_KEY_PASSPHRASE` in help
* Updates man
* Updates help text
* Updates doc