### PR TITLE
Fix Typo

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -168,7 +168,7 @@ Example configuration:
   * central status file and shared data directory
     (``statusfile=/data/central.raucs`` and ``data-directory=/data/rauc``)
   * central status file in shared data directory
-    (``data-directory=/data/rauc``, implies ``statusfile=/data/rauc/central.rauc``)
+    (``data-directory=/data/rauc``, implies ``statusfile=/data/rauc/central.raucs``)
 
   .. important:: This directory must be located on a non-redundant filesystem
      which is not overwritten during updates.

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -619,7 +619,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	 * - central status file and shared data directory
 	 *   (``statusfile=/data/central.raucs`` and ``data-directory=/data/rauc``)
 	 * - central status file in shared data directory
-	 *   (``data-directory=/data/rauc``, implies ``statusfile=/data/rauc/central.rauc``)
+	 *   (``data-directory=/data/rauc``, implies ``statusfile=/data/rauc/central.raucs``)
 	 */
 	c->data_directory = resolve_path_take(filename,
 			key_file_consume_string(key_file, "system", "data-directory", &ierror));


### PR DESCRIPTION
Fix the documentation in accordance to the [code](https://github.com/rauc/rauc/blob/8e71d346be28/src/config_file.c#L636) currently found at the tip of the master branch.