### PR TITLE
Add System Information HTTP Headers

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -478,6 +478,22 @@ round-trip-time (RTT) lead to longer installation times.
 This can be compensated somewhat by using a HTTP/2 server, as this supports
 multiplexing and better connection reuse.
 
+Additional HTTP Header Information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Upon first HTTP request, RAUC can expose some additional information about the
+system in HTTP headers.
+This allows the receiving server to log this information or to build some
+simple logic and rollout handling on it.
+
+The actual information exposed to the server is configurable by
+``send-headers`` option in the :ref:`[streaming] section
+<streaming-config-section>` of ``system.conf``.
+
+Beside some standard information, like the *boot ID*, the system's *uptime* or
+the *installation transaction ID*, one can also expose custom information
+provided by the ``system-info`` :ref:`handler <sec_ref_handlers>`.
+
 .. _sec-encryption:
 
 Bundle Encryption

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -298,6 +298,22 @@ For more information about using the streaming support of RAUC, refer to
   This option can be used to set the path of the CA certificate which should be
   used instead of the system wide store of trusted TLS/HTTPS certificates.
 
+``send-headers``
+  This option takes a ``;``-separated list of information to send as HTTP
+  header fields to the server with the first request.
+
+  Supported values are:
+
+  * ``boot-id``: Enables sending the *boot_id* as ``RAUC-Boot-ID`` header field.
+  * ``machine-id``: Enables sending the *machine-id* as ``RAUC-Machine-ID`` header field.
+
+    .. note:: The machine ID should be considered "confidential" and thus not
+       be used over unauthenticated connections or with untrusted servers!
+  * ``serial``: Enables sending the *system serial* as ``RAUC-Serial`` header field.
+  * ``variant``: Enables sending the *variant* as ``RAUC-Variant`` header field.
+  * ``transaction-id``: Enables sending the *transaction UUID* as ``RAUC-Transaction-ID`` header field.
+  * ``uptime``: Enables sending the system's current uptime as ``RAUC-Uptime`` header field.
+
 **[encryption]**
 
 The ``encryption`` section contains information required to decrypt a 'crypt'
@@ -359,6 +375,8 @@ performed from a dedicated (recovery) slot.
   The full path of the bundle file to check for.
   If file at ``path`` exists, auto-install will be triggered.
 
+.. _sec_ref_handlers:
+
 **[handlers] section**
 
 Handlers allow to customize RAUC by placing scripts in the system that RAUC can
@@ -388,6 +406,16 @@ See details about using handlers in `Custom Handlers (Interface)`_.
 
   System information is made available to other handlers via environment
   variables that have the exact same name and value.
+
+  The ``system-info`` handler also allows to define custom information that is
+  forwarded to the server upon RAUC's first streaming request.
+  In order to define forwarded info, this must be returned as a key prefixed.
+  with ``RAUC_HTTP_``.
+  The generated header field will be name of the key (with out the prefix)
+  where an ``RAUC-`` is prepended and all underscores are converted to
+  hyphens.
+  E.g. ``RAUC_HTTP_MY_CUSTOM_INFO=dummyvalue`` will emit a header
+  ``RAUC-MY-CUSTOM-INFO: dummyvalue``.
 
 ``pre-install``
   This handler will be called right before RAUC starts with the installation.

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -28,6 +28,7 @@ typedef struct {
 	gchar *tls_ca;
 	gboolean tls_no_verify;
 	GStrv http_headers;
+	GStrv http_info_headers;
 } RaucBundleAccessArgs;
 
 typedef struct {

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -73,6 +73,8 @@ typedef struct {
 
 	gchar *systeminfo_handler;
 
+	gchar **enabled_headers; /* standard HTTP headers to send */
+
 	/* streaming */
 	gchar *streaming_sandbox_user;
 	gchar *streaming_tls_cert;

--- a/include/install.h
+++ b/include/install.h
@@ -156,3 +156,13 @@ void r_image_install_plan_free(gpointer value);
  */
 GPtrArray* r_install_make_plans(const RaucManifest *manifest, GHashTable *target_group, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
+
+/**
+ * Checks if header is supported.
+ *
+ * @param header Header config name to check
+ *
+ * @return TRUE if is supported, FALSE otherwise
+ */
+gboolean r_install_is_supported_http_header(const gchar *header)
+G_GNUC_WARN_UNUSED_RESULT;

--- a/include/nbd.h
+++ b/include/nbd.h
@@ -37,6 +37,7 @@ typedef struct {
 	gchar *tls_ca; /* local file */
 	gboolean tls_no_verify;
 	GStrv headers; /* array of strings such as 'Foo: bar' */
+	GStrv info_headers; /* array of strings such as 'Foo: bar' */
 
 	/* discovered information */
 	guint64 data_size; /* bundle size */

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1926,6 +1926,7 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleP
 			ibundle->nbd_srv->tls_ca = g_strdup(access_args->tls_ca);
 			ibundle->nbd_srv->tls_no_verify = access_args->tls_no_verify;
 			ibundle->nbd_srv->headers = g_strdupv(access_args->http_headers);
+			ibundle->nbd_srv->info_headers = g_strdupv(access_args->http_info_headers);
 		}
 		if (!ibundle->nbd_srv->tls_cert)
 			ibundle->nbd_srv->tls_cert = g_strdup(r_context()->config->streaming_tls_cert);
@@ -2922,6 +2923,7 @@ void clear_bundle_access_args(RaucBundleAccessArgs *access_args)
 		g_free(access_args->tls_key);
 		g_free(access_args->tls_ca);
 		g_strfreev(access_args->http_headers);
+		g_strfreev(access_args->http_info_headers);
 	}
 
 	memset(access_args, 0, sizeof(*access_args));


### PR DESCRIPTION
This implements passing system information upon the first HTTP request when accessing the URL of a streaming bundle.

This allows the server to collect more information about the device in order to create more verbose logs or to actually build deployment logic on this.

Besides some standard information that is configurable, custom information can be provided by the `system-info` handler.

This implements parts of concept #1114