### PR TITLE
update glib version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,12 +59,12 @@ AS_IF([test "x$enable_create" != "xno"], [
 ])
 
 # Checks for libraries.
-PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.50 gio-2.0 gio-unix-2.0])
+PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.54 gio-2.0 gio-unix-2.0])
 # Sanity checks to not use new glib methods unintentionally.
 # package check, minimum and maximum required version must be updated
 # explicitly when using newer glib APIs
-AC_DEFINE(GLIB_VERSION_MAX_ALLOWED, G_ENCODE_VERSION(2,52), [Prevent post-2.52 APIs])
-AC_DEFINE(GLIB_VERSION_MIN_REQUIRED, G_ENCODE_VERSION(2,50), [Set to minimum supported API version])
+AC_DEFINE(GLIB_VERSION_MAX_ALLOWED, G_ENCODE_VERSION(2,54), [Prevent post-2.54 APIs])
+AC_DEFINE(GLIB_VERSION_MIN_REQUIRED, G_ENCODE_VERSION(2,54), [Set to minimum supported API version])
 
 AC_ARG_ENABLE([network],
         AS_HELP_STRING([--disable-network], [Disable network update mode])

--- a/meson.build
+++ b/meson.build
@@ -25,14 +25,14 @@ conf.set('bindir', bindir)
 libexecdir = join_paths(prefixdir, get_option('libexecdir'))
 conf.set('libexecdir', libexecdir)
 
-glibdep = dependency('glib-2.0', version : '>=2.50')
+glibdep = dependency('glib-2.0', version : '>=2.54')
 
 # Sanity checks to not use new glib methods unintentionally.
 # package check, minimum and maximum required version must be updated
 # explicitly when using newer glib APIs
 c_flags = [
-  '-DGLIB_VERSION_MAX_ALLOWED=G_ENCODE_VERSION(2,52)',
-  '-DGLIB_VERSION_MIN_REQUIRED=G_ENCODE_VERSION(2,50)'
+  '-DGLIB_VERSION_MAX_ALLOWED=G_ENCODE_VERSION(2,54)',
+  '-DGLIB_VERSION_MIN_REQUIRED=G_ENCODE_VERSION(2,54)'
 ]
 
 giodep = dependency('gio-2.0', version : '>=2.26.0')

--- a/meson.build
+++ b/meson.build
@@ -35,8 +35,8 @@ c_flags = [
   '-DGLIB_VERSION_MIN_REQUIRED=G_ENCODE_VERSION(2,54)'
 ]
 
-giodep = dependency('gio-2.0', version : '>=2.26.0')
-giounixdep = dependency('gio-unix-2.0', version : '>=2.26.0')
+giodep = dependency('gio-2.0', version : '>=2.54')
+giounixdep = dependency('gio-unix-2.0', version : '>=2.54')
 openssldep = dependency('openssl', version : '>=1.1.1')
 jsonglibdep = dependency('json-glib-1.0', required : get_option('json'))
 dbusdep = dependency('dbus-1', required : get_option('service'))


### PR DESCRIPTION
This allows us to use g_ptr_array_find().

Versions newer that 2.54.0 are used by the oldest releases of mayor
distributions still in long term support.
- Debian buster: 2.58.3
- Ubuntu bionic: 2.56.1
- Yocto dunfell 2.62.2