### PR TITLE
test: fix pre-check tests and generate slot artifacts only when needed

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -44,7 +44,7 @@ Some of them only run in CI, but most of them can be executed locally.
 When working on a new feature or fixing a bug, please make sure these tests
 succeed.
 
-Code Style - uncrustify 
+Code Style - uncrustify
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 To maintain a consistent code style, we use the `uncrustify
@@ -73,7 +73,7 @@ from the RAUC source code's root directory but they will also be triggered by
 the general test suite run (see below).
 If you add or change subcommands or arguments of the CLI tool, make sure these
 tests succeed and extend them if possible.
-As many of these tests need root permissions, we recommend running them using the 
+As many of these tests need root permissions, we recommend running them using the
 ``qemu-test`` helper below.
 
 glib Unit Tests - gtest

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -1117,7 +1117,7 @@ To register the custom bootloader backend handler, assign your handler to the
 Custom bootloader backend interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-According to :ref:`sec-boot-slot` the custom bootloader handler is called by 
+According to :ref:`sec-boot-slot` the custom bootloader handler is called by
 RAUC to trigger the following actions:
 
 * get the primary slot

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -200,13 +200,13 @@ Example configuration:
   Normally, this option is not needed as every access to the bundle payload during
   installation is already protected by ``dm-verity``.
   The default value is ``false`` which means that this pre-check is not performed.
-  
+
   This option is useful when the installation should be aborted early even if the corrupt
   part of the bundle is not used during installation (perhaps due to adaptive updates or
   image variants).
 
   It has no effect for ``plain`` bundles, as the signature verification already checks the
-  whole bundle.  
+  whole bundle.
 
 .. _keyring-section:
 

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2549,7 +2549,7 @@ static gboolean read_complete_dm_device(gchar *dev, GError **error)
 			g_set_error(error,
 					G_FILE_ERROR,
 					g_file_error_from_errno(err),
-					"Check %s device failed between %"G_GOFFSET_FORMAT " and %"G_GOFFSET_FORMAT " bytes with error: %s", dev, chunk*sizeof(buf), (chunk+1)*sizeof(buf), g_strerror(err));
+					"Check %s device failed between %"G_GOFFSET_FORMAT " and %"G_GOFFSET_FORMAT " bytes with error: %s", dev, chunk*chunk_size, (chunk+1)*chunk_size, g_strerror(err));
 			ret = FALSE;
 			break;
 		}

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -288,6 +288,7 @@ static void bundle_test_create_check_mount_with_pre_check_corrupt(BundleFixture 
 	res = mount_bundle(bundle, &ierror);
 	g_assert_error(ierror, G_FILE_ERROR, G_FILE_ERROR_IO);
 	g_assert_false(res);
+	g_assert_nonnull(strstr(ierror->message, "failed between 1048576 and 1114112 bytes with error: Input/output error"));
 }
 
 static void bundle_test_extract_signature(BundleFixture *fixture,

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -856,12 +856,12 @@ int main(int argc, char *argv[])
 
 	/* test casync manifest contents */
 	g_test_add("/bundle/check_casync/old",
-			BundleFixture, bundle_data,
+			BundleFixture, NULL,
 			bundle_fixture_set_up, bundle_test_check_casync_old,
 			bundle_fixture_tear_down);
 
 	g_test_add("/bundle/check_casync/new",
-			BundleFixture, bundle_data,
+			BundleFixture, NULL,
 			bundle_fixture_set_up, bundle_test_check_casync_new,
 			bundle_fixture_tear_down);
 

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -843,15 +843,17 @@ int main(int argc, char *argv[])
 				bundle_fixture_set_up_bundle_codesign, bundle_test_purpose_codesign,
 				bundle_fixture_tear_down);
 
-		g_test_add(dup_test_printf(ptrs, "/bundle/create_mount_extract_with_pre_check/%s", format_name),
-				BundleFixture, bundle_data,
-				bundle_fixture_set_up_bundle, bundle_test_create_mount_extract_with_pre_check,
-				bundle_fixture_tear_down);
+		if (format != R_MANIFEST_FORMAT_PLAIN) {
+			g_test_add(dup_test_printf(ptrs, "/bundle/create_mount_extract_with_pre_check/%s", format_name),
+					BundleFixture, bundle_data,
+					bundle_fixture_set_up_bundle, bundle_test_create_mount_extract_with_pre_check,
+					bundle_fixture_tear_down);
 
-		g_test_add(dup_test_printf(ptrs, "/bundle/create_mount_with_pre_check_corrupt/%s", format_name),
-				BundleFixture, bundle_data,
-				bundle_fixture_set_up_bundle_corrupt, bundle_test_create_check_mount_with_pre_check_corrupt,
-				bundle_fixture_tear_down);
+			g_test_add(dup_test_printf(ptrs, "/bundle/create_mount_with_pre_check_corrupt/%s", format_name),
+					BundleFixture, bundle_data,
+					bundle_fixture_set_up_bundle_corrupt, bundle_test_create_check_mount_with_pre_check_corrupt,
+					bundle_fixture_tear_down);
+		}
 	}
 
 	/* test casync manifest contents */

--- a/test/common.c
+++ b/test/common.c
@@ -182,19 +182,19 @@ int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, cons
 		rm->hook_name = g_strdup("hook.sh");
 	}
 
-	img = g_new0(RaucImage, 1);
+	if (options->slots) {
+		img = g_new0(RaucImage, 1);
+		img->slotclass = g_strdup("rootfs");
+		img->filename = g_strdup("rootfs.ext4");
+		if (options->hooks)
+			img->hooks.post_install = TRUE;
+		rm->images = g_list_append(rm->images, img);
 
-	img->slotclass = g_strdup("rootfs");
-	img->filename = g_strdup("rootfs.ext4");
-	if (options->hooks)
-		img->hooks.post_install = TRUE;
-	rm->images = g_list_append(rm->images, img);
-
-	img = g_new0(RaucImage, 1);
-
-	img->slotclass = g_strdup("appfs");
-	img->filename = g_strdup("appfs.ext4");
-	rm->images = g_list_append(rm->images, img);
+		img = g_new0(RaucImage, 1);
+		img->slotclass = g_strdup("appfs");
+		img->filename = g_strdup("appfs.ext4");
+		rm->images = g_list_append(rm->images, img);
+	}
 
 	g_assert_true(save_manifest_file(path, rm, NULL));
 

--- a/test/common.h
+++ b/test/common.h
@@ -7,6 +7,7 @@
 typedef struct {
 	gboolean custom_handler;
 	gboolean hooks;
+	gboolean slots;
 	RManifestBundleFormat format;
 } ManifestTestOptions;
 

--- a/test/install.c
+++ b/test/install.c
@@ -1481,6 +1481,7 @@ int main(int argc, char *argv[])
 		install_data = dup_test_data(ptrs, (&(InstallData) {
 			.manifest_test_options = {
 			        .format = format,
+			        .slots = TRUE,
 			},
 		}));
 		g_test_add(dup_test_printf(ptrs, "/install/bootname/%s", format_name),
@@ -1520,6 +1521,7 @@ int main(int argc, char *argv[])
 			.manifest_test_options = {
 			        .custom_handler = TRUE,
 			        .hooks = FALSE,
+			        .slots = TRUE,
 			},
 		}));
 		g_test_add(dup_test_printf(ptrs, "/install/bundle-custom-handler/%s", format_name),
@@ -1532,6 +1534,7 @@ int main(int argc, char *argv[])
 			.manifest_test_options = {
 			        .custom_handler = FALSE,
 			        .hooks = TRUE,
+			        .slots = TRUE,
 			},
 		}));
 		g_test_add(dup_test_printf(ptrs, "/install/bundle-hook/install-check/%s", format_name),
@@ -1544,6 +1547,7 @@ int main(int argc, char *argv[])
 			.manifest_test_options = {
 			        .custom_handler = FALSE,
 			        .hooks = TRUE,
+			        .slots = TRUE,
 			},
 		}));
 		g_test_add(dup_test_printf(ptrs, "/install/bundle-hook/slot-install/%s", format_name),
@@ -1556,6 +1560,7 @@ int main(int argc, char *argv[])
 			.manifest_test_options = {
 			        .custom_handler = FALSE,
 			        .hooks = TRUE,
+			        .slots = TRUE,
 			},
 		}));
 		g_test_add(dup_test_printf(ptrs, "/install/bundle-hook/slot-post-install/%s", format_name),
@@ -1568,6 +1573,7 @@ int main(int argc, char *argv[])
 			.manifest_test_options = {
 			        .custom_handler = TRUE,
 			        .hooks = TRUE,
+			        .slots = TRUE,
 			},
 		}));
 		g_test_add(dup_test_printf(ptrs, "/install/already-mounted/%s", format_name),
@@ -1579,6 +1585,7 @@ int main(int argc, char *argv[])
 	install_data = dup_test_data(ptrs, (&(InstallData) {
 		.manifest_test_options = {
 		        .format = R_MANIFEST_FORMAT_VERITY,
+		        .slots = TRUE,
 		},
 	}));
 	g_test_add("/install/adaptive",

--- a/test/service.c
+++ b/test/service.c
@@ -36,6 +36,7 @@ static void service_install_fixture_set_up(ServiceFixture *fixture, gconstpointe
 			&(ManifestTestOptions) {
 		.custom_handler = FALSE,
 		.hooks = FALSE,
+		.slots = TRUE,
 	});
 
 	/* Write a D-Bus service file with current tmpdir */


### PR DESCRIPTION
This increases the flexibility for testing artifacts later.