### PR TITLE
Obtain system's boot ID and machine ID

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -50,6 +50,7 @@ typedef struct {
 	gchar *mountprefix;
 	gchar *bootslot;
 	gchar *boot_id;
+	gchar *machine_id;
 
 	gchar *system_serial;
 	GHashTable *system_info; /* key/values of system information */

--- a/include/context.h
+++ b/include/context.h
@@ -49,6 +49,7 @@ typedef struct {
 	/* optional global mount prefix overwrite */
 	gchar *mountprefix;
 	gchar *bootslot;
+	gchar *boot_id;
 
 	gchar *system_serial;
 	GHashTable *system_info; /* key/values of system information */

--- a/src/context.c
+++ b/src/context.c
@@ -27,6 +27,20 @@ static gchar *regex_match(const gchar *pattern, const gchar *string)
 	return NULL;
 }
 
+static gchar* get_machine_id(void)
+{
+	gchar *contents = NULL;
+	g_autoptr(GError) ierror = NULL;
+
+	if (!g_file_get_contents("/etc/machine-id", &contents, NULL, &ierror)) {
+		g_info("Failed to get machine-id: %s", ierror->message);
+		return NULL;
+	}
+
+	/* file contains newline, modify in-place */
+	return g_strchomp(contents);
+}
+
 static gchar* get_boot_id(void)
 {
 	gchar *contents = NULL;
@@ -336,9 +350,12 @@ static gboolean r_context_configure_target(GError **error)
 	}
 
 	g_clear_pointer(&context->boot_id, g_free);
+	g_clear_pointer(&context->machine_id, g_free);
 
 	context->boot_id = get_boot_id();
 	g_debug("Obtained system boot ID: '%s'", context->boot_id);
+	context->machine_id = get_machine_id();
+	g_debug("Obtained system machine ID: '%s'", context->machine_id);
 
 	return TRUE;
 }
@@ -769,6 +786,7 @@ void r_context_clean(void)
 		g_clear_pointer(&context->mountprefix, g_free);
 		g_clear_pointer(&context->bootslot, g_free);
 		g_clear_pointer(&context->boot_id, g_free);
+		g_clear_pointer(&context->machine_id, g_free);
 		g_clear_pointer(&context->system_serial, g_free);
 		g_clear_pointer(&context->system_info, g_hash_table_destroy);
 


### PR DESCRIPTION
For now, we just collect some information to be used in follow-up features:

* machine-id -> allows to identify the machine we run on
* boot-id -> allows to identify the boot we are in

Related to #1070 and #1114 