### PR TITLE
README.rst: document 'ninja -C build' alternative to 'meson compile -C build'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,7 @@ Building from Sources
     git clone https://github.com/rauc/rauc
     cd rauc
     meson setup build
-    meson compile -C build
+    meson compile -C build # or 'ninja -C build' on meson < 0.54.0
 
 .. note:: At the moment, also `automake cross-compilation
    <https://www.gnu.org/software/automake/manual/html_node/Cross_002dCompilation.html>`_


### PR DESCRIPTION
Only meson versions (<0.54.0), as on Ubuntu 20.04 LTS don't support 'meson compile'. Mention this alternative until we can deprecate support for it.