### PR TITLE
Boot nor fallback

### DIFF
--- a/src/slot.c
+++ b/src/slot.c
@@ -146,6 +146,7 @@ RaucSlotType supported_slot_types[] = {
 	{"boot-gpt-switch", FALSE},
 	{"vfat", TRUE},
 	{"boot-raw-fallback", FALSE},
+	{"boot-nor-fallback", FALSE},
 	{}
 };
 


### PR DESCRIPTION
This PR adds a special handler that allows bootloader fallback updates on `nor` (aka. QSPI) flash.

The first patch implements this feature using the current version of flashcp. It will work on systems that check the full integrity of the bootloader before trying to load it. It will not work right on systems that only check the bootloader header. This is where the second patch comes in. It uses a new option in flashcp that delays writing of a specified amount of bytes till the very end.

I have written and [submitted the necessary patch](http://lists.infradead.org/pipermail/linux-mtd/2023-August/100952.html) to mtd-utils project.

The new slot type is called `boot-nor-fallback` and we pass two mtd devices to the handler by separating them with a colon `:`. First device is the **primary** and the second device is the **secondary**. Using two mtd devices avoids us having to also add the ability to write at an offset to `flashcp`.

Resolves: #1235 

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
