### PR TITLE
Skip target-related context setup if no config is required

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -351,10 +351,6 @@ gboolean r_context_configure(GError **error)
 			break;
 	}
 
-	if (!r_context_configure_target(error)) {
-		return FALSE;
-	}
-
 	if (context->mountprefix) {
 		g_free(context->config->mount_prefix);
 		context->config->mount_prefix = g_strdup(context->mountprefix);
@@ -370,6 +366,20 @@ gboolean r_context_configure(GError **error)
 
 	if (context->encryption_key) {
 		context->config->encryption_key = g_strdup(context->encryption_key);
+	}
+
+	/* When no context is required, we can safely assume that we do not
+	 * operate on the target but are used as a (host) tool.
+	 * In this case, skip all the necessary target-related context setup steps
+	 */
+	if (configmode != R_CONTEXT_CONFIG_MODE_REQUIRED) {
+		context->pending = FALSE;
+
+		return TRUE;
+	}
+
+	if (!r_context_configure_target(error)) {
+		return FALSE;
 	}
 
 	context->pending = FALSE;

--- a/src/context.c
+++ b/src/context.c
@@ -222,7 +222,6 @@ static gchar* get_variant_from_file(const gchar* filename, GError **error)
 
 gboolean r_context_configure(GError **error)
 {
-	gboolean res = TRUE;
 	GError *ierror = NULL;
 	RContextConfigMode configmode;
 	const gchar *configpath = NULL;
@@ -314,8 +313,7 @@ gboolean r_context_configure(GError **error)
 		vars = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
 		g_message("Getting Systeminfo: %s", context->config->systeminfo_handler);
-		res = launch_and_wait_variables_handler(context->config->systeminfo_handler, vars, &ierror);
-		if (!res) {
+		if (!launch_and_wait_variables_handler(context->config->systeminfo_handler, vars, &ierror)) {
 			g_propagate_prefixed_error(error, ierror, "Failed to read system-info variables: ");
 			return FALSE;
 		}

--- a/test/context.c
+++ b/test/context.c
@@ -8,6 +8,8 @@
 
 static void external_boot(void)
 {
+	r_context_conf()->configpath = g_strdup("test/test.conf");
+	r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_REQUIRED;
 	r_context_conf()->mock.proc_cmdline = "quiet root=/dev/dummy rauc.external rootwait";
 	g_clear_pointer(&r_context_conf()->bootslot, g_free);
 
@@ -19,6 +21,8 @@ static void external_boot(void)
 
 static void nfs_boot(void)
 {
+	r_context_conf()->configpath = g_strdup("test/test.conf");
+	r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_REQUIRED;
 	r_context_conf()->mock.proc_cmdline = "quiet root=/dev/nfs";
 	g_clear_pointer(&r_context_conf()->bootslot, g_free);
 


### PR DESCRIPTION
Do not invoke any target-related context setup steps if no config is required.
This is safe since config mode is 'required' for all target-related subcommands (like 'service') that need to have specific context available (such as bootname, etc.).

With this we gain two major benefits:

* Not invoking pointless procfs, sysfs and mount inspections when running as a host tool

* Removing the misleading 'info'-Messages like:
  > rauc-Message: 13:53:56.765: Failed to resolve realpath for '/dev/mapper/Root-root'

  e.g. when running rauc 'host' subcommands from a container

Resolves #846
Fixes #737