### PR TITLE
src/update_handler: support *.bin for u-boot emmc-boot image

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -2777,6 +2777,7 @@ RaucUpdatePair updatepairs[] = {
 	{"*.squashfs-zst", "ubivol", img_to_ubivol_handler},
 #if ENABLE_EMMC_BOOT_SUPPORT == 1
 	{"*.img", "boot-emmc", img_to_boot_emmc_handler},
+	{"*.bin", "boot-emmc", img_to_boot_emmc_handler},
 #endif
 	{"*", "boot-emmc", NULL},
 	{"*.vfat", "boot-mbr-switch", img_to_boot_mbr_switch_handler},


### PR DESCRIPTION
Since a common name for U-Boot binaries is flash.bin or u-boot.bin add support for the "*.bin" suffix for the emmc-boot type.