### PR TITLE
src/service: do not configure context twice

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -614,16 +614,9 @@ static gboolean r_on_signal(gpointer user_data)
 
 gboolean r_service_run(void)
 {
-	GError *ierror = NULL;
 	gboolean service_return = TRUE;
 	GBusType bus_type = (!g_strcmp0(g_getenv("DBUS_STARTER_BUS_TYPE"), "session"))
 	                    ? G_BUS_TYPE_SESSION : G_BUS_TYPE_SYSTEM;
-
-	if (!r_context_configure(&ierror)) {
-		g_printerr("Failed to initialize context: %s\n", ierror->message);
-		g_clear_error(&ierror);
-		return FALSE;
-	}
 
 	service_loop = g_main_loop_new(NULL, FALSE);
 	g_unix_signal_add(SIGTERM, r_on_signal, NULL);


### PR DESCRIPTION
Just before invoking the `cmd_handler` in `main.c`, the context is configured. Thus we should not directly configure it again from within our command handler `r_service_run()`.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
