### PR TITLE
.github: workflows: tests: (re)enable coverage in builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Test with service and gpt
       run: |
         rm -rf build/
-        meson setup -Dservice=true -Dgpt=enabled -Dwerror=true build
+        meson setup -Dservice=true -Dgpt=enabled -Db_coverage=true -Dwerror=true build
         ninja -C build
         ./qemu-test
         lcov --directory . --capture --output-file "service.info"
@@ -30,7 +30,7 @@ jobs:
     - name: Test without service and gpt
       run: |
         rm -rf build/
-        meson setup -Dservice=false -Dgpt=enabled -Dwerror=true build
+        meson setup -Dservice=false -Dgpt=enabled -Db_coverage=true -Dwerror=true build
         ninja -C build
         ./qemu-test
         lcov --directory . --capture --output-file "noservice.info"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         ./qemu-test
         lcov --directory . --capture --output-file "noservice.info"
 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       with:
         files: service.info,noservice.info
         verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         rm -rf build/
         meson setup -Dservice=true -Dgpt=enabled -Db_coverage=true -Dwerror=true build
+        meson configure build
         meson compile -C build
         ./qemu-test
         lcov --directory . --capture --output-file "service.info"
@@ -31,6 +32,7 @@ jobs:
       run: |
         rm -rf build/
         meson setup -Dservice=false -Dgpt=enabled -Db_coverage=true -Dwerror=true build
+        meson configure build
         meson compile -C build
         ./qemu-test
         lcov --directory . --capture --output-file "noservice.info"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         rm -rf build/
         meson setup -Dservice=true -Dgpt=enabled -Db_coverage=true -Dwerror=true build
-        ninja -C build
+        meson compile -C build
         ./qemu-test
         lcov --directory . --capture --output-file "service.info"
         
@@ -31,7 +31,7 @@ jobs:
       run: |
         rm -rf build/
         meson setup -Dservice=false -Dgpt=enabled -Db_coverage=true -Dwerror=true build
-        ninja -C build
+        meson compile -C build
         ./qemu-test
         lcov --directory . --capture --output-file "noservice.info"
 
@@ -94,7 +94,7 @@ jobs:
       run: |
         docker exec -i cross whoami
         docker exec -i cross meson setup -Dgpt=enabled -Dwerror=true build
-        docker exec -i cross ninja -C build
+        docker exec -i cross meson compile -C build
         # don't run make check here, as we don't have full access to the kernel (mount, loopback, dm)
 
     - name: Show logs

--- a/test/meson.build
+++ b/test/meson.build
@@ -22,6 +22,18 @@ tests = [
   'stats',
 ]
 
+if get_option('network')
+  tests += 'network'
+endif
+
+if get_option('streaming')
+  tests += 'nbd'
+endif
+
+if jsonglibdep.found()
+  tests += 'boot_switch'
+endif
+
 extra_test_sources = files([
   'common.c',
   'install-fixtures.c',


### PR DESCRIPTION
Coverage data is expected to be generated and has not been (re)enabled yet when transitioning from autotools to meson in CI tests.
