### PR TITLE
test: meson.build: let tests depend on dbus_sources being generated

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -43,7 +43,7 @@ foreach test_name : tests
   exe = executable(
     test_name + '-test',
     test_name + '.c',
-    extra_test_sources,
+    extra_test_sources, dbus_sources,
     link_with : librauc,
     c_args : '-DTEST_SERVICES="' + meson.build_root() + '"',
     include_directories : incdir,


### PR DESCRIPTION
This is actually only required for building 'service.c' which includes the generated 'rauc-installer-generated.h' header. But since we generate all tests in a single loop that is only parametrized by the build name currently, we just add it as a dependency to all first of all.

Without this, the build order may decide to build test/service.c before having called gdbus-codegen which will result in the following error:

```
cc -Itest/service-test.p -Itest -I../../home/test -I../../home/include -I/usr/include/x86_64-linux-gnu -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/gio-unix-2.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu11 -O0 -g '-DGLIB_VERSION_MAX_ALLOWED=G_ENCODE_VERSION(2,52)' '-DGLIB_VERSION_MIN_REQUIRED=G_ENCODE_VERSION(2,50)' -Wundef -Wnested-externs -Wwrite-strings -Wpointer-arith -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wredundant-decls -Wno-unused-parameter -Wno-missing-field-initializers -Wdeclaration-after-statement -Wformat=2 -Wold-style-definition -Wcast-align -Wformat-nonliteral -Wformat-security -Wsign-compare -Wstrict-aliasing -Wshadow -Winline -Wpacked -Wmissing-format-attribute -Wmissing-noreturn -Winit-self -Wmissing-include-dirs -Wunused-but-set-variable -Warray-bounds -Wimplicit-function-declaration -Wreturn-type -Wswitch-enum -Wswitch-default -Wno-error=unused-parameter -Wno-error=missing-field-initializers -Wno-error=deprecated-declarations -fdata-sections -ffunction-sections -fno-strict-aliasing '-DG_LOG_DOMAIN="rauc"' -D_GNU_SOURCE -include /tmp/build/config.h -pthread '-DTEST_SERVICES="/tmp/build"' -MD -MQ test/service-test.p/service.c.o -MF test/service-test.p/service.c.o.d -o test/service-test.p/service.c.o -c ../../home/test/service.c | ../../home/test/service.c:14:10: fatal error: ../rauc-installer-generated.h: No such file or directory
   14 | #include "../rauc-installer-generated.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```
