### PR TITLE
contrib/uboot.sh: reset BOOT_ORDER to initial value

### DIFF
--- a/contrib/uboot.sh
+++ b/contrib/uboot.sh
@@ -29,6 +29,7 @@ else
   echo "No valid slot found, resetting tries to 3"
   setenv BOOT_A_LEFT 3
   setenv BOOT_B_LEFT 3
+  setenv BOOT_ORDER "A B"
   saveenv
   reset
 fi


### PR DESCRIPTION
When setting the BOOT_ORDER environment variable to an invalid value, the boot sequence will be broken. This will result in an endless reset loop.
To make sure that the next boot will start using a valid BOOT_ORDER, reset it to its initial value BOOT_ORDER='A B'.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
