### PR TITLE
src/manifest: add missing return on error

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -250,6 +250,7 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 	if (raucm->handler_args && !raucm->handler_name) {
 		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
 				"Setting 'args' requires a full custom handler to be defined under 'filename' in group '[handler]'.");
+		return FALSE;
 	}
 	if (!check_remaining_keys(key_file, "handler", &ierror)) {
 		g_propagate_error(error, ierror);


### PR DESCRIPTION
Credit to OSS-Fuzz for finding this issue.

Fixes: 1e2d723f ("src/manifest: explicit error when using [handler] args without filename")