### PR TITLE
get_system_info_from_handler: do not step on existing values

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -216,6 +216,7 @@ EXTRA_DIST += tap-t \
 	      test/test.conf \
 	      test/test-global.conf \
 	      test/test-datadir.conf \
+	      test/test-dummy-handler.conf \
 	      test/get-coverity.sh \
 	      test/openssl-ca-create.sh \
 	      test/openssl-ca-check.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -275,6 +275,7 @@ AC_CONFIG_LINKS([test/sharness.sh:test/sharness.sh])
 AC_CONFIG_LINKS([test/test.conf:test/test.conf])
 AC_CONFIG_LINKS([test/test-global.conf:test/test-global.conf])
 AC_CONFIG_LINKS([test/test-datadir.conf:test/test-datadir.conf])
+AC_CONFIG_LINKS([test/test-dummy-handler.conf:test/test-dummy-handler.conf])
 
 AC_CONFIG_FILES([
         Makefile

--- a/src/context.c
+++ b/src/context.c
@@ -274,16 +274,15 @@ static GHashTable *get_system_info_from_handler(GError **error)
 		return NULL;
 	}
 
-	g_clear_pointer(&context->system_serial, g_free);
-	g_clear_pointer(&context->config->system_variant, g_free);
 	g_hash_table_iter_init(&iter, vars);
 	while (g_hash_table_iter_next(&iter, (gpointer*) &key, (gpointer*) &value)) {
 		/* legacy handling */
 		if (g_strcmp0(key, "RAUC_SYSTEM_SERIAL") == 0) {
+			g_clear_pointer(&context->system_serial, g_free);
 			context->system_serial = g_strdup(value);
 		} else if (g_strcmp0(key, "RAUC_SYSTEM_VARIANT") == 0) {
 			/* set variant (overrides possible previous value) */
-			g_free(context->config->system_variant);
+			g_clear_pointer(&context->config->system_variant, g_free);
 			context->config->system_variant = g_strdup(value);
 		}
 	}

--- a/test/context.c
+++ b/test/context.c
@@ -90,6 +90,25 @@ static void test_context_system_info(void)
 	r_context_clean();
 }
 
+/* Tests that the static variant from the system.conf is not cleared by an
+ * empty system-info handler.
+ */
+static void test_context_system_info_dummy(void)
+{
+	r_context_conf()->configpath = g_strdup("test/test-dummy-handler.conf");
+	r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_REQUIRED;
+	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+
+	g_assert_cmpstr(r_context()->system_serial, ==, NULL);
+	g_assert_true(r_context()->config->system_variant_type == R_CONFIG_SYS_VARIANT_NAME);
+	g_assert_cmpstr(r_context()->config->system_variant, ==, "Default Variant");
+
+	g_assert_nonnull(r_context()->system_info);
+	g_assert_cmpuint(g_hash_table_size(r_context()->system_info), ==, 0);
+
+	r_context_clean();
+}
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -107,6 +126,8 @@ int main(int argc, char *argv[])
 	g_test_add_func("/context/bootslot/no-bootslot", test_bootslot_no_bootslot);
 
 	g_test_add_func("/context/system-info", test_context_system_info);
+
+	g_test_add_func("/context/system-info-dummy", test_context_system_info_dummy);
 
 	return g_test_run();
 }

--- a/test/test-dummy-handler.conf
+++ b/test/test-dummy-handler.conf
@@ -1,0 +1,26 @@
+# testsuite system configuration
+
+[system]
+compatible=Test Config
+bootloader=grub
+grubenv=grubenv.test
+variant-name=Default Variant
+
+[handlers]
+system-info=/bin/echo
+pre-install=/bin/true
+post-install=/bin/true
+
+[keyring]
+path=openssl-ca/dev-ca.pem
+check-crl=true
+
+[slot.rootfs.0]
+device=images/rootfs-0
+type=ext4
+bootname=system0
+
+[slot.rootfs.1]
+device=images/rootfs-1
+type=ext4
+bootname=system1


### PR DESCRIPTION
context->system_serial and context->config->system_variant was deleted even when no substitute is found in the script.

This breaks systems using DTB compatible variant setups when the script did not supply this information.
Keep off values not supplied by the handler script!