### PR TITLE
create links to active slot devices in /run/rauc/slots/active

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -86,8 +86,8 @@ To actually install an update bundle on your target hardware, RAUC provides the
 
 Alternatively you can trigger a bundle installation `using the D-Bus API`_.
 
-Viewing the System Status
--------------------------
+Accessing the System Status
+---------------------------
 
 For debugging purposes and for scripting it is helpful to gain an overview of
 the current system as RAUC sees it.
@@ -103,6 +103,18 @@ important properties. Alternatively you can obtain a shell-parsable description,
 or a JSON representation of the system status.
 If more information is needed such as the slots' :ref:`status <slot-status>` add
 the command line option ``--detailed``.
+
+Symbolic Links in ``/run/rauc``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Especially for use by other programs and services, RAUC creates symbolic links
+in ``/run/rauc`` during service startup.
+
+For example, on a system with A/B rootfs slots and corresponding appfs slots,
+``/run/rauc/slots/active/appfs`` would point to the appfs slot that corresponds
+to the booted rootfs.
+This could be used to mount the correct appfs without replicating the status
+determination already implemented in RAUC.
 
 React to a Successfully Booted System/Failed Boot
 -------------------------------------------------

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -9,6 +9,7 @@ mount -t sysfs none /sys
 mount -t debugfs debugfs /sys/kernel/debug/ || true
 mount -t tracefs tracefs /sys/kernel/tracing/ || true
 mount -t tmpfs none /mnt
+mount -t tmpfs none /run
 mount -t tmpfs none /tmp
 
 BUILD_DIR="build/"

--- a/src/main.c
+++ b/src/main.c
@@ -1451,7 +1451,7 @@ static gchar* r_status_formatter_shell(RaucStatusPrint *status)
 	formatter_shell_append(text, "RAUC_BOOT_PRIMARY", status->primary ? status->primary->name : NULL);
 
 	slotnames = g_ptr_array_new();
-	slotnumbers = g_ptr_array_new();
+	slotnumbers = g_ptr_array_new_with_free_func(g_free);
 	g_hash_table_iter_init(&iter, status->slots);
 	while (g_hash_table_iter_next(&iter, (gpointer*) &name, NULL)) {
 		g_ptr_array_add(slotnames, name);

--- a/src/main.c
+++ b/src/main.c
@@ -2001,6 +2001,33 @@ static gboolean status_start(int argc, char **argv)
 }
 
 G_GNUC_UNUSED
+static void create_run_links(void)
+{
+	g_autoptr(GError) ierror = NULL;
+	GHashTableIter iter;
+	RaucSlot *slot;
+
+	if (g_mkdir_with_parents("/run/rauc/slots/active", 0755) != 0) {
+		g_warning("Failed to create /run/rauc/slots/active");
+		return;
+	}
+
+	g_hash_table_iter_init(&iter, r_context()->config->slots);
+	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
+		g_autofree gchar* path = NULL;
+
+		if (!(slot->state & ST_ACTIVE))
+			continue;
+
+		path = g_build_filename("/run/rauc/slots/active", slot->sclass, NULL);
+
+		if (!r_update_symlink(slot->device, path, &ierror)) {
+			g_warning("Failed to create symlink for active slot: %s", ierror->message);
+		}
+	}
+}
+
+G_GNUC_UNUSED
 static gboolean service_start(int argc, char **argv)
 {
 	g_autoptr(GError) ierror = NULL;
@@ -2012,6 +2039,8 @@ static gboolean service_start(int argc, char **argv)
 		r_exit_status = 1;
 		return TRUE;
 	}
+
+	create_run_links();
 
 	if (r_context()->system_status) {
 		/* Boot ID-based system reboot vs service restart detection */

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -1200,6 +1200,10 @@ test_expect_success ROOT,SERVICE "rauc install" "
     --override-boot-slot=system0 &&
   test_when_finished stop_rauc_dbus_service_with_system &&
   test ! -s ${SHARNESS_TEST_DIRECTORY}/images/rootfs-1 &&
+  test -d /run/rauc/slots/active &&
+  test -L /run/rauc/slots/active/rootfs &&
+  readlink /run/rauc/slots/active/rootfs &&
+  test \"\$(readlink /run/rauc/slots/active/rootfs)\" = \"${SHARNESS_TEST_DIRECTORY}/images/rootfs-0\" &&
   rauc \
     install ${TEST_TMPDIR}/good-bundle.raucb &&
   test -s ${SHARNESS_TEST_DIRECTORY}/images/rootfs-1


### PR DESCRIPTION
This will be extended by artifact repository links later.