### PR TITLE
add meson wrap files for glib, json-glib and openssl

### DIFF
--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -1,0 +1,11 @@
+[wrap-file]
+directory = glib-2.76.4
+source_url = https://download.gnome.org/sources/glib/2.76/glib-2.76.4.tar.xz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/glib_2.76.4-1/glib-2.76.4.tar.xz
+source_filename = glib-2.76.4.tar.xz
+source_hash = 5a5a191c96836e166a7771f7ea6ca2b0069c603c7da3cba1cd38d1694a395dda
+wrapdb_version = 2.76.4-1
+
+[provide]
+dependency_names = gthread-2.0, gobject-2.0, gmodule-no-export-2.0, gmodule-export-2.0, gmodule-2.0, glib-2.0, gio-2.0, gio-windows-2.0, gio-unix-2.0
+program_names = glib-genmarshal, glib-mkenums, glib-compile-schemas, glib-compile-resources, gio-querymodules, gdbus-codegen

--- a/subprojects/json-glib.wrap
+++ b/subprojects/json-glib.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = json-glib-1.6.6
+source_url = https://download.gnome.org/sources/json-glib/1.6/json-glib-1.6.6.tar.xz
+source_fallback_url = https://ftp.acc.umu.se/pub/gnome/sources/json-glib/1.6/json-glib-1.6.6.tar.xz
+source_filename = json-glib-1.6.6.tar.xz
+source_hash = 96ec98be7a91f6dde33636720e3da2ff6ecbb90e76ccaa49497f31a6855a490e
+wrapdb_version = 1.6.6-2
+
+[provide]
+json-glib-1.0 = json_glib_dep

--- a/subprojects/openssl.wrap
+++ b/subprojects/openssl.wrap
@@ -1,0 +1,15 @@
+[wrap-file]
+directory = openssl-3.0.8
+source_url = https://www.openssl.org/source/openssl-3.0.8.tar.gz
+source_filename = openssl-3.0.8.tar.gz
+source_hash = 6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e
+patch_filename = openssl_3.0.8-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/openssl_3.0.8-1/get_patch
+patch_hash = 12d9c884174a91ccd1aa9230e9567c019f8a582ce46c98736f99a5200b4f2514
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/openssl_3.0.8-1/openssl-3.0.8.tar.gz
+wrapdb_version = 3.0.8-1
+
+[provide]
+libcrypto = libcrypto_dep
+libssl = libssl_dep
+openssl = openssl_dep


### PR DESCRIPTION
This allows us to build against a local copies of these dependencies (with --wrap-mode=forcefallback) and also supports static compilation for use in oss-fuzz.

These files were installed from meson's wrapdb.