### PR TITLE
Refactor and Extend `system-info` Handler to Obtain Generic System Information

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -561,13 +561,43 @@ A valid RAUC manifest file must be named ``manifest.raucm``.
 
 **[handler] section**
 
+The ``handler`` section refers to the
+`full custom handler <https://rauc.readthedocs.io/en/latest/using.html#full-custom-update>`_
+that allows to fully replace the default RAUC update process.
+
+.. note:: This is not to be confused with the ``[handlers]`` section from the
+   system.conf which defines e.g. pre- and post-install handlers!
+
+When the full custom handler is enabled in a bundle, it will be invoked during
+the bundle installation
+
+* **after** bundle signature verification
+* **after** slot state and target slots determination logic
+* **after** the ``pre-install`` system handler
+* **before** the ``post-install`` system handler
+
+Also, the bundle will be mounted at this point and thus all its content is
+available to the full custom handler.
+Further system information is passed by RAUC via environment variables.
+No built-in slot update will run and no hook will be executed.
+
 ``filename``
-  Handler script path name, relative to the bundle content. Used to fully
-  replace default update process.
+  Full custom handler path, relative to the bundle content.
+  Having this set will activate the full custom handler and use the given
+  script/binary instead of the default handling.
 
 ``args``
-  Arguments to pass to the handler script, such as ``args=--verbose``
+  Arguments to pass to the full custom handler, such as
+  ``args=--setup --verbose``
 
+  .. note:: Until RAUC v1.9, these arguments were also implicitly passed
+     to handlers defined in the system.conf.
+     This behavior was fixed/removed in v1.10.
+     If someone uses this undocumented behavior and still requires this,
+     please file an `issue <https://github.com/rauc/rauc/issues/new/choose>`_.
+
+  If additional arguments are provided via ``--handler-args`` command line
+  argument, these will be appended to the ones defined in the manifest.
 
 .. _image.slot-class-section:
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -361,13 +361,19 @@ See details about using handlers in `Custom Handlers (Interface)`_.
   It is used for obtaining further information about the individual system RAUC
   runs on.
   The handler script must print the information to standard output in form of
-  key value pairs ``KEY=value``.
-  The following variables are supported:
+  key value pairs.
+  A valid generic key must start with ``RAUC_`` as prefix to be added to the
+  system information; e.g. ``RAUC_KEY=value``.
+
+  Some additional special keys that are supported, are:
 
   :``RAUC_SYSTEM_SERIAL``:
     Serial number of the individual board
   :``RAUC_SYSTEM_VARIANT``:
     Sets the RAUC system variant
+
+  System information is made available to other handlers via environment
+  variables that have the exact same name and value.
 
 ``pre-install``
   This handler will be called right before RAUC starts with the installation.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -390,11 +390,6 @@ See details about using handlers in `Custom Handlers (Interface)`_.
   if a custom bootloader backend is used.
   See :ref:`sec-custom-bootloader-backend` for more details.
 
-.. note::
-  When using a full custom installation
-  (see :ref:`[handler] section <sec-manifest-handler>`)
-  RAUC will not execute any system handler script.
-
 .. _slot.slot-class.idx-section:
 
 **[slot.<slot-class>.<idx>] section**

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -364,8 +364,10 @@ See details about using handlers in `Custom Handlers (Interface)`_.
   key value pairs ``KEY=value``.
   The following variables are supported:
 
-  ``RAUC_SYSTEM_SERIAL``
+  :``RAUC_SYSTEM_SERIAL``:
     Serial number of the individual board
+  :``RAUC_SYSTEM_VARIANT``:
+    Sets the RAUC system variant
 
 ``pre-install``
   This handler will be called right before RAUC starts with the installation.

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -276,8 +276,8 @@ The system-info handler is called after loading the configuration file. This
 way it can collect additional variables from the system, like the system's
 serial number.
 
-The handler script must return a system serial number by echoing
-`RAUC_SYSTEM_SERIAL=<value>` to standard out.
+The handler script can return variables by echoing ``<VARIABLE-NAME>=<value>``
+to stdout, like ``RAUC_SYSTEM_SERIAL`` or ``RAUC_SYSTEM_VARIANT``.
 
 .. _sec-hooks:
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -466,15 +466,27 @@ or, without ``filename``:
 Full Custom Update
 ~~~~~~~~~~~~~~~~~~
 
-For some special tasks (recovery, testing, migration) it might be required to
+For some special tasks (recovery, testing, migration), it might be required to
 completely replace the default RAUC update mechanism and to only use its
-infrastructure for executing an application or a script on the target side.
+infrastructure and the signature verification for executing an application or a
+script on the target side.
 
-For this case, you may replace the entire default installation handler of rauc
-by a custom handler script or application.
+For this case, RAUC allows to define a **full custom handler** in a bundle's
+manifest that will be executed instead of the built-in slot update handling:
+
+.. code-block:: cfg
+
+   [update]
+   compatible=Test Platform
+
+   [handler]
+   filename=custom-handler.sh
+
+The handler script/binary must be part of the bundle.
 
 Refer manifest :ref:`[handler] <sec-manifest-handler>` section description
-on how to achieve this.
+for details about how the full custom handler can be configured and gets
+called.
 
 
 Using the D-Bus API

--- a/include/context.h
+++ b/include/context.h
@@ -51,6 +51,7 @@ typedef struct {
 	gchar *bootslot;
 
 	gchar *system_serial;
+	GHashTable *system_info; /* key/values of system information */
 
 	/* optional custom handler extra arguments */
 	gchar *handlerextra;

--- a/include/utils.h
+++ b/include/utils.h
@@ -69,6 +69,20 @@ G_GNUC_WARN_UNUSED_RESULT;
 		__VA_ARGS__)
 
 /**
+ * Adds elements of a zero-terminated GStrv/gchar** to an existing GPtrArray
+ *
+ * @param ptrarray GPtrArray to add to
+ * @param argvp arguments to add
+ * @param copy whether to just add the pointer (FALSE) or copy the underlying data (TRUE)
+ */
+static inline void r_ptr_array_addv(GPtrArray *ptrarray, gchar **argvp, gboolean copy)
+{
+	for (gchar **addarg = argvp; *addarg != NULL; addarg++) {
+		g_ptr_array_add(ptrarray, copy ? g_strdup(*addarg) : *addarg);
+	}
+}
+
+/**
  * Read file content into a GBytes.
  *
  * @param filename Filename to read from

--- a/rauc.1
+++ b/rauc.1
@@ -265,7 +265,7 @@ show progress bar
 
 .TP
 \fB\-\-handler\-args=\fR\fIARGS\fR
-pass extra handler arguments
+extra arguments for full custom handler
 
 .TP
 \fB\-\-override\-boot\-slot=\fR\fIBOOTNAME\fR

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -134,9 +134,7 @@ static gboolean mksquashfs(const gchar *bundlename, const gchar *contentdir, GEr
 					"Failed to parse mksquashfs extra args: ");
 			goto out;
 		}
-		for (gchar **mksquashfs_args = mksquashfs_argvp; *mksquashfs_args != NULL; mksquashfs_args++) {
-			g_ptr_array_add(args, g_strdup(*mksquashfs_args));
-		}
+		r_ptr_array_addv(args, mksquashfs_argvp, TRUE);
 	}
 	g_ptr_array_add(args, NULL);
 
@@ -269,9 +267,7 @@ static gboolean casync_make_arch(const gchar *idxpath, const gchar *contentpath,
 					"Failed to parse casync extra args: ");
 			goto out;
 		}
-		for (gchar **casync_args = casync_argvp; *casync_args != NULL; casync_args++) {
-			g_ptr_array_add(iargs, g_strdup(*casync_args));
-		}
+		r_ptr_array_addv(iargs, casync_argvp, TRUE);
 	}
 	g_ptr_array_add(iargs, NULL);
 
@@ -376,9 +372,7 @@ static gboolean casync_make_blob(const gchar *idxpath, const gchar *contentpath,
 					"Failed to parse casync extra args: ");
 			goto out;
 		}
-		for (gchar **casync_args = casync_argvp; *casync_args != NULL; casync_args++) {
-			g_ptr_array_add(args, g_strdup(*casync_args));
-		}
+		r_ptr_array_addv(args, casync_argvp, TRUE);
 	}
 	g_ptr_array_add(args, NULL);
 

--- a/src/context.c
+++ b/src/context.c
@@ -110,6 +110,16 @@ static gchar* get_cmdline_bootname(void)
 	return bootname;
 }
 
+/**
+ * Launches a handler and obtains variables from output by looking for
+ * 'RAUC_<SOMETHING>=value' lines to put them into a key/value store (GHashTable).
+ *
+ * @param handler_name name / path of handler script to start
+ * @param[out] variables Return location for a GHashTable table with obtained key/value-pairs
+ * @param[out] error Return location for a GError, or NULL
+ *
+ * @return TRUE on success, otherwise FALSE
+ */
 static gboolean launch_and_wait_variables_handler(gchar *handler_name, GHashTable **variables, GError **error)
 {
 	g_autoptr(GSubprocessLauncher) handlelaunch = NULL;
@@ -151,6 +161,7 @@ static gboolean launch_and_wait_variables_handler(gchar *handler_name, GHashTabl
 			g_auto(GStrv) split = g_strsplit(outline, "=", 2);
 
 			if (g_strv_length(split) != 2) {
+				g_message("Failed to convert '%s' line to variable", outline);
 				g_free(outline);
 				continue;
 			}

--- a/src/install.c
+++ b/src/install.c
@@ -551,11 +551,23 @@ static gboolean verify_compatible(RaucInstallArgs *args, RaucManifest *manifest,
 
 static gchar **add_system_environment(gchar **envp)
 {
-	g_return_val_if_fail(envp && *envp == NULL, NULL);
+	GHashTableIter iter;
+	const gchar *key;
+	const gchar *value;
+
+	g_return_val_if_fail(envp, NULL);
 
 	envp = g_environ_setenv(envp, "RAUC_SYSTEM_CONFIG", r_context()->configpath, TRUE);
 	envp = g_environ_setenv(envp, "RAUC_CURRENT_BOOTNAME", r_context()->bootslot, TRUE);
 	envp = g_environ_setenv(envp, "RAUC_MOUNT_PREFIX", r_context()->config->mount_prefix, TRUE);
+
+	g_assert_nonnull(r_context()->system_info);
+	g_hash_table_iter_init(&iter, r_context()->system_info);
+	/* Allow defining new env variables based on system-info
+	 * handler, but do not override existing ones. */
+	while (g_hash_table_iter_next(&iter, (gpointer*) &key, (gpointer*) &value)) {
+		envp = g_environ_setenv(envp, key, value, FALSE);
+	}
 
 	return envp;
 }

--- a/src/install.c
+++ b/src/install.c
@@ -636,25 +636,34 @@ static void prepare_environment(GSubprocessLauncher *launcher, gchar *update_sou
 	g_subprocess_launcher_setenv(launcher, "RAUC_TARGET_SLOTS", target_slots->str, TRUE);
 }
 
-static gboolean launch_and_wait_handler(RaucInstallArgs *args, gchar *update_source, gchar *handler_name, RaucManifest *manifest, const gchar *handler_args, GHashTable *target_group, GError **error)
+static gboolean launch_and_wait_handler(RaucInstallArgs *args, gchar *update_source, gchar *handler_name, RaucManifest *manifest, gchar **handler_argv, GHashTable *target_group, GError **error)
 {
 	g_autoptr(GSubprocessLauncher) handlelaunch = NULL;
 	g_autoptr(GSubprocess) handleproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
+	g_autoptr(GPtrArray) args_array = NULL;
 	GInputStream *instream = NULL;
 	g_autoptr(GDataInputStream) datainstream = NULL;
 	gchar *outline;
+
+	g_return_val_if_fail(args, FALSE);
+	g_return_val_if_fail(handler_name, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	handlelaunch = g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE | G_SUBPROCESS_FLAGS_STDERR_MERGE);
 
 	prepare_environment(handlelaunch, update_source, manifest, target_group);
 
-	handleproc = g_subprocess_launcher_spawn(
-			handlelaunch, &ierror,
-			handler_name,
-			handler_args,
-			NULL);
+	args_array = g_ptr_array_new();
+	g_ptr_array_add(args_array, handler_name);
+	if (handler_argv) {
+		r_ptr_array_addv(args_array, handler_argv, FALSE);
+	}
+	g_ptr_array_add(args_array, NULL);
+
+	handleproc = g_subprocess_launcher_spawnv(
+			handlelaunch, (const gchar *const *) args_array->pdata, &ierror);
 	if (handleproc == NULL) {
 		g_propagate_error(error, ierror);
 		goto out;
@@ -769,7 +778,7 @@ static gboolean launch_and_wait_custom_handler(RaucInstallArgs *args, gchar* bun
 {
 	GError *ierror = NULL;
 	g_autofree gchar* handler_name = NULL;
-	g_autoptr(GString) handler_args = NULL;
+	g_autoptr(GPtrArray) handler_args = NULL;
 	gboolean res = FALSE;
 
 	r_context_begin_step_weighted("launch_and_wait_custom_handler", "Launching update handler", 0, 6);
@@ -789,14 +798,28 @@ static gboolean launch_and_wait_custom_handler(RaucInstallArgs *args, gchar* bun
 	}
 
 	handler_name = g_build_filename(bundledir, manifest->handler_name, NULL);
-	handler_args = g_string_new(manifest->handler_args);
-	if (r_context()->handlerextra) {
-		if (handler_args->len)
-			g_string_append_c(handler_args, ' ');
-		g_string_append(handler_args, r_context()->handlerextra);
+	handler_args = g_ptr_array_new_full(0, g_free);
+	if (manifest->handler_args) {
+		g_auto(GStrv) handler_argvp = NULL;
+		res = g_shell_parse_argv(manifest->handler_args, NULL, &handler_argvp, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+		r_ptr_array_addv(handler_args, handler_argvp, TRUE);
 	}
+	if (r_context()->handlerextra) {
+		g_auto(GStrv) extra_argvp = NULL;
+		res = g_shell_parse_argv(r_context()->handlerextra, NULL, &extra_argvp, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+		r_ptr_array_addv(handler_args, extra_argvp, TRUE);
+	}
+	g_ptr_array_add(handler_args, NULL);
 
-	res = launch_and_wait_handler(args, bundledir, handler_name, manifest, handler_args->str, target_group, error);
+	res = launch_and_wait_handler(args, bundledir, handler_name, manifest, (gchar**) handler_args->pdata, target_group, error);
 
 out:
 	r_context_end_step("launch_and_wait_custom_handler", res);

--- a/src/install.c
+++ b/src/install.c
@@ -549,6 +549,17 @@ static gboolean verify_compatible(RaucInstallArgs *args, RaucManifest *manifest,
 	}
 }
 
+static gchar **add_system_environment(gchar **envp)
+{
+	g_return_val_if_fail(envp && *envp == NULL, NULL);
+
+	envp = g_environ_setenv(envp, "RAUC_SYSTEM_CONFIG", r_context()->configpath, TRUE);
+	envp = g_environ_setenv(envp, "RAUC_CURRENT_BOOTNAME", r_context()->bootslot, TRUE);
+	envp = g_environ_setenv(envp, "RAUC_MOUNT_PREFIX", r_context()->config->mount_prefix, TRUE);
+
+	return envp;
+}
+
 static gchar **prepare_environment(gchar *update_source, RaucManifest *manifest, GHashTable *target_group)
 {
 	GHashTableIter iter;
@@ -559,10 +570,8 @@ static gchar **prepare_environment(gchar *update_source, RaucManifest *manifest,
 
 	/* get current process environment to use as base for appending */
 	gchar **envp = g_get_environ();
-	
-	envp = g_environ_setenv(envp, "RAUC_SYSTEM_CONFIG", r_context()->configpath, TRUE);
-	envp = g_environ_setenv(envp, "RAUC_CURRENT_BOOTNAME", r_context()->bootslot, TRUE);
-	envp = g_environ_setenv(envp, "RAUC_MOUNT_PREFIX", r_context()->config->mount_prefix, TRUE);
+
+	envp = add_system_environment(envp);
 	envp = g_environ_setenv(envp, "RAUC_BUNDLE_MOUNT_POINT", update_source, TRUE);
 	/* Deprecated, included for backwards compatibility: */
 	envp = g_environ_setenv(envp, "RAUC_UPDATE_SOURCE", update_source, TRUE);

--- a/src/install.c
+++ b/src/install.c
@@ -689,8 +689,8 @@ static gboolean launch_and_wait_handler(RaucInstallArgs *args, gchar *handler_na
 	}
 	g_ptr_array_add(args_array, NULL);
 
-	handleproc = g_subprocess_launcher_spawnv(
-			handlelaunch, (const gchar *const *) args_array->pdata, &ierror);
+	handleproc = r_subprocess_launcher_spawnv(
+			handlelaunch, args_array, &ierror);
 	if (handleproc == NULL) {
 		g_propagate_error(error, ierror);
 		goto out;

--- a/src/install.c
+++ b/src/install.c
@@ -572,6 +572,18 @@ static gchar **add_system_environment(gchar **envp)
 	return envp;
 }
 
+/**
+ * Sets up an environment containing RAUC information, ready to be passed to e.g. handlers
+ *
+ * Extends the system environment so that the result is save to be used with
+ * g_subprocess_launcher_set_environ().
+ *
+ * @param update_source Path to the current bundle mount point
+ * @param manifest Currently used manifest
+ * @param target_group Determined target group
+ *
+ * @return A newly allocated List of environment variables
+ */
 static gchar **prepare_environment(gchar *update_source, RaucManifest *manifest, GHashTable *target_group)
 {
 	GHashTableIter iter;
@@ -662,6 +674,21 @@ static gchar **prepare_environment(gchar *update_source, RaucManifest *manifest,
 	return envp;
 }
 
+/**
+ * Launches a handler using g_subprocess and waits for it to finish.
+ *
+ * Messages printed by the handler to stdout or stderr are parsed and can be
+ * used for generating high-level user output in RAUC.
+ * See parse_handler_output().
+ *
+ * @param args Install args, required for user output
+ * @param handler_name Path to the handler script/binary
+ * @param handler_argv Argument list passed to the handler call, or NULL
+ * @param override_env Environment to set for the handler call, or NULL
+ * @param[out] error Return location for a GError, or NULL
+ *
+ * @return TRUE on success, FALSE otherwise
+ */
 static gboolean launch_and_wait_handler(RaucInstallArgs *args, gchar *handler_name, gchar **handler_argv, gchar **override_env, GError **error)
 {
 	g_autoptr(GSubprocessLauncher) handlelaunch = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -2103,7 +2103,7 @@ static GOptionEntry entries_install[] = {
 #if ENABLE_SERVICE == 1
 	{"progress", '\0', 0, G_OPTION_ARG_NONE, &install_progressbar, "show progress bar", NULL},
 #else
-	{"handler-args", '\0', 0, G_OPTION_ARG_STRING, &handler_args, "extra handler arguments", "ARGS"},
+	{"handler-args", '\0', 0, G_OPTION_ARG_STRING, &handler_args, "extra arguments for full custom handler", "ARGS"},
 	{"override-boot-slot", '\0', 0, G_OPTION_ARG_STRING, &bootslot, "override auto-detection of booted slot", "BOOTNAME"},
 #endif
 	{0}
@@ -2167,7 +2167,7 @@ static GOptionEntry entries_status[] = {
 };
 
 static GOptionEntry entries_service[] = {
-	{"handler-args", '\0', 0, G_OPTION_ARG_STRING, &handler_args, "extra handler arguments", "ARGS"},
+	{"handler-args", '\0', 0, G_OPTION_ARG_STRING, &handler_args, "extra arguments for full custom handler", "ARGS"},
 	{"override-boot-slot", '\0', 0, G_OPTION_ARG_STRING, &bootslot, "override auto-detection of booted slot", "BOOTNAME"},
 	{0}
 };

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -224,6 +224,10 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 	/* parse [handler] section */
 	raucm->handler_name = key_file_consume_string(key_file, "handler", "filename", NULL);
 	raucm->handler_args = key_file_consume_string(key_file, "handler", "args", NULL);
+	if (raucm->handler_args && !raucm->handler_name) {
+		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
+				"Setting 'args' requires a full custom handler to be defined under 'filename' in group '[handler]'.");
+	}
 	if (!check_remaining_keys(key_file, "handler", &ierror)) {
 		g_propagate_error(error, ierror);
 		return FALSE;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -558,9 +558,7 @@ static gboolean casync_extract(RaucImage *image, gchar *dest, int out_fd, const 
 					"Failed to parse casync extra args: ");
 			goto out;
 		}
-		for (gchar **casync_args = casync_argvp; *casync_args != NULL; casync_args++) {
-			g_ptr_array_add(args, g_strdup(*casync_args));
-		}
+		r_ptr_array_addv(args, casync_argvp, TRUE);
 	}
 	g_ptr_array_add(args, g_strdup(image->filename));
 	g_ptr_array_add(args, g_strdup(out_fd >= 0 ? "-" : dest));

--- a/test/bin/systeminfo.sh
+++ b/test/bin/systeminfo.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
 echo RAUC_SYSTEM_SERIAL=1234
+echo RAUC_SYSTEM_VARIANT=test-variant-x
+echo RAUC_CUSTOM_VARIABLE=test-value
 echo RAUC_TEST_VAR

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -997,13 +997,6 @@ static void config_file_test_write_slot_status(void)
 	r_slot_free_status(ss);
 }
 
-static void config_file_system_serial(ConfigFileFixture *fixture,
-		gconstpointer user_data)
-{
-	g_assert_nonnull(r_context()->system_serial);
-	g_assert_cmpstr(r_context()->system_serial, ==, "1234");
-}
-
 static void config_file_test_global_slot_status(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1350,9 +1343,6 @@ int main(int argc, char *argv[])
 			config_file_fixture_tear_down);
 	g_test_add_func("/config-file/read-slot-status", config_file_test_read_slot_status);
 	g_test_add_func("/config-file/write-read-slot-status", config_file_test_write_slot_status);
-	g_test_add("/config-file/system-serial", ConfigFileFixture, NULL,
-			config_file_fixture_set_up, config_file_system_serial,
-			config_file_fixture_tear_down);
 	g_test_add("/config-file/statusfile-missing", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_statusfile_missing,
 			config_file_fixture_tear_down);

--- a/test/context.c
+++ b/test/context.c
@@ -67,6 +67,29 @@ static void test_bootslot_no_bootslot(void)
 }
 
 
+/* Tests that the infos provided by the configured system-info handler make it
+ * into RAUC's system information.
+ */
+static void test_context_system_info(void)
+{
+	r_context_conf()->configpath = g_strdup("test/test.conf");
+	r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_REQUIRED;
+	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+
+	/* Test if special keys are retrieved */
+	g_assert_cmpstr(r_context()->system_serial, ==, "1234");
+	g_assert_cmpstr(r_context()->config->system_variant, ==, "test-variant-x");
+
+	/* Test if configured keys appear in system_info hash table */
+	g_assert_nonnull(r_context()->system_info);
+	g_assert_true(g_hash_table_contains(r_context()->system_info, "RAUC_SYSTEM_SERIAL"));
+	g_assert_true(g_hash_table_contains(r_context()->system_info, "RAUC_SYSTEM_VARIANT"));
+	g_assert_true(g_hash_table_contains(r_context()->system_info, "RAUC_CUSTOM_VARIABLE"));
+	g_assert_false(g_hash_table_contains(r_context()->system_info, "RAUC_TEST_VAR"));
+
+	r_context_clean();
+}
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -82,6 +105,8 @@ int main(int argc, char *argv[])
 	g_test_add_func("/context/bootslot/nfs_boot", test_bootslot_nfs_boot);
 
 	g_test_add_func("/context/bootslot/no-bootslot", test_bootslot_no_bootslot);
+
+	g_test_add_func("/context/system-info", test_context_system_info);
 
 	return g_test_run();
 }

--- a/test/install.c
+++ b/test/install.c
@@ -71,6 +71,7 @@ compatible=Test Config\n\
 \n\
 [handler]\n\
 filename=custom_handler.sh\n\
+args=arg1 arg2\n\
 \n\
 [image.rootfs]\n\
 filename=rootfs.ext4\n\
@@ -1496,7 +1497,7 @@ int main(int argc, char *argv[])
 		install_data = memdup((&(InstallData) {
 			.message_needles = memdup((&(const gchar *[]) {
 				"Checking and mounting bundle...",
-				"Debug: --dummy1 --dummy2",
+				"Debug: arg1 arg2 --dummy1 --dummy2",
 				"Handler status: [STARTED]",
 				"Bootloader status: [DONE]",
 				"Handler status: [DONE]",

--- a/test/service.c
+++ b/test/service.c
@@ -222,7 +222,7 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 	compatible = r_installer_get_compatible(installer);
 	g_assert_cmpstr(compatible, ==, "Test Config");
 	variant = r_installer_get_variant(installer);
-	g_assert_cmpstr(variant, ==, "Default Variant");
+	g_assert_cmpstr(variant, ==, "test-variant-x");
 	bootslot = r_installer_get_boot_slot(installer);
 	g_assert_cmpstr(bootslot, ==, "system0");
 


### PR DESCRIPTION
This cleans up a bit of the handler code, fixes some issues and prepares for more.

The actual focus of this is to extend the already-existing `system-info` handler (that had no real purpose yet) with the capability to add and collect custom information. For now, these informations are made available in pre- and post-install handler env variables only, but there will be follow-up work to provide them via HTTP headers.

Preparation is related to #1114 