### PR TITLE
meson.build: do not install generated gdbus header file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -157,7 +157,6 @@ dbus_sources = gnome.gdbus_codegen(
   sources : dbus_ifaces,
   interface_prefix : 'de.pengutronix.rauc.',
   namespace : 'R',
-  install_header : true,
 )
 
 config_h = configure_file(


### PR DESCRIPTION
There is no reason to install the header file since the generated source file and the generated methods are only used internally.

For external use, we have the 'de.pengutronix.rauc.Installer.xml' file that can be used by the code generator of choice.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
