### PR TITLE
data: meson.build: install rauc-service.sh with executable bit set

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -21,7 +21,7 @@ rauc_dbus_wrapper = configure_file(
   output : 'rauc-service.sh',
   configuration : conf
 )
-install_data(rauc_dbus_wrapper, install_dir : dbuswrapperdir)
+install_data(rauc_dbus_wrapper, install_dir : dbuswrapperdir, install_mode : 'rwxr-xr-x')
 
 rauc_dbus_policy = configure_file(
   input : 'de.pengutronix.rauc.conf',


### PR DESCRIPTION
The script needs to be executable. This got lost during meson transition.

Fixes #1165

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
