### PR TITLE
src/main: fix --no-verify usage for rauc resign

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -531,9 +531,8 @@ static gboolean resign_start(int argc, char **argv)
 	}
 
 	if (r_context()->certpath == NULL ||
-	    r_context()->keypath == NULL ||
-	    r_context()->keyringpath == NULL) {
-		g_printerr("Cert, key and keyring files must be provided\n");
+	    r_context()->keypath == NULL) {
+		g_printerr("Cert and key files must be provided\n");
 		r_exit_status = 1;
 		goto out;
 	}

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -973,7 +973,6 @@ test_expect_success FAKETIME "rauc resign extend (expired, no-verify)" "
     rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-1.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-1.pem \
-    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
     --no-verify \
     resign ${TEST_TMPDIR}/out1.raucb ${TEST_TMPDIR}/out2.raucb &&
   test -f ${TEST_TMPDIR}/out2.raucb


### PR DESCRIPTION
In 3272c7ba ("src/main: support --no-verify for rauc resign"), the `--no-verify` argument was added to 'rauc resign' to allow resigning a bundle without the need to verify against the keyring.

Due to the additional sanity check in src/main, it was however not possible to omit the keyring and thus this implicitly enforces a (possibly unexpected) post-signing verification.

A check for a missing keyring is implemented in check_bundle() anyway, thus the extra check in `resign_start()` is safe to omit.

To ensure this is also covered by testing, we simply omit the `--keyring` argument in the no-verify resigning test.
