### PR TITLE
Document URL as proper argument for 'rauc install' / InstallBundle

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -263,9 +263,13 @@ service process in background::
 Installing a Bundle (Target)
 ----------------------------
 
-To install the bundle on your target device, run::
+To install the bundle (from local storage) on your target device, run::
 
-    rauc install update-2019.01-1.raucb
+    rauc install update-2023.02-1.raucb
+
+To install a bundle from a webserver (using RAUC's built-in HTTP(S) streaming), run::
+
+    rauc install https://example.com/update-2023.02-1.raucb
 
 Contributing
 ------------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1193,7 +1193,7 @@ This method call is non-blocking.
 After completion, the :ref:`"Completed" <gdbus-signal-de-pengutronix-rauc-Installer.Completed>` signal will be emitted.
 
 IN s *source*:
-    Path to bundle to be installed
+    Path or URL to the bundle that should be installed
 
 IN a{sv} *args*:
     Arguments to pass to installation

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -550,7 +550,7 @@ Triggering an installation:
 
 .. code-block:: sh
 
-  busctl call de.pengutronix.rauc / de.pengutronix.rauc.Installer InstallBundle sa{sv} "/path/to/bundle" 0
+  busctl call de.pengutronix.rauc / de.pengutronix.rauc.Installer InstallBundle sa{sv} "<bundle-path>/<bundle-url>" 0
 
 Mark a slot as good:
 

--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -14,7 +14,7 @@
 
     <!--
          InstallBundle:
-         @source: Path to bundle to be installed
+         @source: Path or URL to bundle to be installed
          @args: Additional arguments to pass
 
          Triggers an installation.

--- a/src/main.c
+++ b/src/main.c
@@ -2205,7 +2205,7 @@ static void cmdline_handler(int argc, char **argv)
 		{EXTRACT, "extract", "extract <BUNDLENAME> <OUTPUTDIR>",
 		 "Extract the bundle content",
 		 extract_start, extract_group, R_CONTEXT_CONFIG_MODE_AUTO, FALSE},
-		{INFO, "info", "info <FILE>",
+		{INFO, "info", "info <BUNDLE>",
 		 "Print bundle info",
 		 info_start, info_group, R_CONTEXT_CONFIG_MODE_AUTO, FALSE},
 		{STATUS, "status", "status",


### PR DESCRIPTION
This is still missing in various places.
Also fix the 'rauc info' help text to use `BUNDLE` instead of `FILE`.