### PR TITLE
qemu-test: optimize nginx startup

### DIFF
--- a/qemu-test-init
+++ b/qemu-test-init
@@ -125,11 +125,7 @@ if type nginx; then
 fi
 
 if python3 -m aiohttp.web --help > /dev/null; then
-  python3 test/nginx_backend.py &
-  while sleep 1; do
-    test -e /tmp/backend.sock && break
-  done
-  chmod a=rw /tmp/backend.sock
+  python3 test/nginx_backend.py
   export RAUC_TEST_HTTP_BACKEND=1
 fi
 

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -124,8 +124,7 @@ if type nginx; then
   export RAUC_TEST_HTTP_SERVER=1
 fi
 
-if python3 -m aiohttp.web --help > /dev/null; then
-  python3 test/nginx_backend.py
+if python3 test/nginx_backend.py; then
   export RAUC_TEST_HTTP_BACKEND=1
 fi
 

--- a/test/nginx_backend.py
+++ b/test/nginx_backend.py
@@ -4,7 +4,11 @@ import os
 import socket
 import sys
 
-from aiohttp import web
+try:
+    from aiohttp import web
+except ModuleNotFoundError:
+    print("aiohttp python module not installed, disabling RAUC_TEST_HTTP_BACKEND")
+    exit(1)
 
 routes = web.RouteTableDef()
 


### PR DESCRIPTION
The two Python startups and the `while sleep 1` loop can take quite some time when restarting `qemu-test` often, so optimize it a bit.