### PR TITLE
src/hash_index: initialize 'middle' for consistency

### DIFF
--- a/src/hash_index.c
+++ b/src/hash_index.c
@@ -451,6 +451,7 @@ gboolean r_hash_index_get_chunk(const RaucHashIndex *idx, const guint8 *hash, Ra
 	/* use a binary search over the sorted chunk hash indices */
 	left = 0;
 	right = idx->count - 1;
+	middle = 0;
 	while (left <= right) {
 		int cmp;
 		middle = left + (right - left) / 2;


### PR DESCRIPTION
Note that it was not actually used uninitialized since using it depended on having 'found' set to TRUE which can only happen in a code path that also sets 'middle' to some value.

Closes: #1155
