### PR TITLE
Allow to skip bundle verification

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,16 @@ AS_IF([test "x$enable_create" != "xno"], [
         AC_DEFINE([ENABLE_CREATE], [0])
 ])
 
+AC_ARG_ENABLE([no-verify],
+        AS_HELP_STRING([--enable-no-verify], [Allow to skip bundle verification during installation]),
+	[], [enable_no_verify=no]
+)
+AS_IF([test "x$enable_no_verify" != "xno"], [
+        AC_DEFINE([ALLOW_NO_VERIFY], [1], [Define to 1 to allow skipping bundle verification during installation])
+], [
+        AC_DEFINE([ALLOW_NO_VERIFY], [0])
+])
+
 # Checks for libraries.
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.50 gio-2.0 gio-unix-2.0])
 # Sanity checks to not use new glib methods unintentionally.
@@ -285,4 +295,5 @@ AC_MSG_RESULT([
 
         network:                ${enable_network}
         streaming:              ${enable_streaming}
+        no-verify:              ${enable_no_verify}
 ])

--- a/include/install.h
+++ b/include/install.h
@@ -34,6 +34,7 @@ typedef struct {
 	gint status_result;
 	/* install options */
 	gboolean ignore_compatible;
+	gboolean no_verify;
 	RaucBundleAccessArgs access_args;
 } RaucInstallArgs;
 

--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,7 @@ systemddep = dependency('systemd', required : false)
 conf.set10('ENABLE_SERVICE', get_option('service'))
 conf.set10('ENABLE_CREATE', get_option('create'))
 conf.set10('ENABLE_JSON', jsonglibdep.found())
+conf.set10('ALLOW_NO_VERIFY', get_option('allow-no-verify'))
 
 c_warn_flags = '''
   -Wundef

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -29,6 +29,11 @@ option(
   type : 'feature',
   value : 'auto',
   description : 'Enable/Disable GPT support')
+option(
+  'allow-no-verify',
+  type : 'boolean',
+  value : 'false',
+  description : 'Allow to skip bundle verification during installation')
 
 # other options
 option(

--- a/src/install.c
+++ b/src/install.c
@@ -1088,6 +1088,7 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	gboolean res = FALSE;
 	g_autoptr(RaucBundle) bundle = NULL;
 	GHashTable *target_group;
+	CheckBundleParams params = CHECK_BUNDLE_DEFAULT;
 
 	g_assert_nonnull(bundlefile);
 	g_assert_null(r_context()->install_info->mounted_bundle);
@@ -1103,10 +1104,13 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 		goto out;
 	}
 
+	if (args->no_verify)
+		params |= CHECK_BUNDLE_NO_VERIFY;
+
 	// TODO: mount info in context ?
 	install_args_update(args, "Checking and mounting bundle...");
 
-	res = check_bundle(bundlefile, &bundle, CHECK_BUNDLE_DEFAULT, &args->access_args, &ierror);
+	res = check_bundle(bundlefile, &bundle, params, &args->access_args, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;

--- a/src/main.c
+++ b/src/main.c
@@ -261,7 +261,8 @@ static gboolean install_start(int argc, char **argv)
 		g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
 
 		g_variant_dict_insert(&dict, "ignore-compatible", "b", args->ignore_compatible);
-		g_variant_dict_insert(&dict, "no_verify", "b", args->no_verify);
+		if (ALLOW_NO_VERIFY)
+			g_variant_dict_insert(&dict, "no_verify", "b", args->no_verify);
 		if (args->access_args.tls_cert)
 			g_variant_dict_insert(&dict, "tls-cert", "s", args->access_args.tls_cert);
 		if (args->access_args.tls_key)
@@ -2103,7 +2104,9 @@ typedef struct {
 } RaucCommand;
 
 static GOptionEntry entries_install[] = {
+#if ALLOW_NO_VERIFY
 	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
+#endif
 	{"ignore-compatible", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_compatible, "disable compatible check", NULL},
 #if ENABLE_SERVICE == 1
 	{"progress", '\0', 0, G_OPTION_ARG_NONE, &install_progressbar, "show progress bar", NULL},

--- a/src/main.c
+++ b/src/main.c
@@ -253,11 +253,15 @@ static gboolean install_start(int argc, char **argv)
 	if (access_args.http_headers)
 		args->access_args.http_headers = g_strdupv(access_args.http_headers);
 
+	if (verification_disabled)
+		args->no_verify = TRUE;
+
 	r_loop = g_main_loop_new(NULL, FALSE);
 	if (ENABLE_SERVICE) {
 		g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
 
 		g_variant_dict_insert(&dict, "ignore-compatible", "b", args->ignore_compatible);
+		g_variant_dict_insert(&dict, "no_verify", "b", args->no_verify);
 		if (args->access_args.tls_cert)
 			g_variant_dict_insert(&dict, "tls-cert", "s", args->access_args.tls_cert);
 		if (args->access_args.tls_key)
@@ -2099,6 +2103,7 @@ typedef struct {
 } RaucCommand;
 
 static GOptionEntry entries_install[] = {
+	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
 	{"ignore-compatible", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_compatible, "disable compatible check", NULL},
 #if ENABLE_SERVICE == 1
 	{"progress", '\0', 0, G_OPTION_ARG_NONE, &install_progressbar, "show progress bar", NULL},

--- a/src/service.c
+++ b/src/service.c
@@ -102,7 +102,8 @@ static gboolean r_on_handle_install_bundle(
 	if (g_variant_dict_lookup(&dict, "ignore-compatible", "b", &args->ignore_compatible))
 		g_variant_dict_remove(&dict, "ignore-compatible");
 
-	if (g_variant_dict_lookup(&dict, "no_verify", "b", &args->no_verify))
+	if (!ALLOW_NO_VERIFY ||
+	    g_variant_dict_lookup(&dict, "no_verify", "b", &args->no_verify))
 		g_variant_dict_remove(&dict, "no_verify");
 
 	convert_dict_to_bundle_access_args(&dict, &args->access_args);

--- a/src/service.c
+++ b/src/service.c
@@ -102,6 +102,9 @@ static gboolean r_on_handle_install_bundle(
 	if (g_variant_dict_lookup(&dict, "ignore-compatible", "b", &args->ignore_compatible))
 		g_variant_dict_remove(&dict, "ignore-compatible");
 
+	if (g_variant_dict_lookup(&dict, "no_verify", "b", &args->no_verify))
+		g_variant_dict_remove(&dict, "no_verify");
+
 	convert_dict_to_bundle_access_args(&dict, &args->access_args);
 
 	/* Check for unhandled keys */


### PR DESCRIPTION
<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

During development, bundles are often signed by self signed certificates which change e.g. with every run of the CI.

To test such bundles on existing systems, it is required to add the used certificate to /etc/rauc/ca.cert.pem.  This is cumbersome because /etc might be read-only or the used certificate might not be available.

Patch adds a '--no-verify' option to 'install' which allows to skip bundle verification.

Support for this option is disabled by default to reduce the impact of other configuration problems.

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
