### PR TITLE
src/install: un-break external mount point detection

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -132,7 +132,7 @@ gboolean determine_slot_states(GError **error)
 			 * To avoid leaking the string returned by g_unix_mount_get_mount_path() here, we skip all further matches
 			 */
 			if (s->ext_mount_point) {
-				break;
+				continue;
 			}
 			s->ext_mount_point = g_strdup(g_unix_mount_get_mount_path(m));
 			g_debug("Found external mountpoint for slot %s at %s", s->name, s->ext_mount_point);


### PR DESCRIPTION
The memory leakage 'fix' introduced in a6c17a402 ("src/install: avoid leaking string if multpile mount points match") erroneously uses 'break' where it should have used 'continue'.
As a result, external mount point detection aborts way too early in some cases and further external mount points will not be detected then.

This is also not ideal in terms of safety, since it could lead to unintentionally overriding a still-mounted partition which RAUC refuses normally.

This affects all RAUC releases since (including) v1.2.