### PR TITLE
.github/workflows: update to actions/checkout@v3

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - id: build-image
       uses: redhat-actions/buildah-build@v2
       with:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ jobs:
       image: ghcr.io/rauc/rauc/rauc-ci:latest
       options: --user=root
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: |
         PLATFORM=`uname`
         export TOOL_BASE="/tmp/coverity-scan-analysis"

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -16,7 +16,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install automake libtool libglib2.0-dev libcurl3-dev libssl-dev libdbus-1-dev libjson-glib-dev libfdisk-dev libnl-genl-3-dev dbus-x11 faketime casync
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Run autogen.sh
       run: |

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -20,7 +20,7 @@ jobs:
         gcc --version
         ls -la /usr/bin/clang*
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Run meson
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         apt-get update
         DEBIAN_FRONTEND='noninteractive' apt-get install -qy meson
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Test with service and gpt
       run: |
@@ -80,7 +80,7 @@ jobs:
         - armel
         - i386
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Prepare ${{ matrix.architecture }} container
       run: |
@@ -120,7 +120,7 @@ jobs:
           - release: "ubuntu:18.04"
             builder: "meson"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Prepare ${{ matrix.release }} container for ${{ matrix.builder }} build
       run: |
@@ -168,7 +168,7 @@ jobs:
   uncrustify:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install codespell
       run: |


### PR DESCRIPTION
Node 12 based workflows are deprecated, so update to the current version.