### PR TITLE
src: give check_slot low progress weight

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -119,6 +119,9 @@ void r_context_begin_step_weighted(const gchar *name, const gchar *description,
 void r_context_begin_step_formatted(const gchar *name, gint substeps, const gchar *description, ...)
 __attribute__((__format__(__printf__, 3, 4)));
 
+void r_context_begin_step_weighted_formatted(const gchar *name, gint substeps, gint weight, const gchar *description, ...)
+__attribute__((__format__(__printf__, 4, 5)));
+
 /**
  * Call at the end of a relevant code block. Percentage calculation is done
  * automatically if not set explicitly.

--- a/src/context.c
+++ b/src/context.c
@@ -526,6 +526,21 @@ void r_context_begin_step_formatted(const gchar *name, gint substeps, const gcha
 	r_context_begin_step(name, desc_formatted, substeps);
 }
 
+void r_context_begin_step_weighted_formatted(const gchar *name, gint substeps, gint weight, const gchar *description, ...)
+{
+	va_list args;
+	g_autofree gchar *desc_formatted = NULL;
+
+	g_return_if_fail(name);
+	g_return_if_fail(description);
+
+	va_start(args, description);
+	desc_formatted = g_strdup_vprintf(description, args);
+	va_end(args);
+
+	r_context_begin_step_weighted(name, desc_formatted, substeps, weight);
+}
+
 void r_context_end_step(const gchar *name, gboolean success)
 {
 	RaucProgressStep *step;

--- a/src/install.c
+++ b/src/install.c
@@ -891,7 +891,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 	if (manifest->hook_name)
 		hook_name = g_build_filename(bundledir, manifest->hook_name, NULL);
 
-	r_context_begin_step_weighted("update_slots", "Updating slots", g_list_length(install_images) * 2, 6);
+	r_context_begin_step_weighted("update_slots", "Updating slots", g_list_length(install_images) * 10, 6);
 	install_args_update(args, "Updating slots...");
 	for (GList *l = install_images; l != NULL; l = l->next) {
 		RaucImage *mfimage = l->data;
@@ -911,7 +911,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 
 		install_args_update(args, g_strdup_printf("Checking slot %s", dest_slot->name));
 
-		r_context_begin_step_formatted("check_slot", 0, "Checking slot %s", dest_slot->name);
+		r_context_begin_step_weighted_formatted("check_slot", 0, 1, "Checking slot %s", dest_slot->name);
 
 		load_slot_status(dest_slot);
 		slot_state = dest_slot->status;
@@ -957,7 +957,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 				g_message("Updating %s with %s", dest_slot->device, mfimage->filename);
 		}
 
-		r_context_begin_step_formatted("copy_image", 0, "Copying image to %s", dest_slot->name);
+		r_context_begin_step_weighted_formatted("copy_image", 0, 9, "Copying image to %s", dest_slot->name);
 
 		res = update_handler(
 				mfimage,

--- a/test/service.c
+++ b/test/service.c
@@ -185,12 +185,12 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Determining target install group done.", 2));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Updating slots", 2));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Checking slot rootfs.1", 3));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  55, "Checking slot rootfs.1 done.", 3));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  55, "Copying image to rootfs.1", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  43, "Checking slot rootfs.1 done.", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  43, "Copying image to rootfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  70, "Copying image to rootfs.1 done.", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  70, "Checking slot appfs.1", 3));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  85, "Checking slot appfs.1 done.", 3));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  85, "Copying image to appfs.1", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  73, "Checking slot appfs.1 done.", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  73, "Copying image to appfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  99, "Copying image to appfs.1 done.", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  99, "Updating slots done.", 2));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)", 100, "Installing done.", 1));


### PR DESCRIPTION
This adds a function for formatted weighting of progress and uses it to give the 'check_slot' progress sub step of 'update_slots' a weight of 1 while the actual 'copy_image' step gets a weight of 9 to reflect that in 'check_slot' hardly any work is done in contrast to 'copy_image'.

An alternative could be to just fully remove the check_slot sub step which does not check nearly as much as the name might indicate.

Without this patch and with having a single slot, progress will be:

```
 40% Updating slots
 40% Checking slot rootfs.1
 70% Checking slot rootfs.1 done.
 70% Copying image to rootfs.1
 99% Copying image to rootfs.1 done.
```

Note that this almost instantly jumps from 40% to 70%.

With the patch instead, we get:

```
 40% Updating slots
 40% Checking slot rootfs.1
 46% Checking slot rootfs.1 done.
 46% Copying image to rootfs.1
 99% Copying image to rootfs.1 done.
 99% Updating slots done.
```

Which better reflects the time actually spent in each subtask.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
