### PR TITLE
docs: meson.build: add input files as build dependencies

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -4,9 +4,28 @@ if not sphinx.found()
   subdir_done()
 endif
 
+sources_doc = files([
+  'conf.py',
+  'advanced.rst',
+  'basic.rst',
+  'changes.rst',
+  'checklist.rst',
+  'contributing.rst',
+  'examples.rst',
+  'faq.rst',
+  'index.rst',
+  'integration.rst',
+  'reference.rst',
+  'scenarios.rst',
+  'terminology.rst',
+  'updating.rst',
+  'using.rst',
+])
+
 custom_target(
   'doc',
   output: 'html',
+  depend_files: sources_doc,
   command: [sphinx, '-b', 'html', meson.current_source_dir(), meson.current_build_dir() / 'html'],
   build_by_default: false
 )


### PR DESCRIPTION
Since we do not track all doc input files, we cannot say if sphinx needs to rebuild. Thus, with the configuration so far, meson would have built the docs only once and then assumed they were built.

Since sphinx can track required rebuilds itself and does not rebuild unnecessary parts, we can safely enforce always calling sphinx here by settings the target as 'stale'.
