### PR TITLE
meson.build: support generating version information from git

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -169,6 +169,8 @@ version_h = vcs_tag(
 )
 versiondep = declare_dependency(sources: version_h)
 
+meson.add_dist_script('version-gen', meson.project_version())
+
 rauc_deps = [threaddep, libcurldep, libnlgenldep, jsonglibdep, dbusdep, glibdep, giodep, giounixdep, openssldep, fdiskdep]
 
 librauc = static_library('rauc',

--- a/meson.build
+++ b/meson.build
@@ -14,8 +14,6 @@ cc = meson.get_compiler('c')
 
 conf = configuration_data()
 conf.set_quoted('PACKAGE_NAME', 'rauc')
-conf.set_quoted('PACKAGE_VERSION', meson.project_version())
-conf.set_quoted('PACKAGE_STRING', 'rauc ' + meson.project_version())
 conf.set_quoted('STREAMING_USER', get_option('streaming_user'))
 
 prefixdir = get_option('prefix')
@@ -165,20 +163,28 @@ config_h = configure_file(
 )
 add_project_arguments('-include', meson.current_build_dir() / 'config.h', language : 'c')
 
+version_h = vcs_tag(
+  input : 'version.h.in',
+  output : 'version.h',
+)
+versiondep = declare_dependency(sources: version_h)
+
 rauc_deps = [threaddep, libcurldep, libnlgenldep, jsonglibdep, dbusdep, glibdep, giodep, giounixdep, openssldep, fdiskdep]
 
 librauc = static_library('rauc',
   sources_rauc,
   dbus_sources,
   include_directories : incdir,
-  dependencies : rauc_deps,
+  c_args : ['-include', meson.current_build_dir() / 'version.h'],
+  dependencies : rauc_deps + [versiondep],
   )
 
 executable('rauc',
   'src/main.c',
   dbus_sources,
   include_directories : incdir,
-  dependencies : rauc_deps,
+  c_args : ['-include', meson.current_build_dir() / 'version.h'],
+  dependencies : rauc_deps + [versiondep],
   link_with : librauc,
   install : true)
 

--- a/version-gen
+++ b/version-gen
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "$1" > "$MESON_DIST_ROOT/.tarball-version"

--- a/version.h.in
+++ b/version.h.in
@@ -1,0 +1,3 @@
+#define PACKAGE_STRING "rauc @VCS_TAG@"
+
+#define PACKAGE_VERSION "@VCS_TAG@"


### PR DESCRIPTION
This creates a `version.h` file with version information derived from `git describe` using `vcs_tag`.
The `version.h` include will be injected into rauc and librauc builds.

For `meson dist`, no git information will be available, thus `meson.project_version()` serves as a fallback.

However, the generated tarball then still produces a non-fatal message that might upset users:

> fatal: not a git repository (or any parent up to mount point /)

Note that meson does not seem to allow including generated files in dist tarballs by design, thus adding a '.tarball-version'-like file will not be possible.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
