### PR TITLE
recommend verity bundles by default

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -676,9 +676,13 @@ Bundle Formats
 
 RAUC currently supports three bundle formats (``plain``,  ``verity`` and
 ``crypt``) and additional formats could be added if required.
+When starting a new project, the ``verity`` or ``crypt`` formats should be used.
+
 Version 1.4 (released on 2020-06-20) and earlier only supported a single format
-which is now named ``plain``, which should be used as long as compatibility to
-those versions is required.
+now named ``plain``, which should only be used as long as compatibility with
+older versions is required.
+For information on how to migrate to the recommended ``verity`` format, see
+:ref:`sec_int_migration`).
 
 The ``verity`` format was added to support new use cases like network
 streaming, for better parallelization of installation with hash verification
@@ -688,8 +692,16 @@ The ``crypt`` format is an extension to the ``verity`` format that allows full
 encryption of the bundle.
 
 The bundle format is detected when reading a bundle and checked against the set
-of allowed formats configured in the ``system.conf`` (see :ref:`bundle-formats
-<bundle-formats>`).
+of allowed formats configured in the ``system.conf`` (using the :ref:`bundle-formats
+<bundle-formats>` option).
+
+.. note::
+  When creating a bundle without an explicitly configured format, RAUC will warn
+  about defaulting to ``plain`` and recommend to use ``verity`` instead.
+  The warning can be silenced by explicitly configuring ``plain``, but note that
+  this will produce bundles incompatible to 1.4 and earlier due to the added
+  ``[bundle]`` section.
+  In that case, we **strongly recommend** updating these systems.
 
 .. _sec_ref_format_plain:
 

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -67,6 +67,9 @@ typedef struct {
 	gboolean was_encrypted;
 	/* computed manifest hash */
 	gchar *hash;
+
+	/* warnings generated during parsing */
+	GPtrArray *warnings;
 } RaucManifest;
 
 /**

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -50,6 +50,9 @@ typedef struct {
 	gchar *bundle_verity_hash;
 	guint64 bundle_verity_size;
 
+	/* remember if the bundle format was specified explicitly */
+	gboolean bundle_format_explicit;
+
 	gchar *bundle_crypt_key;
 
 	gchar *handler_name;

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -875,6 +875,11 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 		goto out;
 	}
 
+	/* print warnings collected while parsing */
+	for (guint i =  0; i < manifest->warnings->len; i++) {
+		g_print("%s\n", (gchar *)g_ptr_array_index(manifest->warnings, i));
+	}
+
 	res = sync_manifest_with_contentdir(manifest, contentdir, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -208,6 +208,8 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 				"  To silence this warning, select the 'plain' format explicitly."));
 		g_ptr_array_add(raucm->warnings, g_strdup(
 				"  See https://rauc.readthedocs.io/en/latest/reference.html#sec-ref-formats for details.'"));
+	} else {
+		raucm->bundle_format_explicit = TRUE;
 	}
 	if (tmp == NULL || g_strcmp0(tmp, "plain") == 0) {
 		raucm->bundle_format = R_MANIFEST_FORMAT_PLAIN;
@@ -611,6 +613,8 @@ static GKeyFile *prepare_manifest(const RaucManifest *mf)
 
 	switch (mf->bundle_format) {
 		case R_MANIFEST_FORMAT_PLAIN:
+			if (mf->bundle_format_explicit)
+				g_key_file_set_string(key_file, "bundle", "format", "plain");
 			break;
 		case R_MANIFEST_FORMAT_CRYPT: {
 			if (mf->bundle_crypt_key)

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -179,6 +179,9 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 	g_return_val_if_fail(manifest != NULL && *manifest == NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
+	/* initialize empty warnings array */
+	raucm->warnings = g_ptr_array_new_with_free_func(g_free);
+
 	/* parse [update] section */
 	raucm->update_compatible = key_file_consume_string(key_file, "update", "compatible", &ierror);
 	if (!raucm->update_compatible) {
@@ -887,6 +890,7 @@ void free_manifest(RaucManifest *manifest)
 	g_list_free_full(manifest->images, r_free_image);
 	g_clear_pointer(&manifest->meta, (GDestroyNotify)g_hash_table_destroy);
 	g_free(manifest->hash);
+	g_clear_pointer(&manifest->warnings, (GDestroyNotify)g_ptr_array_unref);
 	g_free(manifest);
 }
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -199,6 +199,16 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 
 	/* parse [bundle] section */
 	tmp = key_file_consume_string(key_file, "bundle", "format", NULL);
+	if (tmp == NULL) {
+		g_ptr_array_add(raucm->warnings, g_strdup(
+				"WARNING: The manifest does not specify a bundle format, defaulting to 'plain'."));
+		g_ptr_array_add(raucm->warnings, g_strdup(
+				"  We recommend using the 'verity' format instead, if possible."));
+		g_ptr_array_add(raucm->warnings, g_strdup(
+				"  To silence this warning, select the 'plain' format explicitly."));
+		g_ptr_array_add(raucm->warnings, g_strdup(
+				"  See https://rauc.readthedocs.io/en/latest/reference.html#sec-ref-formats for details.'"));
+	}
 	if (tmp == NULL || g_strcmp0(tmp, "plain") == 0) {
 		raucm->bundle_format = R_MANIFEST_FORMAT_PLAIN;
 	} else if ((g_strcmp0(tmp, "verity") == 0) || (g_strcmp0(tmp, "crypt") == 0)) {


### PR DESCRIPTION
There is no reason to start new projects with plain format bundles, so
recommend against it in the docs and when creating new bundles.
Also point to the migration section for existing projects.