### PR TITLE
meson.build: fix dbus default directories

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -201,7 +201,7 @@ datadir = get_option('datadir')
 
 dbussystemservicedir = get_option('dbussystemservicedir')
 if dbussystemservicedir == ''
-  dbussystemservicedir = datadir / 'dbus-1' / 'interfaces'
+  dbussystemservicedir = datadir / 'dbus-1' / 'system-services'
   if dbusdep.found()
     dbussystemservicedir = dbusdep.get_variable(pkgconfig : 'system_bus_services_dir', default_value : dbussystemservicedir)
   endif
@@ -214,7 +214,7 @@ endif
 
 dbusinterfacesdir = get_option('dbusinterfacesdir')
 if dbusinterfacesdir == ''
-  dbusinterfacesdir = datadir / 'dbus-1' / 'system.d'
+  dbusinterfacesdir = datadir / 'dbus-1' / 'interfaces'
   if dbusdep.found()
     dbusinterfacesdir = dbusdep.get_variable(pkgconfig: 'interfaces_dir', default_value : dbusinterfacesdir)
   endif


### PR DESCRIPTION
Looks like the default directories for system services and interfaces were pointing to wrong locations.

The build variable dbusinterfaces is currently not explicitly set by the recipe rauc.inc in meta-rauc. This causes bitbake not to find the proper package for file de.pengutronix.rauc.Installer.xml.