### PR TITLE
Initializing middle

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -50,6 +50,7 @@ typedef struct {
 	gchar *mountprefix;
 	gchar *bootslot;
 	gchar *boot_id;
+	gchar *machine_id;
 
 	gchar *system_serial;
 	GHashTable *system_info; /* key/values of system information */

--- a/include/context.h
+++ b/include/context.h
@@ -49,6 +49,7 @@ typedef struct {
 	/* optional global mount prefix overwrite */
 	gchar *mountprefix;
 	gchar *bootslot;
+	gchar *boot_id;
 
 	gchar *system_serial;
 	GHashTable *system_info; /* key/values of system information */

--- a/src/context.c
+++ b/src/context.c
@@ -27,6 +27,20 @@ static gchar *regex_match(const gchar *pattern, const gchar *string)
 	return NULL;
 }
 
+static gchar* get_machine_id(void)
+{
+	gchar *contents = NULL;
+	g_autoptr(GError) ierror = NULL;
+
+	if (!g_file_get_contents("/etc/machine-id", &contents, NULL, &ierror)) {
+		g_info("Failed to get machine-id: %s", ierror->message);
+		return NULL;
+	}
+
+	/* file contains newline, modify in-place */
+	return g_strchomp(contents);
+}
+
 static gchar* get_boot_id(void)
 {
 	gchar *contents = NULL;
@@ -336,9 +350,12 @@ static gboolean r_context_configure_target(GError **error)
 	}
 
 	g_clear_pointer(&context->boot_id, g_free);
+	g_clear_pointer(&context->machine_id, g_free);
 
 	context->boot_id = get_boot_id();
 	g_debug("Obtained system boot ID: '%s'", context->boot_id);
+	context->machine_id = get_machine_id();
+	g_debug("Obtained system machine ID: '%s'", context->machine_id);
 
 	return TRUE;
 }
@@ -769,6 +786,7 @@ void r_context_clean(void)
 		g_clear_pointer(&context->mountprefix, g_free);
 		g_clear_pointer(&context->bootslot, g_free);
 		g_clear_pointer(&context->boot_id, g_free);
+		g_clear_pointer(&context->machine_id, g_free);
 		g_clear_pointer(&context->system_serial, g_free);
 		g_clear_pointer(&context->system_info, g_hash_table_destroy);
 

--- a/src/hash_index.c
+++ b/src/hash_index.c
@@ -451,7 +451,6 @@ gboolean r_hash_index_get_chunk(const RaucHashIndex *idx, const guint8 *hash, Ra
 	/* use a binary search over the sorted chunk hash indices */
 	left = 0;
 	right = idx->count - 1;
-	middle = 0;
 	while (left <= right) {
 		int cmp;
 		middle = left + (right - left) / 2;

--- a/src/hash_index.c
+++ b/src/hash_index.c
@@ -451,6 +451,7 @@ gboolean r_hash_index_get_chunk(const RaucHashIndex *idx, const guint8 *hash, Ra
 	/* use a binary search over the sorted chunk hash indices */
 	left = 0;
 	right = idx->count - 1;
+	middle = 0;
 	while (left <= right) {
 		int cmp;
 		middle = left + (right - left) / 2;


### PR DESCRIPTION
<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

Variable `middle` coule be uninitialized at the access of the variable on line 481 in `hash_index.c`; adding a line that initializes middle to 0.

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
