### PR TITLE
update_utils: make copy_with_progress reusable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ librauc_la_SOURCES = \
 	src/status_file.c \
 	src/utils.c \
 	src/update_handler.c \
+	src/update_utils.c \
 	src/verity_hash.c \
 	include/bootchooser.h \
 	include/bundle.h \
@@ -79,6 +80,7 @@ librauc_la_SOURCES = \
 	include/stats.h \
 	include/status_file.h \
 	include/update_handler.h \
+	include/update_utils.h \
 	include/utils.h \
 	include/verity_hash.h
 

--- a/include/update_utils.h
+++ b/include/update_utils.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+
+/* These functions can be used by slot and artifact update handlers. */
+
+/**
+ * Copies data from an input stream to an output stream, while generating
+ * progress updates.
+ *
+ * @param in_stream input stream
+ * @param out_stream output stream
+ * @param size expected size of the data to copy
+ * @param error return location for a GError, or NULL
+ *
+ * @return TRUE if copying was successful, FALSE otherwise
+ */
+
+gboolean r_copy_stream_with_progress(GInputStream *in_stream, GOutputStream *out_stream,
+		goffset size, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;

--- a/meson.build
+++ b/meson.build
@@ -121,6 +121,7 @@ sources_rauc = files([
   'src/status_file.c',
   'src/slot.c',
   'src/update_handler.c',
+  'src/update_utils.c',
   'src/utils.c',
   'src/verity_hash.c',
 ])

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -239,7 +239,7 @@ static gboolean ubifs_ioctl(RaucImage *image, int fd, GError **error)
 	return TRUE;
 }
 
-static gssize copy_with_progress(GOutputStream *out_stream, GInputStream *image_stream,
+static gssize copy_with_progress(GInputStream *image_stream, GOutputStream *out_stream,
 		goffset image_size, GError **error)
 {
 	GError *ierror = NULL;
@@ -411,7 +411,7 @@ static gboolean copy_raw_image(RaucImage *image, GUnixOutputStream *outstream, g
 		}
 	}
 
-	size = copy_with_progress(G_OUTPUT_STREAM(outstream), instream, image->checksum.size, &ierror);
+	size = copy_with_progress(instream, G_OUTPUT_STREAM(outstream), image->checksum.size, &ierror);
 	if (size == -1) {
 		g_propagate_prefixed_error(error, ierror,
 				"Failed splicing data: ");

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -413,7 +413,7 @@ static gboolean copy_raw_image(RaucImage *image, GUnixOutputStream *outstream, g
 
 	if (!copy_with_progress(instream, G_OUTPUT_STREAM(outstream), image->checksum.size, &ierror)) {
 		g_propagate_prefixed_error(error, ierror,
-				"Failed splicing data: ");
+				"Failed to copy data: ");
 		return FALSE;
 	}
 

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -239,8 +239,8 @@ static gboolean ubifs_ioctl(RaucImage *image, int fd, GError **error)
 	return TRUE;
 }
 
-static gssize copy_with_progress(GInputStream *image_stream, GOutputStream *out_stream,
-		goffset image_size, GError **error)
+static gssize copy_with_progress(GInputStream *in_stream, GOutputStream *out_stream,
+		goffset size, GError **error)
 {
 	GError *ierror = NULL;
 	gsize out_size = 0;
@@ -252,7 +252,7 @@ static gssize copy_with_progress(GInputStream *image_stream, GOutputStream *out_
 	do {
 		gboolean ret;
 
-		in_size = g_input_stream_read(image_stream,
+		in_size = g_input_stream_read(in_stream,
 				buffer, 8192, NULL, &ierror);
 		if (in_size == -1) {
 			g_propagate_error(error, ierror);
@@ -267,7 +267,7 @@ static gssize copy_with_progress(GInputStream *image_stream, GOutputStream *out_
 
 		sum_size += out_size;
 
-		percent = sum_size * 100 / image_size;
+		percent = sum_size * 100 / size;
 		/* emit progress info (but only when in progress context) */
 		if (r_context()->progress && percent != last_percent) {
 			last_percent = percent;

--- a/src/update_utils.c
+++ b/src/update_utils.c
@@ -1,0 +1,49 @@
+#include <errno.h>
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "update_utils.h"
+#include "context.h"
+
+gboolean r_copy_stream_with_progress(GInputStream *in_stream, GOutputStream *out_stream,
+		goffset size, GError **error)
+{
+	GError *ierror = NULL;
+	gsize out_size = 0;
+	goffset sum_size = 0;
+	gint last_percent = -1, percent;
+	gchar buffer[8192];
+	gssize in_size;
+
+	do {
+		gboolean ret;
+
+		in_size = g_input_stream_read(in_stream,
+				buffer, 8192, NULL, &ierror);
+		if (in_size == -1) {
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
+		ret = g_output_stream_write_all(out_stream, buffer,
+				in_size, &out_size, NULL, &ierror);
+		if (!ret) {
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
+
+		sum_size += out_size;
+
+		percent = sum_size * 100 / size;
+		/* emit progress info (but only when in progress context) */
+		if (r_context()->progress && percent != last_percent) {
+			last_percent = percent;
+			r_context_set_step_percentage("copy_image", percent);
+		}
+	} while (out_size);
+
+	return TRUE;
+}


### PR DESCRIPTION
This renames copy_with_progress to r_copy_stream_with_progress and moves it to
a new update_utils module. Also change the return value to a `gboolean`, as a
partial copy is an error case for this function.