### PR TITLE
src: implement --ignore-image option for rauc convert (casync)

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -962,6 +962,13 @@ The conversion process will create two new artifacts:
     This is a directory with chunks grouped by subfolders of the first 4 digits
     of their chunk ID.
 
+.. note:: In case one or several of the images in the original bundle should
+   not be converted to casync images (``.caidx`` or ``.caibx``), you can
+   explicitly skip them during conversion using the ``--ignore-image`` argument
+   of ``rauc convert``. E.g.:
+
+     rauc convert --ignore-image=kernel --ignore-image=dtb ...
+
 Installing casync Bundles
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/bundle.h
+++ b/include/bundle.h
@@ -221,9 +221,10 @@ G_GNUC_WARN_UNUSED_RESULT;
  *
  * @param bundle RaucBundle struct as returned by check_bundle()
  * @param outbundle output location for converted casync bundle
+ * @param ignore_images string list of slot classes of images to ignore during conversion
  * @param error Return location for a GError
  */
-gboolean create_casync_bundle(RaucBundle *bundle, const gchar *outbundle, GError **error)
+gboolean create_casync_bundle(RaucBundle *bundle, const gchar *outbundle, const gchar **ignore_images, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**

--- a/rauc.1
+++ b/rauc.1
@@ -235,6 +235,10 @@ mksquashfs extra args
 \fB\-\-casync\-args=\fR\fIARGS\fR
 casync extra args
 
+.TP
+\fB\-\-ignore\-image=\fR\fISLOTCLASS\fR
+ignore image during conversion
+
 .RE
 .RE
 .PP

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1055,7 +1055,7 @@ out:
 	return res;
 }
 
-static gboolean convert_to_casync_bundle(RaucBundle *bundle, const gchar *outbundle, GError **error)
+static gboolean convert_to_casync_bundle(RaucBundle *bundle, const gchar *outbundle, const gchar **ignore_images, GError **error)
 {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
@@ -1122,6 +1122,11 @@ static gboolean convert_to_casync_bundle(RaucBundle *bundle, const gchar *outbun
 		if (!image->filename)
 			continue;
 
+		if (ignore_images && g_strv_contains(ignore_images, image->slotclass)) {
+			g_message("Skipping conversion of %s as requested", image->filename);
+			continue;
+		}
+
 		if (image_is_archive(image)) {
 			idxfile = g_strconcat(image->filename, ".caidx", NULL);
 			idxpath = g_build_filename(contentdir, idxfile, NULL);
@@ -1184,7 +1189,7 @@ out:
 	return res;
 }
 
-gboolean create_casync_bundle(RaucBundle *bundle, const gchar *outbundle, GError **error)
+gboolean create_casync_bundle(RaucBundle *bundle, const gchar *outbundle, const gchar **ignore_images, GError **error)
 {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
@@ -1204,7 +1209,7 @@ gboolean create_casync_bundle(RaucBundle *bundle, const gchar *outbundle, GError
 		goto out;
 	}
 
-	res = convert_to_casync_bundle(bundle, outbundle, &ierror);
+	res = convert_to_casync_bundle(bundle, outbundle, ignore_images, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		goto out;

--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,7 @@ gchar **intermediate = NULL;
 gchar *signing_keyring = NULL;
 gchar *mksquashfs_args = NULL;
 gchar *casync_args = NULL;
+gchar **convert_ignore_images = NULL;
 gchar **recipients = NULL;
 gchar *handler_args = NULL;
 gchar *bootslot = NULL;
@@ -764,7 +765,7 @@ static gboolean convert_start(int argc, char **argv)
 		goto out;
 	}
 
-	if (!create_casync_bundle(bundle, argv[3], &ierror)) {
+	if (!create_casync_bundle(bundle, argv[3], (const gchar**) convert_ignore_images, &ierror)) {
 		g_printerr("Failed to create bundle: %s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
@@ -2144,6 +2145,7 @@ static GOptionEntry entries_convert[] = {
 	{"signing-keyring", '\0', 0, G_OPTION_ARG_FILENAME, &signing_keyring, "verification keyring file", "PEMFILE"},
 	{"mksquashfs-args", '\0', 0, G_OPTION_ARG_STRING, &mksquashfs_args, "mksquashfs extra args", "ARGS"},
 	{"casync-args", '\0', 0, G_OPTION_ARG_STRING, &casync_args, "casync extra args", "ARGS"},
+	{"ignore-image", '\0', 0, G_OPTION_ARG_STRING_ARRAY, &convert_ignore_images, "ignore image during conversion", "SLOTCLASS"},
 	{0}
 };
 

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -760,6 +760,20 @@ test_expect_success CASYNC "rauc convert" "
   test -f casync.raucb
 "
 
+test_expect_success CASYNC "rauc convert (ignore-image)" "
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&
+  rm -f casync.raucb &&
+  rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+    convert \
+    --ignore-image appfs \
+    ${TEST_TMPDIR}/good-bundle.raucb casync.raucb &&
+  test -f casync.raucb
+"
+
 test_expect_success CASYNC "rauc convert (output exists)" "
   cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
   test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&


### PR DESCRIPTION
This option allows providing the slotclass of an image to ignore during conversion. Multiple images can be ignored by using the argument multiple times.

This can be useful to generate 'mixed' casync bundles that contain both .caidx/.caibx images as well as conventional ones.

Usage:

    rauc convert [..] --ignore-image=rootfs input-bundle.raucb mixed-bundle.raucb


Fixes: #1200

Note: This is a proof-of-concept and a base for discussion only for now.
<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
