### PR TITLE
add info-dbus API support to meta custom section

### DIFF
--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -35,6 +35,7 @@
       <arg name="bundle" type="s" direction="in" />
       <arg name="compatible" type="s" direction="out" />
       <arg name="version" type="s" direction="out" />
+      <arg name="meta" type="as" direction="out" />
     </method>
 
     <!--

--- a/src/main.c
+++ b/src/main.c
@@ -923,6 +923,15 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 	g_string_append_printf(text, "Description:\t'%s'\n", manifest->update_description);
 	g_string_append_printf(text, "Build:      \t'%s'\n", manifest->update_build);
 
+	if (manifest->meta != NULL) {
+		g_string_append_printf(text, "\n");
+		for (GList *l = manifest->meta; l != NULL; l = l->next) {
+			RManifestMetaEntry *entry = l->data;
+			g_string_append_printf(text, "%s:\t'%s'\n", entry->key, entry->value);
+		}
+		g_string_append_printf(text, "\n");
+	}
+
 	hooks = g_ptr_array_new();
 	if (manifest->hooks.install_check == TRUE) {
 		g_ptr_array_add(hooks, g_strdup("install-check"));

--- a/src/service.c
+++ b/src/service.c
@@ -133,6 +133,20 @@ static gboolean r_on_handle_install(RInstaller *interface,
 	return r_on_handle_install_bundle(interface, invocation, arg_source, NULL);
 }
 
+static const gchar *const *manifest_meta_to_string_array(GList *meta)
+{
+	g_autoptr(GPtrArray) array = g_ptr_array_new();
+
+	for (GList *l = meta; l != NULL; l = l->next) {
+		RManifestMetaEntry *entry = l->data;
+		g_ptr_array_add(array, g_strdup(entry->value));
+	}
+
+	g_ptr_array_add(array, NULL);
+
+	return (const gchar *const *) g_ptr_array_free(g_steal_pointer(&array), FALSE);
+}
+
 static gboolean r_on_handle_info(RInstaller *interface,
 		GDBusMethodInvocation  *invocation,
 		const gchar *arg_bundle)
@@ -172,7 +186,8 @@ out:
 				interface,
 				invocation,
 				manifest->update_compatible,
-				manifest->update_version ? manifest->update_version : "");
+				manifest->update_version ? manifest->update_version : "",
+				manifest_meta_to_string_array(manifest->meta));
 	} else {
 		g_dbus_method_invocation_return_error(invocation,
 				G_IO_ERROR,

--- a/test/service.c
+++ b/test/service.c
@@ -342,6 +342,7 @@ static void service_test_info(ServiceFixture *fixture, gconstpointer user_data)
 	GError *error = NULL;
 	gchar *compatible;
 	gchar *version;
+	gchar **meta;
 	g_autofree gchar *bundlepath = NULL;
 
 	if (!ENABLE_SERVICE) {
@@ -369,6 +370,7 @@ static void service_test_info(ServiceFixture *fixture, gconstpointer user_data)
 			bundlepath,
 			&compatible,
 			&version,
+			&meta,
 			NULL,
 			&error);
 	g_assert_no_error(error);


### PR DESCRIPTION
Signed-off-by: Abdallah Elkadri <elkadri.abdallah@gmail.com>

This pull request updates the rauc info command and the Dbus Info API to handle custom meta fields in the manifest, which was not the case in previous versions.

these changes were tested in streaming mode and works perfectly. 

note that there is already 12 tests in rauc.t that already fail, and after the modifications they remain the same. 
this is a work-in-progress PR .

