### PR TITLE
test: meson.build: increase timeout for sharness tests by 1 minute

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -71,7 +71,7 @@ test(
   rauc_t,
   args : '-v',
   is_parallel : false,
-  timeout : 300,
+  timeout : 360,
   env : ['SHARNESS_BUILD_DIRECTORY=' + meson.build_root()],
   workdir : meson.current_source_dir(),
 )


### PR DESCRIPTION
We've seen this fail with TIMEOUT in GitHub actions now a couple of times and also some successful runs take >250 seconds so that it's likely that the current limit of 300 is just too low for GitHub CI.