### PR TITLE
src/manifest: ignore new per-image keys version, description and build

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -84,6 +84,10 @@ static gboolean parse_image(GKeyFile *key_file, const gchar *group, RaucImage **
 		}
 	}
 
+	g_key_file_remove_key(key_file, group, "version", NULL);
+	g_key_file_remove_key(key_file, group, "description", NULL);
+	g_key_file_remove_key(key_file, group, "build", NULL);
+
 	iimage->adaptive = g_key_file_get_string_list(key_file, group, "adaptive", NULL, NULL);
 	g_key_file_remove_key(key_file, group, "adaptive", NULL);
 

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -428,6 +428,48 @@ counter=42\n\
 	free_manifest(rm);
 }
 
+static void test_manifest_load_details(void)
+{
+	gchar *tmpdir;
+	RaucManifest *rm = NULL;
+	gchar* manifestpath = NULL;
+	gboolean res;
+	GError *error = NULL;
+	RaucImage *test_img = NULL;
+	const gchar *mffile = "\
+[update]\n\
+compatible=FooCorp Super BarBazzer\n\
+version=2015.04-1\n\
+\n\
+[image.rootfs]\n\
+filename=rootfs-default.ext4\n\
+version=2015.04.1\n\
+description=image description\n\
+build=123456789\n\
+";
+
+	tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+	g_assert_nonnull(tmpdir);
+
+	manifestpath = write_tmp_file(tmpdir, "manifest.raucm", mffile, NULL);
+	g_assert_nonnull(manifestpath);
+
+	g_free(tmpdir);
+
+	res = load_manifest_file(manifestpath, &rm, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	g_clear_error(&error);
+	g_free(manifestpath);
+
+	test_img = (RaucImage*)g_list_nth_data(rm->images, 0);
+	/* image details are currently ignored during parsing */
+	g_assert_nonnull(test_img);
+
+	free_manifest(rm);
+}
+
 static void test_manifest_invalid_hook_name(void)
 {
 	g_autofree gchar *tmpdir;
@@ -698,6 +740,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/manifest/load_variants", test_manifest_load_variants);
 	g_test_add_func("/manifest/load_adaptive", test_manifest_load_adaptive);
 	g_test_add_func("/manifest/load_meta", test_manifest_load_meta);
+	g_test_add_func("/manifest/load_details", test_manifest_load_details);
 	g_test_add_func("/manifest/invalid_hook_name", test_manifest_invalid_hook_name);
 	g_test_add_func("/manifest/missing_hook_name", test_manifest_missing_hook_name);
 	g_test_add_func("/manifest/missing_image_size", test_manifest_missing_image_size);


### PR DESCRIPTION
In some cases, it's useful to annotate images with more specific information than we currently have at the bundle level. For now, just use the same keys as at the bundle level.

In this change, we just ignore them to allow installation of bundles which contain them in the manifest.

Later, we should store this information in the slot status and expose it via D-Bus and `rauc status`.