### PR TITLE
fix some leaks and add a address-sanitizer workflow

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,51 @@
+name: sanitizers
+
+on: [push, pull_request]
+
+jobs:
+  address:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Inspect environment
+      run: |
+        whoami
+        gcc --version
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        DEBIAN_FRONTEND='noninteractive' sudo apt-get install -qy meson libtool libglib2.0-dev libcurl3-dev libssl-dev libdbus-1-dev libjson-glib-dev libfdisk-dev libnl-genl-3-dev dbus-x11 clang-tools
+
+    - uses: actions/checkout@v3
+
+    - name: Run meson
+      run: |
+        meson setup build -Db_sanitize=address
+        meson compile -C build
+
+    - name: Run selected tests
+      run: |
+        # Configure glib to be compatible with address sanitizer (see
+        # https://developer-old.gnome.org/glib/unstable/glib-running.html).
+        export G_SLICE=always-malloc G_DEBUG=gc-friendly
+        export ASAN_OPTIONS=malloc_context_size=64:fast_unwind_on_malloc=0
+        build/test/bootchooser-test || true
+        build/test/boot_raw_fallback-test
+        build/test/boot_switch-test || true
+        build/test/bundle-test || true
+        build/test/checksum-test
+        build/test/config_file-test || true
+        build/test/context-test || true
+        build/test/dm-test
+        build/test/hash_index-test
+        build/test/install-test || true
+        build/test/manifest-test
+        build/test/nbd-test || true
+        build/test/network-test
+        build/test/progress-test
+        build/test/service-test || true
+        build/test/signature-test || true
+        build/test/slot-test
+        build/test/stats-test
+        build/test/update_handler-test || true
+        build/test/utils-test

--- a/src/context.c
+++ b/src/context.c
@@ -467,12 +467,11 @@ static void r_context_send_progress(gboolean op_finished, gboolean success)
 
 	/* call installer callback with percentage and message */
 	if (op_finished) {
+		g_autofree gchar *old = step->description;
 		if (success)
-			step->description = g_strdup_printf("%s done.",
-					step->description);
+			step->description = g_strdup_printf("%s done.", old);
 		else
-			step->description = g_strdup_printf("%s failed.",
-					step->description);
+			step->description = g_strdup_printf("%s failed.", old);
 	}
 
 	/* handle missing callback gracefully */

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -121,6 +121,8 @@ static void bundle_fixture_tear_down(BundleFixture *fixture,
 {
 	g_assert_true(rm_tree(fixture->tmpdir, NULL));
 	g_free(fixture->tmpdir);
+	g_free(fixture->bundlename);
+	g_free(fixture->contentdir);
 
 	g_test_assert_expected_messages();
 }

--- a/test/checksum.c
+++ b/test/checksum.c
@@ -18,6 +18,7 @@ static void checksum_test1(void)
 	g_clear_error(&error);
 
 	checksum.type = G_CHECKSUM_SHA256;
+	g_free(checksum.digest);
 	checksum.digest = g_strdup(TEST_DIGEST_FAIL);
 	g_assert_false(verify_checksum(&checksum, "test/install-content/appfs.img", &error));
 	g_assert_error(error, R_CHECKSUM_ERROR, R_CHECKSUM_ERROR_SIZE_MISMATCH);
@@ -29,6 +30,7 @@ static void checksum_test1(void)
 	g_clear_error(&error);
 
 	checksum.size = 0;
+	g_free(checksum.digest);
 	checksum.digest = g_strdup(TEST_DIGEST_GOOD);
 	g_assert_false(verify_checksum(&checksum, "test/install-content/appfs.img", &error));
 	g_assert_error(error, R_CHECKSUM_ERROR, R_CHECKSUM_ERROR_SIZE_MISMATCH);

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -224,7 +224,7 @@ static void test_save_load_manifest(void)
  */
 static void test_save_manifest_writefail(void)
 {
-	GError *error = NULL;
+	g_autoptr(GError) error = NULL;
 	gboolean res;
 	g_autoptr(RaucManifest) rm = g_new0(RaucManifest, 1);
 
@@ -242,7 +242,7 @@ static void test_save_manifest_writefail(void)
  */
 static void test_load_manifest_mem(void)
 {
-	GBytes *data = NULL;
+	g_autoptr(GBytes) data = NULL;
 	RaucManifest *rm = NULL;
 
 	data = read_file("test/manifest.raucm", NULL);

--- a/test/network.c
+++ b/test/network.c
@@ -29,7 +29,7 @@ static void network_fixture_tear_down(NetworkFixture *fixture,
 static void test_download_file(NetworkFixture *fixture,
 		gconstpointer user_data)
 {
-	const gchar *target;
+	g_autofree const gchar *target = NULL;
 	GError *ierror = NULL;
 	gboolean res;
 

--- a/test/slot.c
+++ b/test/slot.c
@@ -111,7 +111,7 @@ static void test_slot_get_root_classes(void)
 	RaucSlot *somefs_0 = NULL;
 	RaucSlot *somefs_1 = NULL;
 	RaucSlot *boot_0 = NULL;
-	gchar** root_classes = NULL;
+	g_autofree gchar** root_classes = NULL;
 
 	slots = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, r_slot_free);
 


### PR DESCRIPTION
For now, there are still several tests for which address sanitizer reports leaks, but we can still check for regressions in the others.