### PR TITLE
Make marking interface more consistent

### DIFF
--- a/include/mark.h
+++ b/include/mark.h
@@ -2,6 +2,8 @@
 
 #include <glib.h>
 
+#include "slot.h"
+
 gboolean mark_active(RaucSlot *slot, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 

--- a/include/mark.h
+++ b/include/mark.h
@@ -4,7 +4,17 @@
 
 #include "slot.h"
 
-gboolean mark_active(RaucSlot *slot, GError **error)
+/**
+ * Mark a bootname slot as active.
+ *
+ * This means it is expected to be the next being booted.
+ *
+ * @param slot Slot to mark as active
+ * @param error Return location for a GError
+ *
+ * @return Return TRUE on success and FALSE on error
+ */
+gboolean r_mark_active(RaucSlot *slot, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 gboolean mark_run(const gchar *state,

--- a/include/mark.h
+++ b/include/mark.h
@@ -17,6 +17,32 @@
 gboolean r_mark_active(RaucSlot *slot, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
+/**
+ * Mark a bootname slot as good.
+ *
+ * This means it is considered working after an update.
+ *
+ * @param slot Slot to mark as good
+ * @param error Return location for a GError
+ *
+ * @return Return TRUE on success and FALSE on error
+ */
+gboolean r_mark_good(RaucSlot *slot, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
+ * Mark a bootname slot as bad.
+ *
+ * This means it is considered broken after an update.
+ *
+ * @param slot Slot to mark as bad
+ * @param error Return location for a GError
+ *
+ * @return Return TRUE on success and FALSE on error
+ */
+gboolean r_mark_bad(RaucSlot *slot, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
 gboolean mark_run(const gchar *state,
 		const gchar *slot_identifier,
 		gchar **slot_name,

--- a/src/install.c
+++ b/src/install.c
@@ -1156,7 +1156,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 	if (boot_mark_slot) {
 		/* Mark boot slot non-bootable */
 		g_message("Marking target slot %s as non-bootable...", boot_mark_slot->name);
-		if (!r_boot_set_state(boot_mark_slot, FALSE, &ierror)) {
+		if (!r_mark_bad(boot_mark_slot, &ierror)) {
 			g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_NONBOOTABLE,
 					"Failed marking slot %s non-bootable: %s", boot_mark_slot->name, ierror->message);
 			g_clear_error(&ierror);

--- a/src/install.c
+++ b/src/install.c
@@ -1187,7 +1187,7 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 		if (r_context()->config->activate_installed) {
 			/* Mark boot slot bootable */
 			g_message("Marking target slot %s as bootable...", boot_mark_slot->name);
-			if (!mark_active(boot_mark_slot, &ierror)) {
+			if (!r_mark_active(boot_mark_slot, &ierror)) {
 				g_propagate_prefixed_error(error, ierror,
 						"Failed marking slot %s bootable: ", boot_mark_slot->name);
 				return FALSE;

--- a/src/mark.c
+++ b/src/mark.c
@@ -75,7 +75,7 @@ static RaucSlot* get_slot_by_identifier(const gchar *identifier, GError **error)
 	return slot;
 }
 
-gboolean mark_active(RaucSlot *slot, GError **error)
+gboolean r_mark_active(RaucSlot *slot, GError **error)
 {
 	RaucSlotStatus *slot_state;
 	GError *ierror = NULL;
@@ -133,7 +133,7 @@ gboolean mark_run(const gchar *state,
 		res = r_boot_set_state(slot, FALSE, &ierror);
 		*message = res ? g_strdup_printf("marked slot %s as bad", slot->name) : g_strdup_printf("Failed marking slot %s as bad: %s", slot->name, ierror->message);
 	} else if (!g_strcmp0(state, "active")) {
-		if (!mark_active(slot, &ierror)) {
+		if (!r_mark_active(slot, &ierror)) {
 			res = FALSE;
 			*message = g_strdup(ierror->message);
 		} else {

--- a/src/mark.c
+++ b/src/mark.c
@@ -107,6 +107,40 @@ gboolean r_mark_active(RaucSlot *slot, GError **error)
 	return TRUE;
 }
 
+gboolean r_mark_good(RaucSlot *slot, GError **error)
+{
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (!r_boot_set_state(slot, TRUE, &ierror)) {
+		g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_BOOTABLE,
+				"Failed marking slot %s as good:  %s", slot->name, ierror->message);
+		g_error_free(ierror);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+gboolean r_mark_bad(RaucSlot *slot, GError **error)
+{
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (!r_boot_set_state(slot, FALSE, &ierror)) {
+		g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_BOOTABLE,
+				"Failed marking slot %s as bad:  %s", slot->name, ierror->message);
+		g_error_free(ierror);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
 gboolean mark_run(const gchar *state,
 		const gchar *slot_identifier,
 		gchar **slot_name,

--- a/src/mark.c
+++ b/src/mark.c
@@ -161,11 +161,21 @@ gboolean mark_run(const gchar *state,
 	}
 
 	if (!g_strcmp0(state, "good")) {
-		res = r_boot_set_state(slot, TRUE, &ierror);
-		*message = res ? g_strdup_printf("marked slot %s as good", slot->name) : g_strdup_printf("Failed marking slot %s as good: %s", slot->name, ierror->message);
+		if (!r_mark_good(slot, &ierror)) {
+			res = FALSE;
+			*message = g_strdup(ierror->message);
+		} else {
+			res = TRUE;
+			*message = g_strdup_printf("marked slot %s as good", slot->name);
+		}
 	} else if (!g_strcmp0(state, "bad")) {
-		res = r_boot_set_state(slot, FALSE, &ierror);
-		*message = res ? g_strdup_printf("marked slot %s as bad", slot->name) : g_strdup_printf("Failed marking slot %s as bad: %s", slot->name, ierror->message);
+		if (!r_mark_bad(slot, &ierror)) {
+			res = FALSE;
+			*message = g_strdup(ierror->message);
+		} else {
+			res = TRUE;
+			*message = g_strdup_printf("marked slot %s as bad", slot->name);
+		}
 	} else if (!g_strcmp0(state, "active")) {
 		if (!r_mark_active(slot, &ierror)) {
 			res = FALSE;


### PR DESCRIPTION
So far, we have an `r_mark_*` function for marking "active" but not for marking "good" or bad.

This results in having to use different semantic layers/modules between different mark actions.

Fix this by introducing and using `r_mark_good` and `r_mark_bad`.