### PR TITLE
Introduce new 'InspectBundle' D-Bus API 

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1148,6 +1148,8 @@ Methods
 
 :ref:`Info <gdbus-method-de-pengutronix-rauc-Installer.Info>` (IN  s bundle, s compatible, s version);
 
+:ref:`InspectBundle <gdbus-method-de-pengutronix-rauc-Installer.InspectBundle>` (IN  s source, IN a{sv} args, a{sv} info);
+
 :ref:`Mark <gdbus-method-de-pengutronix-rauc-Installer.Mark>` (IN  s state, IN  s slot_identifier, s slot_name, s message);
 
 :ref:`GetSlotStatus <gdbus-method-de-pengutronix-rauc-Installer.GetSlotStatus>` (a(sa{sv}) slot_status_array);
@@ -1244,6 +1246,8 @@ IN s *source*:
 The Info() Method
 ^^^^^^^^^^^^^^^^^
 
+.. note:: This method is deprecated. Use InspectBundle() instead.
+
 .. code::
 
   de.pengutronix.rauc.Installer.Info()
@@ -1259,6 +1263,59 @@ s *compatible*:
 
 s *version*:
     Version string of bundle
+
+.. _gdbus-method-de-pengutronix-rauc-Installer.InspectBundle:
+
+The InspectBundle() Method
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+  de.pengutronix.rauc.Installer.InspectBundle()
+  InspectBundle (IN  s bundle, IN a{sv} args, a{sv} info);
+
+Provides bundle info.
+
+IN s *bundle*:
+    Path or URL to the bundle that should be queried for information
+
+IN a{sv} *args*:
+    Arguments to pass to information
+
+    Currently supported:
+
+    :STRING 'tls-cert', VARIANT 's' <filename/pkcs11-url>: Use the provided
+        certificate for TLS client authentication
+
+    :STRING 'tls-key', VARIANT 's' <filename/pkcs11-url>: Use the provided
+        private key for TLS client authentication
+
+    :STRING 'tls-ca', VARIANT 's' <filename/pkcs11-url>: Use the provided
+        certificate to authenticate the server (instead of the system wide
+        store)
+
+    :STRING 'http-headers', VARIANT 'as' <array of strings>: Add the provided
+        headers to every request (i.e. for bearer tokens)
+
+    :STRING 'tls-no-verify', VARIANT 'b' <true/false>: Ignore verification
+        errors for the server certificate
+
+a{sv} *info*:
+    Bundle info
+
+    :STRING 'update', VARIANT 'v' <update>: The bundle's update section content
+
+        :STRING 'compatible', VARIANT 's' <compatible>: The bundle's compatible noted
+            in manifest
+
+        :STRING 'version', VARIANT 's' <version>: The bundle's version noted
+            in manifest
+
+        :STRING 'description', VARIANT 's' <description>: The bundle's description
+            text noted in manifest
+
+        :STRING 'build', VARIANT 's' <build>: The bundle's build ID noted in
+            manifest
 
 .. _gdbus-method-de-pengutronix-rauc-Installer.Mark:
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -601,6 +601,12 @@ Monitor the D-Bus interface
 
   busctl monitor de.pengutronix.rauc
 
+Obtain bundle information
+
+.. code-block:: sh
+
+  busctl call de.pengutronix.rauc / de.pengutronix.rauc.Installer InspectBundle sa{sv} "<bundle-path>/<bundle-url>" 0
+
 .. _debugging:
 
 Debugging RAUC

--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -36,6 +36,19 @@
       <arg name="compatible" type="s" direction="out" />
       <arg name="version" type="s" direction="out" />
     </method>
+ 
+    <!--
+         InspectBundle: D-Bus variant of rauc info <bundle>
+         @source: Path or URL to the queried bundle.
+         @args: Additional arguments to pass
+         @info: string variant dict of bundle information
+    -->
+    <method name="InspectBundle">
+      <arg name="source" type="s" direction="in" />
+      <arg name="args" type="a{sv}" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg name="info" type="a{sv}" direction="out"/>
+    </method>
 
     <!--
          Mark:

--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -25,13 +25,13 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
     </method>
 
-   <!--
-    Info: D-Bus variant of rauc info <bundle>
-    @bundle: full path to the queried bundle.
-    @compatible: the compatible string from the bundle
-    @version: the version string from the bundle
-   -->
-   <method name="Info">
+    <!--
+         Info: D-Bus variant of rauc info <bundle>
+         @bundle: full path to the queried bundle.
+         @compatible: the compatible string from the bundle
+         @version: the version string from the bundle
+    -->
+    <method name="Info">
       <arg name="bundle" type="s" direction="in" />
       <arg name="compatible" type="s" direction="out" />
       <arg name="version" type="s" direction="out" />

--- a/test/service.c
+++ b/test/service.c
@@ -337,7 +337,7 @@ static void service_test_install_deprecated(ServiceFixture *fixture, gconstpoint
 	service_test_install(fixture, user_data, TRUE);
 }
 
-static void service_test_info(ServiceFixture *fixture, gconstpointer user_data)
+static void service_test_info(ServiceFixture *fixture, gconstpointer user_data, gboolean deprecated)
 {
 	GError *error = NULL;
 	gchar *compatible;
@@ -365,12 +365,29 @@ static void service_test_info(ServiceFixture *fixture, gconstpointer user_data)
 		goto out;
 	}
 
-	r_installer_call_info_sync(installer,
-			bundlepath,
-			&compatible,
-			&version,
-			NULL,
-			&error);
+	if (deprecated) {
+		r_installer_call_info_sync(installer,
+				bundlepath,
+				&compatible,
+				&version,
+				NULL,
+				&error);
+	} else {
+		GVariant *info = NULL;
+		GVariant *bundle_update = NULL;
+		g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
+		r_installer_call_inspect_bundle_sync(installer,
+				bundlepath,
+				g_variant_dict_end(&dict), /* floating, no unref needed */
+				&info,
+				NULL,
+				&error);
+		g_assert_nonnull(info);
+		g_variant_lookup(info, "update", "v", &bundle_update);
+		g_assert_nonnull(bundle_update);
+		g_variant_lookup(bundle_update, "compatible", "s", &compatible);
+		g_variant_lookup(bundle_update, "version", "s", &version);
+	}
 	g_assert_no_error(error);
 	g_assert_cmpstr(compatible, ==, "Test Config");
 	g_assert_cmpstr(version, ==, "2011.03-2");
@@ -379,6 +396,16 @@ out:
 	g_clear_object(&installer);
 	g_free(compatible);
 	g_free(version);
+}
+
+static void service_test_info_bundle(ServiceFixture *fixture, gconstpointer user_data)
+{
+	service_test_info(fixture, user_data, FALSE);
+}
+
+static void service_test_info_deprecated(ServiceFixture *fixture, gconstpointer user_data)
+{
+	service_test_info(fixture, user_data, TRUE);
 }
 
 static void service_test_slot_status(ServiceFixture *fixture, gconstpointer user_data)
@@ -435,8 +462,12 @@ int main(int argc, char *argv[])
 			service_install_fixture_set_up, service_test_install_api,
 			service_fixture_tear_down);
 
-	g_test_add("/service/info", ServiceFixture, NULL,
-			service_info_fixture_set_up, service_test_info,
+	g_test_add("/service/info-bundle", ServiceFixture, NULL,
+			service_info_fixture_set_up, service_test_info_bundle,
+			service_fixture_tear_down);
+
+	g_test_add("/service/info-deprecated", ServiceFixture, NULL,
+			service_info_fixture_set_up, service_test_info_deprecated,
 			service_fixture_tear_down);
 
 	g_test_add("/service/slot-status", ServiceFixture, NULL,


### PR DESCRIPTION
The old 'InfoBundle' method lacked the capability of passing additional arguments, which prevented adding a lot of features in the past.

Compared to the existing one, the new method differs only in the additional array-of-string-variant parameter 'args'.

This allows passing all kinds of future additional simple arguments.

To guarantee API stability, the old method will be kept as an alternative.

This builds on top of #965 but with the review feedback addressed.

Closes #965.