### PR TITLE
Fix number format handling for U-Boot

### DIFF
--- a/contrib/uboot.sh
+++ b/contrib/uboot.sh
@@ -7,14 +7,14 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   if test "x${bootargs}" != "x"; then
     # skip remaining slots
   elif test "x${BOOT_SLOT}" = "xA"; then
-    if test ${BOOT_A_LEFT} -gt 0; then
+    if test 0x${BOOT_A_LEFT} -gt 0; then
       echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       setenv load_kernel "nand read ${kernel_loadaddr} ${kernel_a_nandoffset} ${kernel_size}"
       setenv bootargs "${default_bootargs} root=/dev/mmcblk0p1 rauc.slot=A"
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
-    if test ${BOOT_B_LEFT} -gt 0; then
+    if test 0x${BOOT_B_LEFT} -gt 0; then
       echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       setenv load_kernel "nand read ${kernel_loadaddr} ${kernel_b_nandoffset} ${kernel_size}"

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -962,7 +962,7 @@ static gboolean uboot_set_primary(RaucSlot *slot, GError **error)
 	if (attempts <= 0)
 		attempts = UBOOT_ATTEMPTS_PRIMARY;
 
-	val = g_strdup_printf("%d", attempts);
+	val = g_strdup_printf("%x", attempts);
 
 	if (!uboot_env_set(key, val, &ierror)) {
 		g_propagate_error(error, ierror);

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -905,9 +905,10 @@ BOOT_B_LEFT=3\n\
 	res = r_boot_set_primary(rootfs0, &error);
 	g_assert_no_error(error);
 	g_assert_true(res);
+	/* remember: U-Boot uses hex numbers without a prefix */
 	g_assert_true(test_uboot_post_state(fixture, "\
 BOOT_ORDER=A B\n\
-BOOT_A_LEFT=10\n\
+BOOT_A_LEFT=a\n\
 BOOT_B_LEFT=3\n\
 "));
 }


### PR DESCRIPTION
* The remaining attempts are hexadecimal numbers (due to `setexpr`) but without a prefix
* The comparisons should take this into account
    * Previously [the comparison]() failed for all values containing non-decimal digits like 'f', for example
        ```
        => setenv BOOT_A_LEFT b00d
        => if test ${BOOT_A_LEFT} -gt 0; then echo greater; else echo not greater; fi
        not greater
        ```
    * Providing the prefix when comparing with `test` gives the expected result
        ```
        => if test 0x${BOOT_A_LEFT} -gt 0; then echo greater; else echo not greater; fi
        greater
        ```
    * As `setexpr` emits the result without prefix, adding the prefix when setting the variable is not possible
*  RAUC also should write hex values to the U-Boot environment consistently
    * Previously a successful update left the new boot slot with its remaining attempts in decimal representation