### PR TITLE
.github: workflows: coverity: disable git unsafe directory check

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -29,6 +29,9 @@ jobs:
           exit
         fi
 
+        # Prevent git's unsafe directory check from failing
+        git config --global --add safe.directory "*"
+
         test/get-coverity.sh
 
         gcc --version


### PR DESCRIPTION
Otherwise job will fail with

>  fatal: detected dubious ownership in repository at '/__w/rauc/rauc' | To add an exception for this directory, call:
> 
> 	git config --global --add safe.directory /__w/rauc/rauc

since the container user is not the repository owner.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
