### PR TITLE
Amend Description of Key ``statusfile``

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -137,19 +137,17 @@ Example configuration:
 .. _statusfile:
 
 ``statusfile``
-  For backwards compatibility, this can be set to point to a central file where
-  slot status information should be stored (e.g. slot-specific metadata, see
-  :ref:`slot-status`).
-  However, if a per-slot status is required as one of the above-noted
-  requirements cannot be met, one can use the value ``per-slot`` to document
-  this decision.
-  For backwards compatibility this option is not mandatory and will default to
-  per-slot status files if not set.
+
+  .. note:: This option is deprecated. Consider using ``data-directory``
+     instead.
+     For more details about backwards compatibility, see :ref:`data-directory
+     <data-directory>`.
+
+  Can be set to point to a central file where slot status information should be
+  stored (e.g. slot-specific metadata, see :ref:`slot-status`).
 
   .. important:: This file must be located on a non-redundant filesystem which
      is not overwritten during updates.
-
-  See ``data-directory`` below as well.
 
 .. _data-directory:
 


### PR DESCRIPTION
Commit dc6e2b2faaa6 introduced a more detailed description of RAUC's central statusfile that is cut down again in bb02c9edcf21 after the implementation of RAUC's shared data directory. However the description was cut down a little too much as the "above-noted requirements" cited later in the text were removed, as well - fix this.