### PR TITLE
Fix installation of rauc.1 manpage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -227,7 +227,7 @@ dbuswrapperdir = get_option('libexecdir')
 
 install_data('src/de.pengutronix.rauc.Installer.xml', install_dir : dbusinterfacesdir)
 
-install_data('rauc.1', install_dir : get_option('mandir'))
+install_man('rauc.1')
 
 subdir('data')
 subdir('docs')


### PR DESCRIPTION
`install_data()` as currently used puts the manpage to `/usr/share/man/rauc.1`, however the right place is `/usr/share/man/man1/rauc.1`. Use the dedicated meson macro `install_man()` to get this right.


