### PR TITLE
src/install: fix broken plan installation failure handling

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -979,6 +979,7 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 		r_context_begin_step("skip_image", "Copying image skipped", 0);
 		r_context_end_step("skip_image", TRUE);
 
+		install_args_update(args, "Updating slot %s done", plan->target_slot->name);
 		return TRUE;
 	}
 
@@ -1032,6 +1033,7 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 		return FALSE;
 	}
 
+	install_args_update(args, "Updating slot %s done", plan->target_slot->name);
 	return TRUE;
 }
 
@@ -1109,11 +1111,9 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 
 		if (!handle_slot_install_plan(manifest, plan, args, hook_name, &ierror)) {
 			g_propagate_error(error, ierror);
-			goto image_out;
+			res = FALSE;
+			goto out;
 		}
-
-image_out:
-		install_args_update(args, "Updating slot %s done", plan->target_slot->name);
 	}
 
 	if (r_context()->config->activate_installed) {


### PR DESCRIPTION
The rework that introduced installation plan handling ignored the result of `handle_slot_install_plan()` and used the wrong jump label (`image_out`).

The handling belonging to the `image_out` label should be part of handle_slot_install_plan() and the formerly used `out` label should be used to abort the installation properly. We also need to save the failure information in 'res' to let `launch_and_wait_default_handler()` fail correctly.

Fixes 99ce07bc ("src/install: factor out per-slot image installation logic")

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
