### PR TITLE
Fix bootchooser for the output of efibootmgr 18

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -198,6 +198,16 @@ gchar * key_file_consume_string(
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Ensure that the input string contains neither whitespace nor tab.
+ *
+ * @param str string to check.
+ *
+ * @return TRUE if str contains neither whitespace nor tab, FALSE otherwise
+ */
+gboolean value_check_tab_whitespace(const gchar *str, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
  * Get integer argument from key and remove key from key_file.
  */
 gint key_file_consume_integer(

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1159,11 +1159,20 @@ static gboolean efi_bootorder_get(GList **bootorder_entries, GList **all_entries
 	}
 
 	while (g_match_info_matches(match)) {
+		gchar *tab_point = NULL;
 		efi_bootentry *entry = g_new0(efi_bootentry, 1);
 		entry->num = g_match_info_fetch(match, 1);
 		entry->name = g_match_info_fetch(match, 2);
+
+		/* Remove anything after a tab, as it is most likely path
+		 * information which we don't need. */
+		tab_point = strchr(entry->name, '\t');
+		if (tab_point)
+			*tab_point = '\0';
+
 		entries = g_list_append(entries, entry);
 		g_match_info_next(match, NULL);
+		g_debug("Detected EFI boot entry %s: %s", entry->num, entry->name);
 	}
 
 	g_clear_pointer(&regex, g_regex_unref);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -233,8 +233,16 @@ static GHashTable *parse_slots(const char *filename, const char *data_directory,
 			}
 
 			value = key_file_consume_string(key_file, groups[i], "bootname", NULL);
+
 			slot->bootname = value;
 			if (slot->bootname) {
+				/* Ensure that the bootname does not contain whitespace or tab */
+				if (!value_check_tab_whitespace(value, &ierror)) {
+					g_propagate_prefixed_error(error, ierror,
+							"Invalid bootname for slot %s: ", slot->name);
+					return NULL;
+				}
+
 				/* check if we have seen this bootname on another slot */
 				if (g_hash_table_contains(bootnames, slot->bootname)) {
 					g_set_error(

--- a/src/utils.c
+++ b/src/utils.c
@@ -227,6 +227,22 @@ gchar * key_file_consume_string(
 	return result;
 }
 
+gboolean value_check_tab_whitespace(const gchar *str, GError **error)
+{
+	g_return_val_if_fail(str != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (strchr(str, '\t') || strchr(str, ' ')) {
+		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
+				"The value '%s' can not contain tab or whitespace characters",
+				str
+				);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
 gint key_file_consume_integer(
 		GKeyFile *key_file,
 		const gchar *group_name,

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -646,6 +646,30 @@ mountprefix=/mnt/myrauc/\n\
 activate-installed=typo\n");
 }
 
+static void config_file_bootname_tab(ConfigFileFixture *fixture, gconstpointer user_data)
+{
+	g_autoptr(RaucConfig) config = NULL;
+	GError *ierror = NULL;
+	g_autofree gchar* pathname = NULL;
+
+	const gchar *contents = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+\n\
+[slot.rootfs.0]\n\
+device=/dev/null\n\
+bootname=the\tslot\n";
+
+	pathname = write_tmp_file(fixture->tmpdir, "bootname_tab.conf", contents, NULL);
+	g_assert_nonnull(pathname);
+
+	g_assert_false(load_config(pathname, &config, &ierror));
+	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE);
+	g_assert_cmpstr(ierror->message, ==, "Invalid bootname for slot rootfs.0: The value 'the\tslot' can not contain tab or whitespace characters");
+	g_clear_error(&ierror);
+}
+
 static void config_file_no_max_bundle_download_size(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1317,6 +1341,9 @@ int main(int argc, char *argv[])
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/typo-in-boolean-activate-installed-key", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_typo_in_boolean_activate_installed_key,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/bootname-tab", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_bootname_tab,
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/no-max-bundle-download-size", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_no_max_bundle_download_size,


### PR DESCRIPTION
Since efibootmgr 18, the default output of `efibootmgr` is now more verbose [1], which breaks the assumptions made by RAUC in regards to parsing the output. This issue is also affecting others [2].

Fix the parsing logic by unconditionally splitting on a tab in the detected name part of the boot entry, so that the unused data part can be discarded.
Emit a debug message for each found boot entry, as this helps in detecting issues in the future.

[1] https://github.com/rhboot/efibootmgr/commit/8ec3e9dedb3cb62f19847794012420b90f475398
[2] https://github.com/rhboot/efibootmgr/issues/169

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->

This fix is not related to an open ticket, as I noticed this quite recently and got in touch on matrix to discuss a possible fix.
I verified this to work in an Arch Linux VM using efibootmgr 18 and a RAUC 1.10 with this patch applied.

As writing C is not really my forte, I'd appreciate feedback (especially whether this works as intended with efibootmgr < 18).