### PR TITLE
Ensure Consistent Slot Status

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1103,7 +1103,7 @@ static void load_slot_status_globally(void)
 
 	g_key_file_load_from_file(key_file, r_context()->config->statusfile_path, G_KEY_FILE_NONE, &ierror);
 	if (ierror && !g_error_matches(ierror, G_FILE_ERROR, G_FILE_ERROR_NOENT))
-		g_message("load_slot_status_globally: %s.", ierror->message);
+		g_message("Failed to load global slot status file: %s", ierror->message);
 	g_clear_error(&ierror);
 
 	/* Load all slot states included in the statusfile */

--- a/src/install.c
+++ b/src/install.c
@@ -948,7 +948,7 @@ skip_filename_checks:
 	return TRUE;
 }
 
-static void update_slot_status(RaucSlotStatus *slot_state, const RaucManifest *manifest, const RImageInstallPlan *plan, const RaucInstallArgs *args)
+static void update_slot_status(RaucSlotStatus *slot_state, const gchar* status, const RaucManifest *manifest, const RImageInstallPlan *plan, const RaucInstallArgs *args)
 {
 	g_autoptr(GDateTime) now = NULL;
 
@@ -961,7 +961,7 @@ static void update_slot_status(RaucSlotStatus *slot_state, const RaucManifest *m
 	slot_state->bundle_description = g_strdup(manifest->update_description);
 	slot_state->bundle_build = g_strdup(manifest->update_build);
 	slot_state->bundle_hash = g_strdup(manifest->hash);
-	slot_state->status = g_strdup("ok");
+	slot_state->status = g_strdup(status);
 	slot_state->checksum.type = plan->image->checksum.type;
 	slot_state->checksum.digest = g_strdup(plan->image->checksum.digest);
 	slot_state->checksum.size = plan->image->checksum.size;
@@ -1031,7 +1031,7 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 		return FALSE;
 	}
 
-	update_slot_status(slot_state, manifest, plan, args);
+	update_slot_status(slot_state, "ok", manifest, plan, args);
 
 	r_context_end_step("copy_image", TRUE);
 

--- a/src/install.c
+++ b/src/install.c
@@ -948,11 +948,32 @@ skip_filename_checks:
 	return TRUE;
 }
 
+static void update_slot_status(RaucSlotStatus *slot_state, const RaucManifest *manifest, const RImageInstallPlan *plan, const RaucInstallArgs *args)
+{
+	g_autoptr(GDateTime) now = NULL;
+
+	r_slot_clear_status(slot_state);
+
+	now = g_date_time_new_now_utc();
+
+	slot_state->bundle_compatible = g_strdup(manifest->update_compatible);
+	slot_state->bundle_version = g_strdup(manifest->update_version);
+	slot_state->bundle_description = g_strdup(manifest->update_description);
+	slot_state->bundle_build = g_strdup(manifest->update_build);
+	slot_state->bundle_hash = g_strdup(manifest->hash);
+	slot_state->status = g_strdup("ok");
+	slot_state->checksum.type = plan->image->checksum.type;
+	slot_state->checksum.digest = g_strdup(plan->image->checksum.digest);
+	slot_state->checksum.size = plan->image->checksum.size;
+	slot_state->installed_txn = g_strdup(args->transaction);
+	slot_state->installed_timestamp = g_date_time_format(now, "%Y-%m-%dT%H:%M:%SZ");
+	slot_state->installed_count++;
+}
+
 static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RImageInstallPlan *plan, RaucInstallArgs *args, const char *hook_name, GError **error)
 {
 	GError *ierror = NULL;
 	RaucSlotStatus *slot_state = NULL;
-	g_autoptr(GDateTime) now = NULL;
 
 	install_args_update(args, "Checking slot %s", plan->target_slot->name);
 
@@ -1010,22 +1031,7 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 		return FALSE;
 	}
 
-	r_slot_clear_status(slot_state);
-
-	now = g_date_time_new_now_utc();
-
-	slot_state->bundle_compatible = g_strdup(manifest->update_compatible);
-	slot_state->bundle_version = g_strdup(manifest->update_version);
-	slot_state->bundle_description = g_strdup(manifest->update_description);
-	slot_state->bundle_build = g_strdup(manifest->update_build);
-	slot_state->bundle_hash = g_strdup(manifest->hash);
-	slot_state->status = g_strdup("ok");
-	slot_state->checksum.type = plan->image->checksum.type;
-	slot_state->checksum.digest = g_strdup(plan->image->checksum.digest);
-	slot_state->checksum.size = plan->image->checksum.size;
-	slot_state->installed_txn = g_strdup(args->transaction);
-	slot_state->installed_timestamp = g_date_time_format(now, "%Y-%m-%dT%H:%M:%SZ");
-	slot_state->installed_count++;
+	update_slot_status(slot_state, manifest, plan, args);
 
 	r_context_end_step("copy_image", TRUE);
 

--- a/src/install.c
+++ b/src/install.c
@@ -1038,6 +1038,14 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 		g_propagate_prefixed_error(error, ierror,
 				"Failed updating slot %s: ", plan->target_slot->name);
 		r_context_end_step("copy_image", FALSE);
+
+		g_message("Updating slot %s status", plan->target_slot->name);
+		update_slot_status(slot_state, "failed", manifest, plan, args);
+		if (!save_slot_status(plan->target_slot, NULL)) {
+			g_propagate_prefixed_error(error, ierror, "Error while writing status file: ");
+			return FALSE;
+		}
+
 		return FALSE;
 	}
 

--- a/src/install.c
+++ b/src/install.c
@@ -999,6 +999,16 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 
 		/* Dummy step to indicate slot was skipped */
 		r_context_begin_step("skip_image", "Copying image skipped", 0);
+
+		/* Update the status also for skipped slots */
+		g_message("Updating slot %s status", plan->target_slot->name);
+		update_slot_status(slot_state, "ok", manifest, plan, args);
+		if (!save_slot_status(plan->target_slot, &ierror)) {
+			g_propagate_prefixed_error(error, ierror, "Error while writing status file: ");
+			r_context_end_step("skip_image", FALSE);
+			return FALSE;
+		}
+
 		r_context_end_step("skip_image", TRUE);
 
 		install_args_update(args, "Updating slot %s done", plan->target_slot->name);

--- a/src/install.c
+++ b/src/install.c
@@ -1049,11 +1049,10 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 		return FALSE;
 	}
 
-	update_slot_status(slot_state, "ok", manifest, plan, args);
-
 	r_context_end_step("copy_image", TRUE);
 
 	g_message("Updating slot %s status", plan->target_slot->name);
+	update_slot_status(slot_state, "ok", manifest, plan, args);
 	if (!save_slot_status(plan->target_slot, &ierror)) {
 		g_propagate_prefixed_error(error, ierror, "Error while writing status file: ");
 		return FALSE;

--- a/src/install.c
+++ b/src/install.c
@@ -1029,7 +1029,7 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 
 	r_context_end_step("copy_image", TRUE);
 
-	install_args_update(args, "Updating slot %s status", plan->target_slot->name);
+	g_message("Updating slot %s status", plan->target_slot->name);
 	if (!save_slot_status(plan->target_slot, &ierror)) {
 		g_propagate_prefixed_error(error, ierror, "Error while writing status file: ");
 		return FALSE;


### PR DESCRIPTION
So far, the slot status has only been written after a successful (not-skipped) slot update.

This makes it hard to identify what the actual content and state of the slot is.

Also, the existing `status=` field had only one possible value which was `"ok"`.

Besides some minor adaptions, the main aspect of this PR is to ensure the slot status gets updated even when the slot update failed or was skipped due to the 'slot skipping' mechanism.

In the first case, it also sets the status to `"failed"` to let the user know this slot is in an unusable state. When having skipped, it sets the state to `"skipped"` indicating it matches the content of the noted bundle information but was not explicitly written.