### PR TITLE
fixing logical-not to bit-wise-not operator

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1898,7 +1898,7 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleP
 
 	g_return_val_if_fail(bundlename, FALSE);
 	g_return_val_if_fail(bundle != NULL && *bundle == NULL, FALSE);
-	g_return_val_if_fail(!(params & TRUE), FALSE); /* protect against passing TRUE as the params enum */
+	g_return_val_if_fail(~(params & TRUE), FALSE); /* protect against passing TRUE as the params enum */
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	r_context_begin_step("check_bundle", "Checking bundle", verify);


### PR DESCRIPTION
<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

In this line, the logical not operator (!) is used rather than the bit-wise not operator (~) which may act unpredictably. 

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
