### PR TITLE
Fix dbus_sources dependency

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -39,6 +39,8 @@ extra_test_sources = files([
   'install-fixtures.c',
 ])
 
+test_dep = declare_dependency(sources : dbus_sources)
+
 foreach test_name : tests
   exe = executable(
     test_name + '-test',
@@ -47,7 +49,7 @@ foreach test_name : tests
     link_with : librauc,
     c_args : '-DTEST_SERVICES="' + meson.build_root() + '"',
     include_directories : incdir,
-    dependencies : rauc_deps)
+    dependencies : [ rauc_deps, test_dep ])
 
   test(
     test_name,


### PR DESCRIPTION
Create a source dependency on dbus_sources to "tests". These sources are required at compile time and might be generated too late otherwise.

The race condition may be provoked by adding a "sleep 10" to "gdbus-codegen"

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
