### PR TITLE
nbd.c: use off_t instead of off64_t with _FILE_OFFSET_BITS=64

### DIFF
--- a/include/nbd.h
+++ b/include/nbd.h
@@ -79,4 +79,4 @@ gboolean r_nbd_run_server(gint sock, GError **error);
 gboolean r_nbd_start_server(RaucNBDServer *nbd_srv, GError **error);
 gboolean r_nbd_stop_server(RaucNBDServer *nbd_srv, GError **error);
 
-gboolean r_nbd_read(gint sock, guint8 *data, size_t size, off64_t offset, GError **error);
+gboolean r_nbd_read(gint sock, guint8 *data, size_t size, off_t offset, GError **error);

--- a/src/nbd.c
+++ b/src/nbd.c
@@ -1231,7 +1231,7 @@ out:
 	return res;
 }
 
-gboolean r_nbd_read(gint sock, guint8 *data, size_t size, off64_t offset, GError **error)
+gboolean r_nbd_read(gint sock, guint8 *data, size_t size, off_t offset, GError **error)
 {
 	struct nbd_request request = {0};
 	struct nbd_reply reply = {0};


### PR DESCRIPTION
With _FILE_OFFSET_BITS=64 there is no "off64_t", but off_t is 64 bit long: https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html#index-_005fFILE_005fOFFSET_005fBITS

While glibc defines the off64_t anyway, musl is more restrictive and only provides the "off64_t" when _LARGEFILE64_SOURCE is defined.

Signed-off-by: Christian Hohnstaedt <christian@hohnstaedt.de>

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
