### PR TITLE
Introduce Manifest Hash

### DIFF
--- a/include/manifest.h
+++ b/include/manifest.h
@@ -71,6 +71,8 @@ typedef struct {
 
 	/* internal marker that this was encrypted */
 	gboolean was_encrypted;
+	/* computed manifest hash */
+	gchar *hash;
 } RaucManifest;
 
 /**

--- a/include/slot.h
+++ b/include/slot.h
@@ -16,6 +16,7 @@ typedef struct {
 	gchar *bundle_version;
 	gchar *bundle_description;
 	gchar *bundle_build;
+	gchar *bundle_hash;
 	gchar *status;
 	RaucChecksum checksum;
 	gchar *installed_timestamp;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -883,6 +883,7 @@ static void status_file_get_slot_status(GKeyFile *key_file, const gchar *group, 
 	g_free(slotstatus->bundle_version);
 	g_free(slotstatus->bundle_description);
 	g_free(slotstatus->bundle_build);
+	g_free(slotstatus->bundle_hash);
 	g_free(slotstatus->status);
 	g_clear_pointer(&slotstatus->checksum.digest, g_free);
 	g_free(slotstatus->installed_timestamp);
@@ -892,6 +893,7 @@ static void status_file_get_slot_status(GKeyFile *key_file, const gchar *group, 
 	slotstatus->bundle_version = key_file_consume_string(key_file, group, "bundle.version", NULL);
 	slotstatus->bundle_description = key_file_consume_string(key_file, group, "bundle.description", NULL);
 	slotstatus->bundle_build = key_file_consume_string(key_file, group, "bundle.build", NULL);
+	slotstatus->bundle_hash = key_file_consume_string(key_file, group, "bundle.hash", NULL);
 	slotstatus->status = key_file_consume_string(key_file, group, "status", NULL);
 
 	digest = key_file_consume_string(key_file, group, "sha256", NULL);
@@ -948,6 +950,7 @@ static void status_file_set_slot_status(GKeyFile *key_file, const gchar *group, 
 	status_file_set_string_or_remove_key(key_file, group, "bundle.version", slotstatus->bundle_version);
 	status_file_set_string_or_remove_key(key_file, group, "bundle.description", slotstatus->bundle_description);
 	status_file_set_string_or_remove_key(key_file, group, "bundle.build", slotstatus->bundle_build);
+	status_file_set_string_or_remove_key(key_file, group, "bundle.hash", slotstatus->bundle_hash);
 	status_file_set_string_or_remove_key(key_file, group, "status", slotstatus->status);
 
 	if (slotstatus->checksum.digest && slotstatus->checksum.type == G_CHECKSUM_SHA256) {

--- a/src/install.c
+++ b/src/install.c
@@ -971,6 +971,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 		g_free(slot_state->bundle_version);
 		g_free(slot_state->bundle_description);
 		g_free(slot_state->bundle_build);
+		g_free(slot_state->bundle_hash);
 		g_free(slot_state->status);
 		g_free(slot_state->checksum.digest);
 		g_free(slot_state->installed_timestamp);
@@ -981,6 +982,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 		slot_state->bundle_version = g_strdup(manifest->update_version);
 		slot_state->bundle_description = g_strdup(manifest->update_description);
 		slot_state->bundle_build = g_strdup(manifest->update_build);
+		slot_state->bundle_hash = g_strdup(manifest->hash);
 		slot_state->status = g_strdup("ok");
 		slot_state->checksum.type = mfimage->checksum.type;
 		slot_state->checksum.digest = g_strdup(mfimage->checksum.digest);

--- a/src/main.c
+++ b/src/main.c
@@ -1276,6 +1276,8 @@ static void r_string_append_slot(GString *text, RaucSlot *slot, RaucStatusPrint 
 			g_string_append_printf(text, "\n              description=%s", slot_state->bundle_description);
 		if (slot_state->bundle_build)
 			g_string_append_printf(text, "\n              build=%s", slot_state->bundle_build);
+		if (slot_state->bundle_hash)
+			g_string_append_printf(text, "\n              hash=%s", slot_state->bundle_hash);
 		if (slot_state->checksum.digest && slot_state->checksum.type == G_CHECKSUM_SHA256) {
 			g_string_append_printf(text, "\n          checksum:");
 			g_string_append_printf(text, "\n              sha256=%s", slot_state->checksum.digest);
@@ -1408,6 +1410,7 @@ static gchar* r_status_formatter_shell(RaucStatusPrint *status)
 			formatter_shell_append_n(text, "RAUC_SLOT_STATUS_BUNDLE_VERSION", slotcnt, slot_state->bundle_version);
 			formatter_shell_append_n(text, "RAUC_SLOT_STATUS_BUNDLE_DESCRIPTION", slotcnt, slot_state->bundle_description);
 			formatter_shell_append_n(text, "RAUC_SLOT_STATUS_BUNDLE_BUILD", slotcnt, slot_state->bundle_build);
+			formatter_shell_append_n(text, "RAUC_SLOT_STATUS_BUNDLE_HASH", slotcnt, slot_state->bundle_hash);
 			formatter_shell_append_n(text, "RAUC_SLOT_STATUS_CHECKSUM_SHA256", slotcnt, slot_state->checksum.digest);
 			str = g_strdup_printf("%"G_GOFFSET_FORMAT, slot_state->checksum.size);
 			formatter_shell_append_n(text, "RAUC_SLOT_STATUS_CHECKSUM_SIZE", slotcnt, str);
@@ -1500,6 +1503,10 @@ static gchar* r_status_formatter_json(RaucStatusPrint *status, gboolean pretty)
 				json_builder_set_member_name(builder, "build");
 				json_builder_add_string_value(builder, slot_state->bundle_build);
 			}
+			if (slot_state->bundle_hash) {
+				json_builder_set_member_name(builder, "hash");
+				json_builder_add_string_value(builder, slot_state->bundle_hash);
+			}
 			json_builder_end_object(builder);               /* bundle */
 			if (slot_state->checksum.digest && slot_state->checksum.type == G_CHECKSUM_SHA256) {
 				json_builder_set_member_name(builder, "checksum");
@@ -1564,6 +1571,7 @@ static RaucSlotStatus* r_variant_get_slot_state(GVariant *vardict)
 	g_variant_dict_lookup(&dict, "bundle.version", "s", &slot_state->bundle_version);
 	g_variant_dict_lookup(&dict, "bundle.description", "s", &slot_state->bundle_description);
 	g_variant_dict_lookup(&dict, "bundle.build", "s", &slot_state->bundle_build);
+	g_variant_dict_lookup(&dict, "bundle.hash", "s", &slot_state->bundle_hash);
 	g_variant_dict_lookup(&dict, "status", "s", &slot_state->status);
 	if (g_variant_dict_lookup(&dict, "sha256", "s", &slot_state->checksum.digest))
 		slot_state->checksum.type = G_CHECKSUM_SHA256;

--- a/src/main.c
+++ b/src/main.c
@@ -857,6 +857,7 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 	formatter_shell_append(text, "RAUC_MF_VERSION", manifest->update_version);
 	formatter_shell_append(text, "RAUC_MF_DESCRIPTION", manifest->update_description);
 	formatter_shell_append(text, "RAUC_MF_BUILD", manifest->update_build);
+	formatter_shell_append(text, "RAUC_MF_HASH", manifest->hash);
 	g_string_append_printf(text, "RAUC_MF_IMAGES=%d\n", g_list_length(manifest->images));
 
 	hooks = g_ptr_array_new();
@@ -950,6 +951,7 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 		g_string_append_printf(text, "  Verity Hash: \t'%s'\n", manifest->bundle_verity_hash);
 		g_string_append_printf(text, "  Verity Size: \t%"G_GUINT64_FORMAT "\n", manifest->bundle_verity_size);
 	}
+	g_string_append_printf(text, "Manifest Hash:\t'%s'\n\n", manifest->hash);
 
 	g_ptr_array_unref(hooks);
 
@@ -1044,6 +1046,9 @@ static gchar* info_formatter_json_base(RaucManifest *manifest, gboolean pretty)
 		json_builder_add_string_value(builder, "install-check");
 	}
 	json_builder_end_array(builder);
+
+	json_builder_set_member_name(builder, "hash");
+	json_builder_add_string_value(builder, manifest->hash);
 
 	json_builder_set_member_name(builder, "images");
 	json_builder_begin_array(builder);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -270,54 +270,46 @@ gboolean load_manifest_mem(GBytes *mem, RaucManifest **manifest, GError **error)
 	g_autoptr(GKeyFile) key_file = NULL;
 	const gchar *data;
 	gsize length;
-	gboolean res = FALSE;
 
 	data = g_bytes_get_data(mem, &length);
 	if (data == NULL) {
 		g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_ERROR_NO_DATA, "No data available");
-		goto out;
+		return FALSE;
 	}
 
 	key_file = g_key_file_new();
 
-	res = g_key_file_load_from_data(key_file, data, length, G_KEY_FILE_NONE, &ierror);
-	if (!res) {
+	if (!g_key_file_load_from_data(key_file, data, length, G_KEY_FILE_NONE, &ierror)) {
 		g_propagate_error(error, ierror);
-		goto out;
+		return FALSE;
 	}
 
-	res = parse_manifest(key_file, manifest, &ierror);
-	if (!res) {
+	if (!parse_manifest(key_file, manifest, &ierror)) {
 		g_propagate_error(error, ierror);
-		goto out;
+		return FALSE;
 	}
 
-out:
-	return res;
+	return TRUE;
 }
 
 gboolean load_manifest_file(const gchar *filename, RaucManifest **manifest, GError **error)
 {
 	GError *ierror = NULL;
 	g_autoptr(GKeyFile) key_file = NULL;
-	gboolean res = FALSE;
 
 	key_file = g_key_file_new();
 
-	res = g_key_file_load_from_file(key_file, filename, G_KEY_FILE_NONE, &ierror);
-	if (!res) {
+	if (!g_key_file_load_from_file(key_file, filename, G_KEY_FILE_NONE, &ierror)) {
 		g_propagate_error(error, ierror);
-		goto out;
+		return FALSE;
 	}
 
-	res = parse_manifest(key_file, manifest, &ierror);
-	if (!res) {
+	if (!parse_manifest(key_file, manifest, &ierror)) {
 		g_propagate_error(error, ierror);
-		goto out;
+		return FALSE;
 	}
 
-out:
-	return res;
+	return TRUE;
 }
 
 static gboolean check_manifest_common(const RaucManifest *mf, GError **error)

--- a/src/service.c
+++ b/src/service.c
@@ -347,6 +347,9 @@ static GVariant* convert_slot_status_to_dict(RaucSlot *slot)
 	if (slot_state->bundle_build)
 		g_variant_dict_insert(&dict, "bundle.build", "s", slot_state->bundle_build);
 
+	if (slot_state->bundle_hash)
+		g_variant_dict_insert(&dict, "bundle.hash", "s", slot_state->bundle_hash);
+
 	if (slot_state->status)
 		g_variant_dict_insert(&dict, "status", "s", slot_state->status);
 


### PR DESCRIPTION
This introduces a manifest hash that is calculated when loading the manifest from the bundle.

Together with 'verity' (or derived) bundle formats, this will allow unambiguously identifying a bundle, since the verity root hash is also part of the manifest and thus indirectly both the payload and the meta data are part of the hash.

The information is exposed both for bundle introspection (`rauc info`) as well as system introspection (`rauc status`) and thus allows for example to see if a given bundle is exactly the one that was installed on the system.