### PR TITLE
src/bundle: fix plain bundle detection for rauc encrypt

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1237,7 +1237,7 @@ gboolean encrypt_bundle(RaucBundle *bundle, const gchar *outbundle, GError **err
 	 * receives an encrypted CMS but no encrypted payload (which is what we
 	 * actually want to protect).
 	 */
-	if (bundle->manifest->bundle_format != R_MANIFEST_FORMAT_CRYPT) {
+	if (!bundle->manifest || bundle->manifest->bundle_format != R_MANIFEST_FORMAT_CRYPT) {
 		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE, "Refused to encrypt input bundle that is not in 'crypt' format.");
 		return FALSE;
 	}


### PR DESCRIPTION
We cannot encrypt plain bundles and these do not even initialize the bundle->manifest member. Thus we ran into a segfault here when attempting to evaluate bundle->manifest->bundle_format:

Fix this by checking for bundle->manifest being NULL first.

Fixes: #1054

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
