### PR TITLE
Add 'crypt' Bundle Support to 'resign' and 'replace-signature' Subcommands

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1286,10 +1286,6 @@ gboolean encrypt_bundle(RaucBundle *bundle, const gchar *outbundle, GError **err
 	GError *ierror = NULL;
 	GBytes *encdata = NULL;
 	gboolean res = FALSE;
-	g_autoptr(GFile) bundlefile = NULL;
-	g_autoptr(GFileIOStream) bundlestream = NULL;
-	GOutputStream *bundleoutstream = NULL; /* owned by the bundle stream */
-	guint64 offset;
 
 	g_return_val_if_fail(bundle != NULL, FALSE);
 	g_return_val_if_fail(outbundle != NULL, FALSE);
@@ -1316,28 +1312,6 @@ gboolean encrypt_bundle(RaucBundle *bundle, const gchar *outbundle, GError **err
 		goto out;
 	}
 
-	bundlefile = g_file_new_for_path(outbundle);
-	bundlestream = g_file_open_readwrite(bundlefile, NULL, &ierror);
-	if (bundlestream == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed to open bundle for encryption: ");
-		res = FALSE;
-		goto out;
-	}
-	bundleoutstream = g_io_stream_get_output_stream(G_IO_STREAM(bundlestream));
-
-	if (!g_seekable_seek(G_SEEKABLE(bundlestream),
-			0, G_SEEK_END, NULL, &ierror)) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed to seek to end of bundle: ");
-		res = FALSE;
-		goto out;
-	}
-
 	/* encrypt sigdata CMS */
 	encdata = cms_encrypt(bundle->sigdata, r_context()->recipients, &ierror);
 	if (encdata == NULL) {
@@ -1349,35 +1323,15 @@ gboolean encrypt_bundle(RaucBundle *bundle, const gchar *outbundle, GError **err
 		goto out;
 	}
 
-	offset = g_seekable_tell(G_SEEKABLE(bundlestream));
-	g_debug("Signature offset: %" G_GUINT64_FORMAT " bytes.", offset);
-	if (!output_stream_write_bytes_all(bundleoutstream, encdata, NULL, &ierror)) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed to append encrypted signature to bundle: ");
-		res = FALSE;
+	res = append_signature_to_bundle(outbundle, encdata, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
 		goto out;
 	}
-
-	offset = g_seekable_tell(G_SEEKABLE(bundlestream)) - offset;
-	if (!output_stream_write_uint64_all(bundleoutstream, offset, NULL, &ierror)) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed to append size of encrypted signature to bundle: ");
-		res = FALSE;
-		goto out;
-	}
-	g_debug("Signature size: %" G_GUINT64_FORMAT " bytes.", offset);
-
-	offset = g_seekable_tell(G_SEEKABLE(bundlestream));
-	g_debug("Bundle size: %" G_GUINT64_FORMAT " bytes.", offset);
 
 out:
 	/* clean encrypted bundle on failure */
 	if (!res) {
-		g_clear_object(&bundlestream); /* enforce closing stream */
 		if (g_file_test(outbundle, G_FILE_TEST_IS_REGULAR)) {
 			if (g_remove(outbundle) != 0)
 				g_warning("Failed to remove %s", outbundle);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -990,7 +990,8 @@ out:
 
 gboolean resign_bundle(RaucBundle *bundle, const gchar *outpath, GError **error)
 {
-	g_autoptr(RaucManifest) manifest = NULL;
+	g_autoptr(RaucManifest) loaded_manifest = NULL;
+	RaucManifest *manifest = NULL; /* alias pointer, not to be freed */
 	goffset squashfs_size;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
@@ -1010,10 +1011,15 @@ gboolean resign_bundle(RaucBundle *bundle, const gchar *outpath, GError **error)
 		goto out;
 	}
 
-	res = load_manifest_from_bundle(bundle, &manifest, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
+	if (bundle->manifest) {
+		manifest = bundle->manifest;
+	} else {
+		res = load_manifest_from_bundle(bundle, &loaded_manifest, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			goto out;
+		}
+		manifest = loaded_manifest;
 	}
 
 	if (manifest->bundle_format == R_MANIFEST_FORMAT_PLAIN) {

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2391,6 +2391,7 @@ gboolean extract_bundle(RaucBundle *bundle, const gchar *outputdir, GError **err
 	gboolean res = FALSE;
 
 	g_return_val_if_fail(bundle != NULL, FALSE);
+	g_return_val_if_fail(outputdir != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	r_context_begin_step("extract_bundle", "Extracting bundle", 2);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -715,6 +715,14 @@ static gboolean sign_bundle(const gchar *bundlename, RaucManifest *manifest, GEr
 	g_assert_nonnull(r_context()->certpath);
 	g_assert_nonnull(r_context()->keypath);
 
+	if ((manifest->bundle_format == R_MANIFEST_FORMAT_VERITY) || (manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT)) {
+
+		if (!create_verity(bundlename, manifest, &ierror)) {
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
+	}
+
 	if (manifest->bundle_format == R_MANIFEST_FORMAT_PLAIN) {
 		g_print("Creating bundle in 'plain' format\n");
 
@@ -739,12 +747,6 @@ static gboolean sign_bundle(const gchar *bundlename, RaucManifest *manifest, GEr
 			return FALSE;
 		}
 	} else if ((manifest->bundle_format == R_MANIFEST_FORMAT_VERITY) || (manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT)) {
-
-		if (!create_verity(bundlename, manifest, &ierror)) {
-			g_propagate_error(error, ierror);
-			return FALSE;
-		}
-
 		g_print("Creating bundle in '%s' format\n", r_manifest_bundle_format_to_str(manifest->bundle_format));
 
 		if (!check_manifest_external(manifest, &ierror)) {

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2255,12 +2255,6 @@ gboolean replace_signature(RaucBundle *bundle, const gchar *insig, const gchar *
 		return FALSE;
 	}
 
-	res = check_bundle_payload(bundle, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
-	}
-
 	if (bundle->manifest) {
 		manifest = bundle->manifest;
 	} else {

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1025,8 +1025,8 @@ gboolean resign_bundle(RaucBundle *bundle, const gchar *outpath, GError **error)
 	if (manifest->bundle_format == R_MANIFEST_FORMAT_PLAIN) {
 		g_print("Reading bundle in 'plain' format\n");
 		squashfs_size = bundle->size;
-	} else if (manifest->bundle_format == R_MANIFEST_FORMAT_VERITY) {
-		g_print("Reading bundle in 'verity' format\n");
+	} else if (manifest->bundle_format == R_MANIFEST_FORMAT_VERITY || manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT) {
+		g_print("Reading bundle in '%s' format\n", manifest->bundle_format == R_MANIFEST_FORMAT_VERITY ? "verity" : "crypt");
 		g_assert(bundle->size > (goffset)manifest->bundle_verity_size);
 		squashfs_size = bundle->size - manifest->bundle_verity_size;
 	} else {

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -716,8 +716,6 @@ static GBytes *generate_bundle_signature(const gchar *bundlename, RaucManifest *
 	g_assert_nonnull(r_context()->keypath);
 
 	if (manifest->bundle_format == R_MANIFEST_FORMAT_PLAIN) {
-		g_print("Creating bundle in 'plain' format\n");
-
 		if (!check_manifest_internal(manifest, &ierror)) {
 			g_propagate_prefixed_error(
 					error,
@@ -739,8 +737,6 @@ static GBytes *generate_bundle_signature(const gchar *bundlename, RaucManifest *
 			return NULL;
 		}
 	} else if ((manifest->bundle_format == R_MANIFEST_FORMAT_VERITY) || (manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT)) {
-		g_print("Creating bundle in '%s' format\n", r_manifest_bundle_format_to_str(manifest->bundle_format));
-
 		if (!check_manifest_external(manifest, &ierror)) {
 			g_propagate_prefixed_error(
 					error,
@@ -948,6 +944,8 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 		goto out;
 	}
 
+	g_print("Creating '%s' format bundle\n", r_manifest_bundle_format_to_str(manifest->bundle_format));
+
 	/* print warnings collected while parsing */
 	for (guint i =  0; i < manifest->warnings->len; i++) {
 		g_print("%s\n", (gchar *)g_ptr_array_index(manifest->warnings, i));
@@ -1095,16 +1093,7 @@ gboolean resign_bundle(RaucBundle *bundle, const gchar *outpath, GError **error)
 		manifest = loaded_manifest;
 	}
 
-	if (manifest->bundle_format == R_MANIFEST_FORMAT_PLAIN) {
-		g_print("Reading bundle in 'plain' format\n");
-	} else if (manifest->bundle_format == R_MANIFEST_FORMAT_VERITY || manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT) {
-		g_print("Reading bundle in '%s' format\n", manifest->bundle_format == R_MANIFEST_FORMAT_VERITY ? "verity" : "crypt");
-		g_assert(bundle->size > (goffset)manifest->bundle_verity_size);
-	} else {
-		g_error("unsupported bundle format");
-		res = FALSE;
-		goto out;
-	}
+	g_print("Resigning '%s' format bundle\n", r_manifest_bundle_format_to_str(manifest->bundle_format));
 
 	res = truncate_bundle(bundle->path, outpath, bundle->size, &ierror);
 	if (!res) {
@@ -2289,17 +2278,7 @@ gboolean replace_signature(RaucBundle *bundle, const gchar *insig, const gchar *
 		manifest = loaded_manifest;
 	}
 
-	if (manifest->bundle_format == R_MANIFEST_FORMAT_PLAIN) {
-		g_print("Reading bundle in 'plain' format\n");
-	} else if (manifest->bundle_format == R_MANIFEST_FORMAT_VERITY) {
-		g_print("Reading bundle in 'verity' format\n");
-	} else if (manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT) {
-		g_print("Reading bundle in 'crypt' format\n");
-	} else {
-		g_error("unsupported bundle format");
-		res = FALSE;
-		goto out;
-	}
+	g_print("Replacing signature for '%s format bundle\n", r_manifest_bundle_format_to_str(manifest->bundle_format));
 
 	sig = read_file(insig, &ierror);
 	if (!sig) {

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2270,6 +2270,8 @@ gboolean replace_signature(RaucBundle *bundle, const gchar *insig, const gchar *
 		g_print("Reading bundle in 'plain' format\n");
 	} else if (manifest->bundle_format == R_MANIFEST_FORMAT_VERITY) {
 		g_print("Reading bundle in 'verity' format\n");
+	} else if (manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT) {
+		g_print("Reading bundle in 'crypt' format\n");
 	} else {
 		g_error("unsupported bundle format");
 		res = FALSE;

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -898,8 +898,15 @@ test_expect_success "rauc resign" "
   rauc \
     --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
     --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
-    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
-    resign ${TEST_TMPDIR}/good-bundle.raucb ${TEST_TMPDIR}/out.raucb &&
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
+    resign ${TEST_TMPDIR}/good-bundle.raucb ${TEST_TMPDIR}/out.raucb \
+    --signing-keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-only-ca.pem && \
+  test_must_fail rauc \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
+    info ${TEST_TMPDIR}/out.raucb && \
+  rauc \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-only-ca.pem \
+    info ${TEST_TMPDIR}/out.raucb && \
   test -f ${TEST_TMPDIR}/out.raucb
 "
 

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -910,6 +910,44 @@ test_expect_success "rauc resign" "
   test -f ${TEST_TMPDIR}/out.raucb
 "
 
+test_expect_success "rauc resign (verity bundle)" "
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-verity-bundle.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-verity-bundle.raucb &&
+  rm -f ${TEST_TMPDIR}/out.raucb &&
+  rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
+    resign ${TEST_TMPDIR}/good-verity-bundle.raucb ${TEST_TMPDIR}/out.raucb \
+    --signing-keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-only-ca.pem && \
+  test_must_fail rauc \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
+    info ${TEST_TMPDIR}/out.raucb && \
+  rauc \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-only-ca.pem \
+    info ${TEST_TMPDIR}/out.raucb && \
+  test -f ${TEST_TMPDIR}/out.raucb
+"
+
+test_expect_success "rauc resign (crypt bundle)" "
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-crypt-bundle-unencrypted.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-crypt-bundle-unencrypted.raucb &&
+  rm -f ${TEST_TMPDIR}/out.raucb &&
+  rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/release-1.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/rel/private/release-1.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-only-ca.pem \
+    resign ${TEST_TMPDIR}/good-crypt-bundle-unencrypted.raucb ${TEST_TMPDIR}/out.raucb \
+    --signing-keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem && \
+  test_must_fail rauc \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-only-ca.pem \
+    info ${TEST_TMPDIR}/out.raucb && \
+  rauc \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/rel-ca.pem \
+    info ${TEST_TMPDIR}/out.raucb && \
+  test -f ${TEST_TMPDIR}/out.raucb
+"
+
 test_expect_success "rauc resign (output exists)" "
   cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
   test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -1071,6 +1071,30 @@ test_expect_success OPENSSL "rauc replace signature (verity)" "
   test -f ${TEST_TMPDIR}/out2.raucb
 "
 
+test_expect_success OPENSSL "rauc replace signature (crypt)" "
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-crypt-bundle-unencrypted.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-crypt-bundle-unencrypted.raucb &&
+  rm -f ${TEST_TMPDIR}/out1.raucb && rm -f ${TEST_TMPDIR}/out2.raucb &&
+  rm -f $TEST_TMPDIR/bundle.sig &&
+  rauc \
+    --cert $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/autobuilder-1.cert.pem \
+    --key $SHARNESS_TEST_DIRECTORY/openssl-ca/dev/private/autobuilder-1.pem \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+    resign ${TEST_TMPDIR}/good-crypt-bundle-unencrypted.raucb ${TEST_TMPDIR}/out1.raucb \
+    --signing-keyring ${SHARNESS_TEST_DIRECTORY}/openssl-ca/dev-only-ca.pem &&
+  test -f ${TEST_TMPDIR}/out1.raucb &&
+  rauc \
+    --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-only-ca.pem \
+    extract-signature ${TEST_TMPDIR}/out1.raucb ${TEST_TMPDIR}/bundle.sig &&
+  test -f ${TEST_TMPDIR}/bundle.sig &&
+  openssl asn1parse -inform DER -in ${TEST_TMPDIR}/bundle.sig -noout > /dev/null 2>&1 &&
+  rauc \
+    --keyring ${SHARNESS_TEST_DIRECTORY}/openssl-ca/dev-ca.pem \
+    replace-signature ${TEST_TMPDIR}/good-crypt-bundle-unencrypted.raucb ${TEST_TMPDIR}/bundle.sig ${TEST_TMPDIR}/out2.raucb \
+    --signing-keyring ${SHARNESS_TEST_DIRECTORY}/openssl-ca/dev-only-ca.pem &&
+  test -f ${TEST_TMPDIR}/out2.raucb
+"
+
 test_expect_success OPENSSL "rauc replace signature (output exists)" "
   cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
   test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&


### PR DESCRIPTION
So far, `rauc resign` and `rauc replace-signature` did not support crypt bundles.

While fixing some underlying inconsistencies, this PR adds support for both.

- [x] add tests