### PR TITLE
README: clarify license

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -280,8 +280,27 @@ Please read the Documentation's
 `Contributing <http://rauc.readthedocs.io/en/latest/contributing.html>`_
 section for more details.
 
+License
+-------
+
+Copyright (C) 2015–2023 RAUC project
+
+RAUC is free software; you can redistribute it and/or modify it under the terms
+of the GNU Lesser General Public License as published by the Free Software
+Foundation; either version 2.1 of the License, or (at your option) any later
+version.
+
+This library is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this source code, see the file named `COPYING`_. If not, see
+https://www.gnu.org/licenses/.
+
 .. |LGPLv2.1| image:: https://img.shields.io/badge/license-LGPLv2.1-blue.svg
-   :target: https://raw.githubusercontent.com/rauc/rauc/master/COPYING
+   :target: #license
+.. _COPYING: https://raw.githubusercontent.com/rauc/rauc/master/COPYING
 .. |CI_branch| image:: https://github.com/rauc/rauc/workflows/tests/badge.svg
    :target: https://github.com/rauc/rauc/actions?query=workflow%3Atests
 .. |Codecov_branch| image:: https://codecov.io/gh/rauc/rauc/branch/master/graph/badge.svg


### PR DESCRIPTION
Simply including the LGPL license text is not enough information to determine the license of a software project, as Section 13 of the LGPL allows licensees to choose the terms of "any later version of the license" if specified so by the copyright holders.

The information in meson.build implies "LGPL-2.1-or-later" as project license. As a minimal measure to make this information explicit, add the usual license notice and warranty disclaimer as recommended in the [GNU GPL How-To](https://www.gnu.org/licenses/gpl-howto.html#why-license-notices) (also see [https://www.gnu.org/licenses/identify-licenses-clearly.html]) to the README file, and also add a minimal copyright notice as required by Section 1 of the LGPL.

Let the LGPL badge at the start of the README point to the relevant section further down.