### PR TITLE
refactor config file parsing and fix memory leak in slot handling

### DIFF
--- a/src/slot.c
+++ b/src/slot.c
@@ -20,6 +20,7 @@ void r_slot_free(gpointer value)
 	g_free(slot->mount_point);
 	g_free(slot->ext_mount_point);
 	g_clear_pointer(&slot->status, r_slot_free_status);
+	g_free(slot->data_directory);
 	g_free(slot);
 }
 


### PR DESCRIPTION
I've split out the slot parsing from `load_config()`, which has grown much too long.

Also fix a minor memory leak in the handling of the data directory for slots.