### PR TITLE
Rework Parts of Slot State Determination

### DIFF
--- a/include/config_file.h
+++ b/include/config_file.h
@@ -82,6 +82,8 @@ typedef struct {
 	gchar *encryption_cert;
 
 	GHashTable *slots;
+	/* flag to ensure slot states were determined */
+	gboolean slot_states_determined;
 } RaucConfig;
 
 typedef enum {

--- a/include/install.h
+++ b/include/install.h
@@ -38,6 +38,16 @@ typedef struct {
 } RaucInstallArgs;
 
 /**
+ * Update the external mount points of a slot.
+ *
+ * @param error return location for a GError
+ *
+ * @return TRUE if succeeded, FALSE if failed
+ */
+gboolean update_external_mount_points(GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
  * Determines the states (ACTIVE | INACTIVE | BOOTED) of the slots specified in
  * system configuration.
  *

--- a/src/context.c
+++ b/src/context.c
@@ -5,6 +5,7 @@
 #include "config_file.h"
 #include "context.h"
 #include "network.h"
+#include "install.h"
 #include "signature.h"
 #include "utils.h"
 

--- a/src/context.c
+++ b/src/context.c
@@ -10,7 +10,7 @@
 
 RaucContext *context = NULL;
 
-static const gchar *regex_match(const gchar *pattern, const gchar *string)
+static gchar *regex_match(const gchar *pattern, const gchar *string)
 {
 	g_autoptr(GRegex) regex = NULL;
 	g_autoptr(GMatchInfo) match = NULL;
@@ -25,11 +25,11 @@ static const gchar *regex_match(const gchar *pattern, const gchar *string)
 	return NULL;
 }
 
-static const gchar* get_cmdline_bootname(void)
+static gchar* get_cmdline_bootname(void)
 {
 	g_autofree gchar *contents = NULL;
 	g_autofree gchar *realdev = NULL;
-	const char *bootname = NULL;
+	gchar *bootname = NULL;
 
 	if (context->mock.proc_cmdline)
 		contents = g_strdup(context->mock.proc_cmdline);
@@ -37,7 +37,7 @@ static const gchar* get_cmdline_bootname(void)
 		return NULL;
 
 	if (strstr(contents, "rauc.external") != NULL)
-		return "_external_";
+		return g_strdup("_external_");
 
 	bootname = regex_match("rauc\\.slot=(\\S+)", contents);
 	if (bootname)
@@ -294,7 +294,7 @@ static gboolean r_context_configure_target(GError **error)
 		g_warning("Ignoring surrounding whitespace in system variant: %s", context->config->system_variant);
 
 	if (context->bootslot == NULL) {
-		context->bootslot = g_strdup(get_cmdline_bootname());
+		context->bootslot = get_cmdline_bootname();
 	}
 
 	return TRUE;

--- a/src/install.c
+++ b/src/install.c
@@ -85,7 +85,7 @@ static gchar *resolve_loop_device(const gchar *devicepath, GError **error)
 	return g_strchomp(content);
 }
 
-static gboolean update_external_mount_points(GError **error)
+gboolean update_external_mount_points(GError **error)
 {
 	GList *mountlist = NULL;
 	GHashTableIter iter;

--- a/src/install.c
+++ b/src/install.c
@@ -128,6 +128,22 @@ gboolean update_external_mount_points(GError **error)
 	return TRUE;
 }
 
+/*
+ * Based on the 'bootslot' information (derived from /proc/cmdline during
+ * context setup), this determines 'booted', 'active' and 'inactive' states for
+ * each slot and stores this in the 'state' member of each slot.
+ *
+ * First, the booted slot is determined by comparing the 'bootslot' against the
+ * slot's 'bootname', 'name', or device path. Then, the other states are
+ * determined based on the slot hierarchies.
+ *
+ * If 'bootslot' is '/dev/nfs' or '_external_', all slots are considered
+ * 'inactive'.
+ *
+ * @param error Return location for a GError, or NULL
+ *
+ * @return TRUE if succeeded, FALSE if failed
+ */
 gboolean determine_slot_states(GError **error)
 {
 	g_autoptr(GList) slotlist = NULL;

--- a/src/install.c
+++ b/src/install.c
@@ -143,7 +143,7 @@ gboolean determine_slot_states(GError **error)
 				error,
 				R_SLOT_ERROR,
 				R_SLOT_ERROR_NO_BOOTSLOT,
-				"Bootname or device of booted slot not found");
+				"Could not find any root device or rauc slot information in /proc/cmdline");
 		return FALSE;
 	}
 

--- a/src/install.c
+++ b/src/install.c
@@ -144,11 +144,6 @@ gboolean determine_slot_states(GError **error)
 		return FALSE;
 	}
 
-
-	if (!update_external_mount_points(error)) {
-		return FALSE;
-	}
-
 	if (r_context()->bootslot == NULL) {
 		g_set_error_literal(
 				error,
@@ -1085,7 +1080,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	r_context_begin_step("do_install_bundle", "Installing", 10);
 
 	r_context_begin_step("determine_slot_states", "Determining slot states", 0);
-	res = determine_slot_states(&ierror);
+	res = update_external_mount_points(&ierror);
 	r_context_end_step("determine_slot_states", res);
 	if (!res) {
 		g_propagate_error(error, ierror);

--- a/src/install.c
+++ b/src/install.c
@@ -210,6 +210,8 @@ gboolean determine_slot_states(GError **error)
 				s->state = ST_INACTIVE;
 			}
 
+			r_context()->config->slot_states_determined = TRUE;
+
 			return TRUE;
 		}
 
@@ -235,6 +237,8 @@ gboolean determine_slot_states(GError **error)
 			s->state = ST_INACTIVE;
 		}
 	}
+
+	r_context()->config->slot_states_determined = TRUE;
 
 	return TRUE;
 }
@@ -1076,6 +1080,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 
 	g_assert_nonnull(bundlefile);
 	g_assert_null(r_context()->install_info->mounted_bundle);
+	g_assert_true(r_context()->config->slot_states_determined);
 
 	r_context_begin_step("do_install_bundle", "Installing", 10);
 

--- a/src/install.c
+++ b/src/install.c
@@ -87,12 +87,11 @@ static gchar *resolve_loop_device(const gchar *devicepath, GError **error)
 
 gboolean determine_slot_states(GError **error)
 {
-	GList *slotlist = NULL;
+	g_autoptr(GList) slotlist = NULL;
 	GList *mountlist = NULL;
 	RaucSlot *booted = NULL;
 	GHashTableIter iter;
 	RaucSlot *slot;
-	gboolean res = FALSE;
 	GError *ierror = NULL;
 
 	g_assert_nonnull(r_context()->config);
@@ -103,7 +102,7 @@ gboolean determine_slot_states(GError **error)
 				R_SLOT_ERROR,
 				R_SLOT_ERROR_NO_CONFIG,
 				"No slot configuration found");
-		goto out;
+		return FALSE;
 	}
 
 	/* Clear all previously detected external mount points as we will
@@ -122,7 +121,7 @@ gboolean determine_slot_states(GError **error)
 		devicepath = resolve_loop_device(g_unix_mount_get_device_path(m), &ierror);
 		if (!devicepath) {
 			g_propagate_error(error, ierror);
-			goto out;
+			return FALSE;
 		}
 		s = find_config_slot_by_device(r_context()->config,
 				devicepath);
@@ -145,7 +144,7 @@ gboolean determine_slot_states(GError **error)
 				R_SLOT_ERROR,
 				R_SLOT_ERROR_NO_BOOTSLOT,
 				"Bootname or device of booted slot not found");
-		goto out;
+		return FALSE;
 	}
 
 	slotlist = g_hash_table_get_keys(r_context()->config->slots);
@@ -200,8 +199,7 @@ gboolean determine_slot_states(GError **error)
 				s->state = ST_INACTIVE;
 			}
 
-			res = TRUE;
-			goto out;
+			return TRUE;
 		}
 
 		g_set_error(
@@ -209,7 +207,7 @@ gboolean determine_slot_states(GError **error)
 				R_SLOT_ERROR,
 				R_SLOT_ERROR_NO_SLOT_WITH_STATE_BOOTED,
 				"Did not find booted slot (matching '%s')", r_context()->bootslot);
-		goto out;
+		return FALSE;
 	}
 
 	/* Determine active group members */
@@ -227,12 +225,7 @@ gboolean determine_slot_states(GError **error)
 		}
 	}
 
-	res = TRUE;
-
-out:
-	g_clear_pointer(&slotlist, g_list_free);
-
-	return res;
+	return TRUE;
 }
 
 gboolean determine_boot_states(GError **error)

--- a/src/install.c
+++ b/src/install.c
@@ -105,7 +105,6 @@ gboolean determine_slot_states(GError **error)
 				"No slot configuration found");
 		goto out;
 	}
-	g_assert_nonnull(r_context()->config->slots);
 
 	/* Clear all previously detected external mount points as we will
 	 * re-deterrmine them. */

--- a/src/main.c
+++ b/src/main.c
@@ -299,6 +299,13 @@ static gboolean install_start(int argc, char **argv)
 			goto out_loop;
 		}
 	} else {
+		if (!determine_slot_states(&error)) {
+			g_printerr("Failed to determine slot states: %s\n", error->message);
+			g_clear_error(&error);
+			r_exit_status = 1;
+			return TRUE;
+		}
+
 		r_context_register_progress_callback(print_progress_callback);
 		install_run(args);
 	}
@@ -1988,7 +1995,15 @@ static gboolean status_start(int argc, char **argv)
 G_GNUC_UNUSED
 static gboolean service_start(int argc, char **argv)
 {
+	g_autoptr(GError) ierror = NULL;
+
 	g_debug("service start");
+
+	if (!determine_slot_states(&ierror)) {
+		g_printerr("Failed to determine slot states: %s\n", ierror->message);
+		r_exit_status = 1;
+		return TRUE;
+	}
 
 	r_exit_status = r_service_run() ? 0 : 1;
 

--- a/src/service.c
+++ b/src/service.c
@@ -243,19 +243,11 @@ static gboolean r_on_handle_mark(RInstaller *interface,
 {
 	g_autofree gchar *slot_name = NULL;
 	g_autofree gchar *message = NULL;
-	GError *ierror = NULL;
 	gboolean res;
 
 	res = !r_context_get_busy();
 	if (!res) {
 		message = g_strdup("already processing a different method");
-		goto out;
-	}
-
-	res = determine_slot_states(&ierror);
-	if (!res) {
-		message = g_strdup_printf("Failed to determine slot states: %s\n", ierror->message);
-		g_clear_error(&ierror);
 		goto out;
 	}
 
@@ -362,12 +354,12 @@ static GVariant* create_slotstatus_array(GError **error)
 
 	g_assert_nonnull(r_installer);
 
-	res = determine_slot_states(&ierror);
+	res = update_external_mount_points(&ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
 				ierror,
-				"Failed to determine slot states: ");
+				"Failed to update mount points: ");
 		return NULL;
 	}
 

--- a/test/context.c
+++ b/test/context.c
@@ -6,6 +6,30 @@
 
 #include "common.h"
 
+static void test_bootslot_rauc_slot(void)
+{
+	r_context_conf()->configpath = g_strdup("test/test.conf");
+	r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_REQUIRED;
+	r_context_conf()->mock.proc_cmdline = "quiet root=/dev/dummy rauc.slot=A rootwait";
+	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+
+	g_assert_cmpstr(r_context()->bootslot, ==, "A");
+
+	r_context_clean();
+}
+
+static void test_bootslot_root(void)
+{
+	r_context_conf()->configpath = g_strdup("test/test.conf");
+	r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_REQUIRED;
+	r_context_conf()->mock.proc_cmdline = "quiet root=/dev/dummy rootwait";
+	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+
+	g_assert_cmpstr(r_context()->bootslot, ==, "/dev/dummy");
+
+	r_context_clean();
+}
+
 static void test_bootslot_external_boot(void)
 {
 	r_context_conf()->configpath = g_strdup("test/test.conf");
@@ -30,15 +54,34 @@ static void test_bootslot_nfs_boot(void)
 	r_context_clean();
 }
 
+static void test_bootslot_no_bootslot(void)
+{
+	r_context_conf()->configpath = g_strdup("test/test.conf");
+	r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_REQUIRED;
+	r_context_conf()->mock.proc_cmdline = "quiet";
+	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+
+	g_assert_null(r_context()->bootslot);
+
+	r_context_clean();
+}
+
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
 
 	g_test_init(&argc, &argv, NULL);
 
+	g_test_add_func("/context/bootslot/rauc-slot", test_bootslot_rauc_slot);
+
+	g_test_add_func("/context/bootslot/root", test_bootslot_root);
+
 	g_test_add_func("/context/bootslot/external_boot", test_bootslot_external_boot);
 
 	g_test_add_func("/context/bootslot/nfs_boot", test_bootslot_nfs_boot);
+
+	g_test_add_func("/context/bootslot/no-bootslot", test_bootslot_no_bootslot);
 
 	return g_test_run();
 }

--- a/test/context.c
+++ b/test/context.c
@@ -6,7 +6,7 @@
 
 #include "common.h"
 
-static void external_boot(void)
+static void test_bootslot_external_boot(void)
 {
 	r_context_conf()->configpath = g_strdup("test/test.conf");
 	r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_REQUIRED;
@@ -15,11 +15,10 @@ static void external_boot(void)
 
 	g_assert_cmpstr(r_context()->bootslot, ==, "_external_");
 
-	r_context_conf()->mock.proc_cmdline = NULL;
-	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+	r_context_clean();
 }
 
-static void nfs_boot(void)
+static void test_bootslot_nfs_boot(void)
 {
 	r_context_conf()->configpath = g_strdup("test/test.conf");
 	r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_REQUIRED;
@@ -28,8 +27,7 @@ static void nfs_boot(void)
 
 	g_assert_cmpstr(r_context()->bootslot, ==, "/dev/nfs");
 
-	r_context_conf()->mock.proc_cmdline = NULL;
-	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+	r_context_clean();
 }
 
 int main(int argc, char *argv[])
@@ -38,9 +36,9 @@ int main(int argc, char *argv[])
 
 	g_test_init(&argc, &argv, NULL);
 
-	g_test_add_func("/context/external_boot", external_boot);
+	g_test_add_func("/context/bootslot/external_boot", test_bootslot_external_boot);
 
-	g_test_add_func("/context/nfs_boot", nfs_boot);
+	g_test_add_func("/context/bootslot/nfs_boot", test_bootslot_nfs_boot);
 
 	return g_test_run();
 }

--- a/test/install.c
+++ b/test/install.c
@@ -1084,6 +1084,10 @@ static void install_test_bundle(InstallFixture *fixture,
 	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
 	g_assert_nonnull(bundlepath);
 
+	res = determine_slot_states(&ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+
 	args = install_args_new();
 	args->name = g_steal_pointer(&bundlepath);
 	args->notify = install_notify;
@@ -1131,6 +1135,8 @@ static void install_test_bundle_thread(InstallFixture *fixture,
 	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
 	g_assert_nonnull(bundlepath);
 
+	g_assert_true(determine_slot_states(NULL));
+
 	args->name = g_steal_pointer(&bundlepath);
 	args->notify = install_notify;
 	args->cleanup = install_cleanup;
@@ -1161,6 +1167,8 @@ static void install_test_bundle_hook_install_check(InstallFixture *fixture,
 
 	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
 	g_assert_nonnull(bundlepath);
+
+	g_assert_true(determine_slot_states(NULL));
 
 	args = install_args_new();
 	args->name = g_steal_pointer(&bundlepath);
@@ -1196,6 +1204,10 @@ static void install_test_bundle_hook_install(InstallFixture *fixture,
 
 	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
 	g_assert_nonnull(bundlepath);
+
+	res = determine_slot_states(&ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 
 	args = install_args_new();
 	args->name = g_steal_pointer(&bundlepath);
@@ -1246,6 +1258,8 @@ static void install_test_bundle_hook_post_install(InstallFixture *fixture,
 
 	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
 	g_assert_nonnull(bundlepath);
+
+	g_assert_true(determine_slot_states(NULL));
 
 	args = install_args_new();
 	args->name = g_steal_pointer(&bundlepath);
@@ -1299,6 +1313,10 @@ static void install_test_already_mounted(InstallFixture *fixture,
 	hookfilepath = g_build_filename(fixture->tmpdir, "bootloader", "hook-install-mounted", NULL);
 	g_assert_nonnull(hookfilepath);
 	g_assert_false(g_file_test(hookfilepath, G_FILE_TEST_EXISTS));
+
+	res = determine_slot_states(&ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
 
 	args = install_args_new();
 	args->name = g_steal_pointer(&bundlepath);
@@ -1380,6 +1398,10 @@ device=images/rootfs-1\n\
 	g_free(slotfile);
 
 	res = determine_slot_states(&error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	res = update_external_mount_points(&error);
 	g_assert_no_error(error);
 	g_assert_true(res);
 

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -1297,6 +1297,7 @@ test_expect_success ROOT,!SERVICE "rauc install (no service)" "
   test ! -s ${SHARNESS_TEST_DIRECTORY}/images/rootfs-1 &&
   rauc \
     --conf=${SHARNESS_TEST_DIRECTORY}/minimal-test.conf \
+    --override-boot-slot=system0 \
     install ${TEST_TMPDIR}/good-bundle.raucb &&
   test -s ${SHARNESS_TEST_DIRECTORY}/images/rootfs-1
 "
@@ -1311,6 +1312,7 @@ test_expect_success ROOT,!SERVICE,STREAMING "rauc install (no service, streaming
   test ! -s ${SHARNESS_TEST_DIRECTORY}/images/rootfs-1 &&
   rauc \
     --conf=${SHARNESS_TEST_DIRECTORY}/minimal-test.conf \
+    --override-boot-slot=system0 \
     install http://127.0.0.1/test/good-verity-bundle.raucb &&
   test -s ${SHARNESS_TEST_DIRECTORY}/images/rootfs-1
 "
@@ -1325,6 +1327,7 @@ test_expect_success ROOT,!SERVICE,STREAMING "rauc install (no service, streaming
   test ! -s ${SHARNESS_TEST_DIRECTORY}/images/rootfs-1 &&
   test_must_fail rauc \
     --conf=${SHARNESS_TEST_DIRECTORY}/minimal-test.conf \
+    --override-boot-slot=system0 \
     install http://127.0.0.1/test/missing-bundle.raucb &&
   test ! -s ${SHARNESS_TEST_DIRECTORY}/images/rootfs-1
 "


### PR DESCRIPTION
This splits up slot state determination and external mount point detection and ensures slot state determination is called quite early in the service.

This removes unnecessary re-determination of static data and allows us to access slot state information earlier in the future.