### PR TITLE
simplify subprocess handling

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -61,6 +61,18 @@ static inline GSubprocess * r_subprocess_launcher_spawnv(GSubprocessLauncher *la
 GSubprocess *r_subprocess_new(GSubprocessFlags flags, GError **error, const gchar *argv0, ...)
 G_GNUC_WARN_UNUSED_RESULT;
 
+/**
+ * Starts a subprocess and waits for it to finish.
+ *
+ * @param args subprocess arguments
+ * @param flags subprocess flags
+ * @param error return location for a GError, or NULL
+ *
+ * @return TRUE on success, FALSE if an error occurred
+ */
+gboolean r_subprocess_runv(GPtrArray *args, GSubprocessFlags flags, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
 #define R_LOG_LEVEL_TRACE 1 << G_LOG_LEVEL_USER_SHIFT
 #define r_trace(...)   g_log(G_LOG_DOMAIN,         \
 		R_LOG_LEVEL_TRACE,    \

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -102,7 +102,6 @@ r_bundle_error_quark(void)
 
 static gboolean mksquashfs(const gchar *bundlename, const gchar *contentdir, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(7, g_free);
@@ -141,18 +140,7 @@ static gboolean mksquashfs(const gchar *bundlename, const gchar *contentdir, GEr
 	}
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE,
-			&ierror);
-	if (sproc == NULL) {
-		res = FALSE;
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed to start mksquashfs: ");
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
@@ -169,7 +157,6 @@ out:
 
 static gboolean unsquashfs(gint fd, const gchar *contentdir, const gchar *extractfile, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(7, g_free);
@@ -190,16 +177,7 @@ static gboolean unsquashfs(gint fd, const gchar *contentdir, const gchar *extrac
 
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
-	if (sproc == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed to start unsquashfs: ");
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
@@ -218,7 +196,6 @@ static gboolean casync_make_blob(const gchar *idxpath, const gchar *contentpath,
 
 static gboolean casync_make_arch(const gchar *idxpath, const gchar *contentpath, const gchar *store, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	GPtrArray *args = g_ptr_array_new_full(15, g_free);
@@ -281,17 +258,7 @@ static gboolean casync_make_arch(const gchar *idxpath, const gchar *contentpath,
 	g_ptr_array_add(args, g_strjoinv(" ", (gchar**) g_ptr_array_free(iargs, FALSE)));
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
-	if (sproc == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed to start casync: ");
-		res = FALSE;
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
@@ -307,7 +274,6 @@ out:
 
 static gboolean casync_make_blob(const gchar *idxpath, const gchar *contentpath, const gchar *store, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	GPtrArray *args = g_ptr_array_new_full(5, g_free);
@@ -379,17 +345,7 @@ static gboolean casync_make_blob(const gchar *idxpath, const gchar *contentpath,
 	}
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
-	if (sproc == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed to start casync: ");
-		res = FALSE;
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,

--- a/src/mount.c
+++ b/src/mount.c
@@ -56,7 +56,6 @@ gboolean r_umount_bundle(const gchar *mountpoint, GError **error)
 
 gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar* type, const gchar* extra_options, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(10, g_free);
@@ -88,16 +87,7 @@ gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar*
 	g_ptr_array_add(args, g_strdup(mountpoint));
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
-	if (sproc == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"failed to start mount: ");
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
@@ -241,7 +231,6 @@ out:
 
 gboolean r_umount(const gchar *filename, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(10, g_free);
@@ -253,16 +242,7 @@ gboolean r_umount(const gchar *filename, GError **error)
 	g_ptr_array_add(args, g_strdup(filename));
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
-	if (sproc == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"failed to start umount: ");
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -946,7 +946,6 @@ raw_copy:
 
 static gboolean ubifs_format_slot(RaucSlot *dest_slot, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(3, g_free);
@@ -956,16 +955,7 @@ static gboolean ubifs_format_slot(RaucSlot *dest_slot, GError **error)
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
-	if (sproc == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"failed to start mkfs.ubifs: ");
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
@@ -980,7 +970,6 @@ out:
 
 static gboolean ext4_resize_slot(RaucSlot *dest_slot, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(3, g_free);
@@ -989,16 +978,7 @@ static gboolean ext4_resize_slot(RaucSlot *dest_slot, GError **error)
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
-	if (sproc == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"Failed to start resize2fs: ");
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
@@ -1013,7 +993,6 @@ out:
 
 static gboolean ext4_format_slot(RaucSlot *dest_slot, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(4, g_free);
@@ -1028,16 +1007,7 @@ static gboolean ext4_format_slot(RaucSlot *dest_slot, GError **error)
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
-	if (sproc == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"failed to start mkfs.ext4: ");
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
@@ -1096,7 +1066,6 @@ static gchar* vfat_label_generator(const gchar *name)
 
 static gboolean vfat_format_slot(RaucSlot *dest_slot, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(4, g_free);
@@ -1107,16 +1076,7 @@ static gboolean vfat_format_slot(RaucSlot *dest_slot, GError **error)
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
-	if (sproc == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"failed to start mkfs.vfat: ");
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
@@ -1131,7 +1091,6 @@ out:
 
 static gboolean nor_write_slot(const gchar *image, const gchar *device, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(5, g_free);
@@ -1141,16 +1100,7 @@ static gboolean nor_write_slot(const gchar *image, const gchar *device, GError *
 	g_ptr_array_add(args, g_strdup(device));
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
-	if (sproc == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"failed to start flashcp: ");
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,
@@ -1165,7 +1115,6 @@ out:
 
 static gboolean flash_format_slot(const gchar *device, GError **error)
 {
-	g_autoptr(GSubprocess) sproc = NULL;
 	GError *ierror = NULL;
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(5, g_free);
@@ -1177,16 +1126,7 @@ static gboolean flash_format_slot(const gchar *device, GError **error)
 	g_ptr_array_add(args, g_strdup("0"));
 	g_ptr_array_add(args, NULL);
 
-	sproc = r_subprocess_newv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
-	if (sproc == NULL) {
-		g_propagate_prefixed_error(
-				error,
-				ierror,
-				"failed to start flash_erase: ");
-		goto out;
-	}
-
-	res = g_subprocess_wait_check(sproc, NULL, &ierror);
+	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
 	if (!res) {
 		g_propagate_prefixed_error(
 				error,

--- a/src/utils.c
+++ b/src/utils.c
@@ -42,6 +42,28 @@ GSubprocess *r_subprocess_new(GSubprocessFlags flags, GError **error, const gcha
 	return result;
 }
 
+gboolean r_subprocess_runv(GPtrArray *args, GSubprocessFlags flags, GError **error)
+{
+	g_autoptr(GSubprocess) sproc = NULL;
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(args != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	sproc = r_subprocess_newv(args, flags, &ierror);
+	if (sproc == NULL) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	if (!g_subprocess_wait_check(sproc, NULL, &ierror)) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
 void close_preserve_errno(int fd)
 {
 	int err;


### PR DESCRIPTION
We often run external tools without the need to communicate with them while running.
So add a helper which calls `r_subprocess_newv()` and `g_subprocess_wait_check()` instead of duplicating that everywhere.