### PR TITLE
test/Dockerfile: remove python3-sphinxext-opengraph for now

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -y \
   slirp \
   python3-sphinx \
   python3-sphinx-rtd-theme \
-  python3-sphinxext-opengraph \
   dbus-x11 \
   user-mode-linux \
   grub-common \


### PR DESCRIPTION
We don't wan't to switch to bookworm yet, so don't try to install python3-sphinxext-opengraph (which is not available in bullseye).