### PR TITLE
src: detect config file change and warn in service log

### DIFF
--- a/include/config_file.h
+++ b/include/config_file.h
@@ -88,6 +88,7 @@ typedef struct {
 	GHashTable *slots;
 	/* flag to ensure slot states were determined */
 	gboolean slot_states_determined;
+	gchar *file_checksum;
 } RaucConfig;
 
 typedef enum {
@@ -164,3 +165,11 @@ G_GNUC_WARN_UNUSED_RESULT;
 void free_config(RaucConfig *config);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucConfig, free_config);
+
+/**
+ * Checks if the current file checksum of the system config matches the one currently loaded.
+ *
+ * Prints a warning if the checksums of the config file does not match the one
+ * recorded during config parsing.
+ */
+void r_config_file_modified_check(void);

--- a/src/service.c
+++ b/src/service.c
@@ -120,6 +120,8 @@ static gboolean r_on_handle_install_bundle(
 		goto out;
 	}
 
+	r_config_file_modified_check();
+
 	r_installer_set_operation(r_installer, "installing");
 	g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_installer));
 	res = install_run(args);
@@ -416,6 +418,8 @@ static gboolean r_on_handle_get_slot_status(RInstaller *interface,
 				"already processing a different method");
 		return TRUE;
 	}
+
+	r_config_file_modified_check();
 
 	slotstatus = create_slotstatus_array(&ierror);
 	if (!slotstatus) {


### PR DESCRIPTION
A common usage issue with RAUC is to change the system configuration but not to restart the rauc service to re-read the configuration.

To make this more obvious, at least in the service log output, this implements a simple checksum-based checking for changes in the system.conf.

On config file loading, the checksum of the original parsed configuration is cached and used as reference for later comparisons of re-calculated checksums.

The checker function r_config_file_sanity_check() that implements the comparison is used first of all in the service on calls of 'install' or 'status' actions and prints a warning.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
