### PR TITLE
Split help into bundle handling and target commands

### DIFF
--- a/rauc.1
+++ b/rauc.1
@@ -72,10 +72,6 @@ use specific keyring file
 mount prefix (/mnt/rauc by default)
 
 .TP
-\fB\-\-override\-boot\-slot=\fR\fIBOOTNAME\fR
-overrides auto-detection of booted slot
-
-.TP
 \fB\-d\fR, \fB\-\-debug\fR
 enable debug output
 
@@ -271,6 +267,10 @@ show progress bar
 \fB\-\-handler\-args=\fR\fIARGS\fR
 pass extra handler arguments
 
+.TP
+\fB\-\-override\-boot\-slot=\fR\fIBOOTNAME\fR
+overrides auto-detection of booted slot
+
 .RE
 .RE
 .PP
@@ -339,6 +339,10 @@ show more status details
 .TP
 \fB\-\-output\-format=\fR[\fBreadable\fR|\fBshell\fR|\fBjson\fR|\fBjson-pretty\fR]
 select output format
+
+.TP
+\fB\-\-override\-boot\-slot=\fR\fIBOOTNAME\fR
+overrides auto-detection of booted slot
 
 .RE
 .RE

--- a/rauc.1
+++ b/rauc.1
@@ -76,10 +76,6 @@ mount prefix (/mnt/rauc by default)
 overrides auto-detection of booted slot
 
 .TP
-\fB\-\-handler\-args=\fR\fIARGS\fR
-pass extra handler arguments
-
-.TP
 \fB\-d\fR, \fB\-\-debug\fR
 enable debug output
 
@@ -270,6 +266,10 @@ disable compatible check
 .TP
 \fB\-\-progress\fR
 show progress bar
+
+.TP
+\fB\-\-handler\-args=\fR\fIARGS\fR
+pass extra handler arguments
 
 .RE
 .RE

--- a/src/main.c
+++ b/src/main.c
@@ -2239,7 +2239,7 @@ static void cmdline_handler(int argc, char **argv)
 			"Command-specific help:\n"
 			"  rauc <COMMAND> --help\n"
 			"\n"
-			"List of rauc commands:\n"
+			"List of rauc bundle handling commands:\n"
 #if ENABLE_CREATE == 1
 			"  bundle\t\tCreate a bundle\n"
 			"  resign\t\tResign an already signed bundle\n"
@@ -2249,13 +2249,15 @@ static void cmdline_handler(int argc, char **argv)
 			"  extract-signature\tExtract the bundle signature\n"
 #endif
 			"  extract\t\tExtract the bundle content\n"
-			"  install\t\tInstall a bundle\n"
 			"  info\t\t\tShow bundle information\n"
-			"  mount\t\t\tMount a bundle\n"
+			"\n"
+			"List of rauc target commands:\n"
 #if ENABLE_SERVICE == 1
 			"  service\t\tStart RAUC service\n"
 #endif
+			"  install\t\tInstall a bundle\n"
 			"  status\t\tShow status\n"
+			"  mount\t\t\tMount a bundle\n"
 			"  write-slot\t\tWrite image to slot and bypass all update logic\n"
 			"\n"
 			"Environment variables:\n"


### PR DESCRIPTION
The list of RAUC commands increased over the last releases.
Together with the dual use of RAUC as host and target tool it becomes harder to distinguish between host and target tool usage.

While for some commands (as 'rauc info') no clear category can be found, for others (as 'rauc service' or 'rauc status') the distinction is quite clear.

To better guide the user, we split the subcommand info prompt into 'bundle handling' and 'target' subcommands.