### PR TITLE
Remove partition information from loop when getting backing_file #1057

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -53,6 +53,8 @@ static gchar *resolve_loop_device(const gchar *devicepath, GError **error)
 		return g_strdup(devicepath);
 
 	devicename = g_path_get_basename(devicepath);
+	g_string_replace(devicename, "p1", "\0", 0);
+
 	syspath = g_build_filename("/sys/block", devicename, "loop/backing_file", NULL);
 
 	content = read_file_str(syspath, &ierror);

--- a/src/install.c
+++ b/src/install.c
@@ -53,8 +53,6 @@ static gchar *resolve_loop_device(const gchar *devicepath, GError **error)
 		return g_strdup(devicepath);
 
 	devicename = g_path_get_basename(devicepath);
-	g_string_replace(devicename, "p1", "\0", 0);
-
 	syspath = g_build_filename("/sys/block", devicename, "loop/backing_file", NULL);
 
 	content = read_file_str(syspath, &ierror);

--- a/src/install.c
+++ b/src/install.c
@@ -45,6 +45,7 @@ static void install_args_update(RaucInstallArgs *args, const gchar *msg)
 static gchar *resolve_loop_device(const gchar *devicepath, GError **error)
 {
 	g_autoptr(GString) devicename = NULL;
+	g_autofree gchar *basename = NULL;
 	g_autofree gchar *syspath = NULL;
 	gchar *content = NULL;
 	GError *ierror = NULL;
@@ -52,9 +53,12 @@ static gchar *resolve_loop_device(const gchar *devicepath, GError **error)
 	if (!g_str_has_prefix(devicepath, "/dev/loop"))
 		return g_strdup(devicepath);
 
-	devicename = g_string_new(g_path_get_basename(devicepath));
-	devicename = g_string_set_size(devicename, 5);
+	basename = g_path_get_basename(devicepath);
 
+	devicename = g_string_new(basename);
+	
+	/* Cut of any partition information like p1*/
+	devicename = g_string_set_size(devicename, sizeof("loop0"));
 
 	syspath = g_build_filename("/sys/block", devicename->str, "loop/backing_file", NULL);
 

--- a/src/install.c
+++ b/src/install.c
@@ -57,7 +57,7 @@ static gchar *resolve_loop_device(const gchar *devicepath, GError **error)
 
 	devicename = g_string_new(basename);
 	
-	/* Cut of any partition information like p1*/
+	/* Cut of any partition information like p1 */
 	devicename = g_string_set_size(devicename, sizeof("loop0"));
 
 	syspath = g_build_filename("/sys/block", devicename->str, "loop/backing_file", NULL);

--- a/src/install.c
+++ b/src/install.c
@@ -44,7 +44,7 @@ static void install_args_update(RaucInstallArgs *args, const gchar *msg)
 
 static gchar *resolve_loop_device(const gchar *devicepath, GError **error)
 {
-	g_autofree gchar *devicename = NULL;
+	g_autoptr(GString) devicename = NULL;
 	g_autofree gchar *syspath = NULL;
 	gchar *content = NULL;
 	GError *ierror = NULL;
@@ -52,8 +52,13 @@ static gchar *resolve_loop_device(const gchar *devicepath, GError **error)
 	if (!g_str_has_prefix(devicepath, "/dev/loop"))
 		return g_strdup(devicepath);
 
-	devicename = g_path_get_basename(devicepath);
-	syspath = g_build_filename("/sys/block", devicename, "loop/backing_file", NULL);
+	devicename = g_string_new(g_path_get_basename(devicepath));
+	devicename = g_string_set_size(devicename, 5);
+
+
+	syspath = g_build_filename("/sys/block", devicename->str, "loop/backing_file", NULL);
+
+	g_debug("Getting backing file for Loopback device: %s from %s", devicename->str, syspath);
 
 	content = read_file_str(syspath, &ierror);
 	if (!content) {


### PR DESCRIPTION
<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
Fixing #1057 removing partition part of /dev/loop when getting backing file.