### PR TITLE
meson: add htmldocs option for installing the docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,10 @@ jobs:
 
     - name: Build documentation
       run: |
-        meson compile doc -C build
+        rm -rf build/
+        meson setup -Dtests=false -Dhtmldocs=true build
+        meson configure build
+        meson compile -C build
 
     - name: Build CGI example
       run: |

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,4 +1,4 @@
-sphinx = find_program('sphinx-build', required: false)
+sphinx = find_program('sphinx-build', required: get_option('htmldocs'))
 
 if not sphinx.found()
   subdir_done()
@@ -27,5 +27,7 @@ custom_target(
   output: 'html',
   depend_files: sources_doc,
   command: [sphinx, '-b', 'html', meson.current_source_dir(), meson.current_build_dir() / 'html'],
-  build_by_default: false
+  build_by_default: get_option('htmldocs'),
+  install_dir: join_paths(datadir, 'doc', 'rauc'),
+  install: get_option('htmldocs'),
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -61,6 +61,11 @@ option(
 
 # build options
 option(
+  'htmldocs',
+  type : 'boolean',
+  value : 'false',
+  description : 'Enable/Disable HTML documentation')
+option(
   'tests',
   type : 'boolean',
   value : 'true',


### PR DESCRIPTION
Currently there is a limited set of documentation installed by default. We already have the sphinx docs wired into the meson build, although there is no way for the end-user to install them.

Add an `htmldocs` option which guards both build and install of the docs. Thus people can opt out of, even if they have sphinx installed.

Issue: https://github.com/rauc/rauc/issues/1251
---
Thanks for wiring up sphinx to the meson build team. I've secretly waited for the autotools build to be merged, since wiring that wasn't fun :-P

Silliness aside, this PR addresses half the referenced issue hence why I didn't use "Fixes".