### PR TITLE
src/main: add missing --key argument for 'rauc info'

### DIFF
--- a/rauc.1
+++ b/rauc.1
@@ -164,6 +164,10 @@ Extract the bundle content to a directory.
 .RS 4
 
 .TP
+\fB\-\-key=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+use given decryption key file or the decryption key referenced by the given PKCS#11 URL
+
+.TP
 \fB\-\-trust\-environment\fR
 trust environment and skip bundle access checks
 
@@ -178,6 +182,10 @@ Extract the bundle signature.
 \fBOptions:\fR
 
 .RS 4
+
+.TP
+\fB\-\-key=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+use given decryption key file or the decryption key referenced by the given PKCS#11 URL
 
 .TP
 \fB\-\-trust\-environment\fR
@@ -290,6 +298,10 @@ disable bundle verification
 .TP
 \fB\-\-no\-check\-time\fR
 don't check validity period of certificates against current time
+
+.TP
+\fB\-\-key=\fR\fIPEMFILE\fR|\fIPKCS11-URL\fR
+use given decryption key file or the decryption key referenced by the given PKCS#11 URL
 
 .TP
 \fB\-\-output\-format=\fR[\fBreadable\fR|\fBshell\fR|\fBjson\fR|\fBjson-pretty\fR|\fBjson-2\fR]

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2018,7 +2018,7 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleP
 		g_debug("CMS type is 'enveloped'. Attempting to decrypt..");
 
 		if (r_context()->config->encryption_key == NULL) {
-			g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE, "Encrypted bundle detected, but no decryption key given");
+			g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE, "Encrypted bundle detected, but no decryption key given. Use --key=<PEMFILE|PKCS11-URL> to provide one.");
 			res = FALSE;
 			goto out;
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -220,7 +220,7 @@ static gboolean install_start(int argc, char **argv)
 	r_exit_status = 1;
 
 	if (argc < 3) {
-		g_printerr("A bundle filename name must be provided\n");
+		g_printerr("A bundle path or URL must be provided\n");
 		goto out;
 	}
 
@@ -1195,7 +1195,7 @@ static gboolean info_start(int argc, char **argv)
 	CheckBundleParams check_bundle_params = CHECK_BUNDLE_DEFAULT;
 
 	if (argc < 3) {
-		g_printerr("A file name must be provided\n");
+		g_printerr("A bundle path or URL must be provided\n");
 		r_exit_status = 1;
 		return FALSE;
 	}
@@ -2018,7 +2018,7 @@ static gboolean mount_start(int argc, char **argv)
 	gboolean res = FALSE;
 
 	if (argc < 3) {
-		g_printerr("A file name must be provided\n");
+		g_printerr("A bundle path or URL must be provided\n");
 		goto out;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -2139,11 +2139,13 @@ static GOptionEntry entries_convert[] = {
 };
 
 static GOptionEntry entries_extract_signature[] = {
+	{"key", '\0', G_OPTION_FLAG_NOALIAS, G_OPTION_ARG_FILENAME, &keypath, "decryption key file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 	{"trust-environment", '\0', 0, G_OPTION_ARG_NONE, &trust_environment, "trust environment and skip bundle access checks", NULL},
 	{0}
 };
 
 static GOptionEntry entries_extract[] = {
+	{"key", '\0', G_OPTION_FLAG_NOALIAS, G_OPTION_ARG_FILENAME, &keypath, "decryption key file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 	{"trust-environment", '\0', 0, G_OPTION_ARG_NONE, &trust_environment, "trust environment and skip bundle access checks", NULL},
 	{0}
 };
@@ -2151,6 +2153,7 @@ static GOptionEntry entries_extract[] = {
 static GOptionEntry entries_info[] = {
 	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
 	{"no-check-time", '\0', 0, G_OPTION_ARG_NONE, &no_check_time, "don't check validity period of certificates against current time", NULL},
+	{"key", '\0', G_OPTION_FLAG_NOALIAS, G_OPTION_ARG_FILENAME, &keypath, "decryption key file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format", "FORMAT"},
 	{"dump-cert", '\0', 0, G_OPTION_ARG_NONE, &info_dumpcert, "dump certificate", NULL},
 	{"dump-recipients", '\0', 0, G_OPTION_ARG_NONE, &info_dumprecipients, "dump recipients", NULL},


### PR DESCRIPTION
For the decryption use case, this specifies the decryption key.
The global `--key` option has been replaced by command-specific ones but the purpose of `--key` for 'rauc info' has not been considered.

Since the former global options are still available but hidden, using the options always worked but it has not been shown in the help output or man page.

Fixes #875.