### PR TITLE
configure.ac: fix help text name of --with-streaming_user

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,7 +117,7 @@ AS_IF([test "x$enable_streaming" = "xyes"], [
 ])
 
 AC_ARG_WITH([streaming_user],
-        AS_HELP_STRING([--with-streaming-user=USERNAME], [unpriviledged user for the streaming subprocess]),
+        AS_HELP_STRING([--with-streaming_user=USERNAME], [unpriviledged user for the streaming subprocess]),
         [],
         [with_streaming_user=nobody])
 AC_DEFINE_UNQUOTED([STREAMING_USER], ["$with_streaming_user"], [Set the unpriviledged user for the streaming subprocess])


### PR DESCRIPTION
The actual name of the option (`--with-streaming_user` ) differs from the help text (`--with-streaming-user`). Fix this.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
