### PR TITLE
src/bundle: ensure that the output directory does not exist before extracting

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2425,6 +2425,12 @@ gboolean extract_bundle(RaucBundle *bundle, const gchar *outputdir, GError **err
 
 	r_context_begin_step("extract_bundle", "Extracting bundle", 2);
 
+	if (g_file_test(outputdir, G_FILE_TEST_EXISTS)) {
+		res = FALSE;
+		g_set_error(error, G_FILE_ERROR, G_FILE_ERROR_EXIST, "output directory %s exists already", outputdir);
+		goto out;
+	}
+
 	res = check_bundle_payload(bundle, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);


### PR DESCRIPTION
Otherwise, unsquashfs will just fail with a possibly confusing error message.

Fixes: #1028