### PR TITLE
src: add installation transaction UUID

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -944,6 +944,7 @@ termed with the slot name (e.g. [slot.rootfs.1]) for the central status file:
   status=ok
   sha256=b14c1457dc10469418b4154fef29a90e1ffb4dddd308bf0f2456d436963ef5b3
   size=419430400
+  installed.transaction=dad3289a-7de1-4ad2-931e-fb827edc6496
   installed.timestamp=2017-03-27T09:51:13Z
   installed.count=3
 
@@ -959,9 +960,12 @@ and ``bundle.build`` are copies of the respective manifest properties.
 More information can be found in this :ref:`subsection <sec-manifest-update>` of
 section :ref:`Manifest <sec_ref_manifest>`.
 
-RAUC also stores the point in time of installing the image to the slot in
-``installed.timestamp`` as well as the number of updates so far in
-``installed.count``.
+RAUC also stores information about the installation run during which the slot
+was updated:
+In ``installed.transaction`` the installation transaction ID is noted,
+while ``installed.timestamp`` notes the time when the slot's installation was
+finished and ``installed.count`` reflects the number of updates the slot
+received so far.
 Additionally RAUC tracks the point in time when a bootable slot is activated in
 ``activated.timestamp`` and the number of activations in ``activated.count``,
 see section :ref:`mark-active`.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1271,6 +1271,10 @@ IN a{sv} *args*:
         installation of bundles on platforms that a compatible not matching the one
         of the bundle to be installed
 
+    :STRING 'transaction-id', VARIANT 's' <UUID>: Set UUID to use for
+        identifying the (installation) transaction.
+        If not given, RAUC will generate a random one.
+
     :STRING 'tls-cert', VARIANT 's' <filename/pkcs11-url>: Use the provided
         certificate for TLS client authentication
 

--- a/include/install.h
+++ b/include/install.h
@@ -34,6 +34,7 @@ typedef struct {
 	gint status_result;
 	/* install options */
 	gboolean ignore_compatible;
+	gchar *transaction;
 	RaucBundleAccessArgs access_args;
 } RaucInstallArgs;
 

--- a/include/slot.h
+++ b/include/slot.h
@@ -19,6 +19,7 @@ typedef struct {
 	gchar *bundle_hash;
 	gchar *status;
 	RaucChecksum checksum;
+	gchar *installed_txn;
 	gchar *installed_timestamp;
 	guint32 installed_count;
 	gchar *activated_timestamp;

--- a/rauc.1
+++ b/rauc.1
@@ -260,6 +260,10 @@ Install a bundle.
 disable compatible check
 
 .TP
+\fB\-\-transaction\-id=\fR\fIUUID\fR
+custom transaction ID
+
+.TP
 \fB\-\-progress\fR
 show progress bar
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -904,6 +904,7 @@ static void status_file_get_slot_status(GKeyFile *key_file, const gchar *group, 
 		slotstatus->checksum.size = g_key_file_get_uint64(key_file, group, "size", NULL);
 	}
 
+	slotstatus->installed_txn = key_file_consume_string(key_file, group, "installed.transaction", NULL);
 	slotstatus->installed_timestamp = key_file_consume_string(key_file, group, "installed.timestamp", NULL);
 	count = g_key_file_get_uint64(key_file, group, "installed.count", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE))
@@ -961,6 +962,8 @@ static void status_file_set_slot_status(GKeyFile *key_file, const gchar *group, 
 		g_key_file_remove_key(key_file, group, "sha256", NULL);
 		g_key_file_remove_key(key_file, group, "size", NULL);
 	}
+
+	status_file_set_string_or_remove_key(key_file, group, "installed.transaction", slotstatus->installed_txn);
 
 	if (slotstatus->installed_timestamp) {
 		g_key_file_set_string(key_file, group, "installed.timestamp", slotstatus->installed_timestamp);

--- a/src/install.c
+++ b/src/install.c
@@ -1172,7 +1172,12 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	g_assert_null(r_context()->install_info->mounted_bundle);
 	g_assert_true(r_context()->config->slot_states_determined);
 
+	if (!args->transaction)
+		args->transaction = g_uuid_string_random();
+
 	r_context_begin_step("do_install_bundle", "Installing", 10);
+
+	g_message("Installation %s started", args->transaction);
 
 	r_context_begin_step("determine_slot_states", "Determining slot states", 0);
 	res = update_external_mount_points(&ierror);
@@ -1319,6 +1324,7 @@ RaucInstallArgs *install_args_new(void)
 void install_args_free(RaucInstallArgs *args)
 {
 	g_free(args->name);
+	g_free(args->transaction);
 	g_mutex_clear(&args->status_mutex);
 	g_assert_cmpint(args->status_result, >=, 0);
 	g_assert_true(g_queue_is_empty(&args->status_messages));

--- a/src/install.c
+++ b/src/install.c
@@ -1021,6 +1021,7 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 	slot_state->checksum.type = plan->image->checksum.type;
 	slot_state->checksum.digest = g_strdup(plan->image->checksum.digest);
 	slot_state->checksum.size = plan->image->checksum.size;
+	slot_state->installed_txn = g_strdup(args->transaction);
 	slot_state->installed_timestamp = g_date_time_format(now, "%Y-%m-%dT%H:%M:%SZ");
 	slot_state->installed_count++;
 

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,7 @@ gchar *casync_args = NULL;
 gchar **recipients = NULL;
 gchar *handler_args = NULL;
 gchar *bootslot = NULL;
+gchar *installation_txn = NULL;
 gboolean utf8_supported = FALSE;
 RaucBundleAccessArgs access_args = {0};
 
@@ -242,6 +243,7 @@ static gboolean install_start(int argc, char **argv)
 	args->status_result = 2;
 
 	args->ignore_compatible = install_ignore_compatible;
+	args->transaction = installation_txn;
 	if (access_args.tls_cert)
 		args->access_args.tls_cert = g_strdup(access_args.tls_cert);
 	if (access_args.tls_key)
@@ -258,6 +260,8 @@ static gboolean install_start(int argc, char **argv)
 		g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
 
 		g_variant_dict_insert(&dict, "ignore-compatible", "b", args->ignore_compatible);
+		if (args->transaction)
+			g_variant_dict_insert(&dict, "transaction-id", "s", args->transaction);
 		if (args->access_args.tls_cert)
 			g_variant_dict_insert(&dict, "tls-cert", "s", args->access_args.tls_cert);
 		if (args->access_args.tls_key)
@@ -2100,6 +2104,7 @@ typedef struct {
 
 static GOptionEntry entries_install[] = {
 	{"ignore-compatible", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_compatible, "disable compatible check", NULL},
+	{"transaction-id", '\0', 0, G_OPTION_ARG_STRING, &installation_txn, "custom transaction id", "UUID"},
 #if ENABLE_SERVICE == 1
 	{"progress", '\0', 0, G_OPTION_ARG_NONE, &install_progressbar, "show progress bar", NULL},
 #else

--- a/src/main.c
+++ b/src/main.c
@@ -1363,10 +1363,13 @@ static void r_string_append_slot(GString *text, RaucSlot *slot, RaucStatusPrint 
 			g_string_append_printf(text, "\n              sha256=%s", slot_state->checksum.digest);
 			g_string_append_printf(text, "\n              size=%s", formatted_size);
 		}
+		g_string_append_printf(text, "\n          installed:");
 		if (slot_state->installed_timestamp) {
-			g_string_append_printf(text, "\n          installed:");
 			g_string_append_printf(text, "\n              timestamp=%s", slot_state->installed_timestamp);
 			g_string_append_printf(text, "\n              count=%u", slot_state->installed_count);
+		}
+		if (slot_state->installed_txn) {
+			g_string_append_printf(text, "\n              transaction=%s", slot_state->installed_txn);
 		}
 		if (slot_state->activated_timestamp) {
 			g_string_append_printf(text, "\n          activated:");
@@ -1656,6 +1659,7 @@ static RaucSlotStatus* r_variant_get_slot_state(GVariant *vardict)
 	if (g_variant_dict_lookup(&dict, "sha256", "s", &slot_state->checksum.digest))
 		slot_state->checksum.type = G_CHECKSUM_SHA256;
 	g_variant_dict_lookup(&dict, "size", "t", &slot_state->checksum.size);
+	g_variant_dict_lookup(&dict, "installed.transaction", "s", &slot_state->installed_txn);
 	g_variant_dict_lookup(&dict, "installed.timestamp", "s", &slot_state->installed_timestamp);
 	g_variant_dict_lookup(&dict, "installed.count", "u", &slot_state->installed_count);
 	g_variant_dict_lookup(&dict, "activated.timestamp", "s", &slot_state->activated_timestamp);

--- a/src/service.c
+++ b/src/service.c
@@ -102,6 +102,9 @@ static gboolean r_on_handle_install_bundle(
 	if (g_variant_dict_lookup(&dict, "ignore-compatible", "b", &args->ignore_compatible))
 		g_variant_dict_remove(&dict, "ignore-compatible");
 
+	if (g_variant_dict_lookup(&dict, "transaction-id", "s", &args->transaction))
+		g_variant_dict_remove(&dict, "transaction-id");
+
 	convert_dict_to_bundle_access_args(&dict, &args->access_args);
 
 	/* Check for unhandled keys */

--- a/src/service.c
+++ b/src/service.c
@@ -326,6 +326,9 @@ static GVariant* convert_slot_status_to_dict(RaucSlot *slot)
 		g_variant_dict_insert(&dict, "size", "t", (guint64) slot_state->checksum.size);
 	}
 
+	if (slot_state->installed_txn)
+		g_variant_dict_insert(&dict, "installed.transaction", "s", slot_state->installed_txn);
+
 	if (slot_state->installed_timestamp) {
 		g_variant_dict_insert(&dict, "installed.timestamp", "s", slot_state->installed_timestamp);
 		g_variant_dict_insert(&dict, "installed.count", "u", slot_state->installed_count);

--- a/src/slot.c
+++ b/src/slot.c
@@ -37,6 +37,7 @@ void r_slot_clear_status(RaucSlotStatus *slotstatus)
 	g_clear_pointer(&slotstatus->status, g_free);
 	g_clear_pointer(&slotstatus->checksum.digest, g_free);
 	slotstatus->checksum.size = 0;
+	g_clear_pointer(&slotstatus->installed_txn, g_free);
 	g_clear_pointer(&slotstatus->installed_timestamp, g_free);
 	g_clear_pointer(&slotstatus->activated_timestamp, g_free);
 }


### PR DESCRIPTION
It can either be provided manually (via D-Bus or command line arg) or will be auto-generated.

The transaction UUID allows us to identify and track an installation run.

It is an important building block for adding future features like history logging, life cycle tracing, and more.

First of all, add a simple printout of the UUID when the installation starts so we can follow it in the logs.

Also see #1070