### PR TITLE
test/Dockerfile: pin desync to version 0.9.3

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -51,10 +51,11 @@ RUN apt-get update && apt-get install -y \
   curl -sLo /usr/bin/codecov https://codecov.io/bash && \
   chmod +x /usr/bin/codecov
 
-# Install the optional desync
+# Install the optional desync (pinned to version 0.9.3)
 ENV GOPATH=/go
 RUN git clone https://github.com/folbricht/desync.git /tmp/desync && \
     cd /tmp/desync/cmd/desync && \
+    git checkout c508eeb0865a5a7c2c9b1158a5f0414265d869df && \
     go install && \
     cp /go/bin/desync /usr/bin/desync && \
     rm -rf /tmp/desync


### PR DESCRIPTION
Later versions fail to build with:
```
/go/pkg/mod/golang.org/x/crypto@v0.8.0/curve25519/curve25519_go120.go:9:8: package crypto/ecdh is not in GOROOT (/usr/lib/go-1.15/src/crypto/ecdh)
/go/pkg/mod/golang.org/x/net@v0.9.0/publicsuffix/table.go:5:8: package embed is not in GOROOT (/usr/lib/go-1.15/src/embed)
/go/pkg/mod/golang.org/x/net@v0.9.0/http2/transport.go:19:2: package io/fs is not in GOROOT (/usr/lib/go-1.15/src/io/fs)
```