### PR TITLE
.gitignore: add bzImage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ config.h.in
 config.status
 configure
 libtool
+/bzImage
 /rauc
 /rauc.map
 /rauc-1.*


### PR DESCRIPTION
The `qemu-test` script downloads the kernel to this filename.