### PR TITLE
src/main: more user-friendly output when no slot is activated

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1402,7 +1402,10 @@ static gchar* r_status_formatter_readable(RaucStatusPrint *status)
 	g_string_append_printf(text, "Booted from: %s (%s)\n\n", bootedfrom ? bootedfrom->name : NULL, status->bootslot);
 
 	g_string_append(text, "=== Bootloader ===\n");
-	g_string_append_printf(text, "Activated: %s (%s)\n\n", status->primary ? status->primary->name : NULL, status->primary ? status->primary->bootname : NULL);
+	if (!status->primary)
+		g_string_append_printf(text, "Activated: none\n\n");
+	else
+		g_string_append_printf(text, "Activated: %s (%s)\n\n", status->primary->name, status->primary->bootname);
 
 	g_string_append(text, "=== Slot States ===\n");
 	slotclasses = r_slot_get_root_classes(status->slots);


### PR DESCRIPTION
Instead of printing

> Activated: null (null)

which is not quite intuitive, print

> Activated: none

This also simplifies the logic a bit.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
