### PR TITLE
Add support for FTPS

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1329,7 +1329,8 @@ static gboolean is_remote_scheme(const gchar *scheme)
 	return (g_strcmp0(scheme, "http") == 0) ||
 	       (g_strcmp0(scheme, "https") == 0) ||
 	       (g_strcmp0(scheme, "sftp") == 0) ||
-	       (g_strcmp0(scheme, "ftp") == 0);
+	       (g_strcmp0(scheme, "ftp") == 0) ||
+	       (g_strcmp0(scheme, "ftps") == 0);
 }
 
 static gboolean take_bundle_ownership(int bundle_fd, GError **error)


### PR DESCRIPTION
* This PR adds support for FTPS
* It depends on https://github.com/systemd/casync/pull/266 to do the same for casync
* libcurl already supports FTPS in its default configuration
* We just need to allow the FTPS URL schema at RAUC

* Successfully tested casync updates via FTPS (unsing vsftpd as server)