### PR TITLE
.github: workflows: tests: test building against older debian releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,12 +112,16 @@ jobs:
         - "ubuntu:18.04"
         - "ubuntu:20.04"
         - "ubuntu:22.04"
+        - "debian:buster"
+        - "debian:bullseye"
         - "debian:testing"
         builder:
         - "meson"
         - "automake"
         exclude:
           - release: "ubuntu:18.04"
+            builder: "meson"
+          - release: "debian:buster"
             builder: "meson"
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Note that standard meson under debian buster is too old:

> meson.build:1:0: ERROR:  Meson version is 0.49.2 but project requires >=0.51.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
