### PR TITLE
test/service: simplify service fixture setup

### DIFF
--- a/test/service.c
+++ b/test/service.c
@@ -24,7 +24,7 @@ typedef struct {
 GMainLoop *testloop = NULL;
 RInstaller *installer = NULL;
 
-static void service_install_fixture_set_up(ServiceFixture *fixture, gconstpointer user_data)
+static void service_fixture_set_up(ServiceFixture *fixture, gconstpointer user_data)
 {
 	g_autofree gchar *contents = NULL;
 	g_autofree gchar *filename = NULL;
@@ -32,12 +32,6 @@ static void service_install_fixture_set_up(ServiceFixture *fixture, gconstpointe
 	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
 
 	fixture_helper_set_up_system(fixture->tmpdir, NULL);
-	fixture_helper_set_up_bundle(fixture->tmpdir, NULL,
-			&(ManifestTestOptions) {
-		.custom_handler = FALSE,
-		.hooks = FALSE,
-		.slots = TRUE,
-	});
 
 	/* Write a D-Bus service file with current tmpdir */
 	contents = g_strdup_printf("\
@@ -51,22 +45,17 @@ Exec="TEST_SERVICES "/rauc -c %s/system.conf --mount=%s/mount --override-boot-sl
 	g_test_dbus_add_service_dir(fixture->dbus, fixture->tmpdir);
 	g_test_dbus_up(fixture->dbus);
 }
-static void service_info_fixture_set_up(ServiceFixture *fixture, gconstpointer user_data)
+
+static void service_install_fixture_set_up(ServiceFixture *fixture, gconstpointer user_data)
 {
-	g_autofree gchar *filename = NULL;
+	service_fixture_set_up(fixture, user_data);
 
-	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
-
-	/* Write a D-Bus service file with current tmpdir */
-	filename = write_tmp_file(fixture->tmpdir, "de.pengutronix.rauc.service", "\
-[D-BUS Service]\n\
-Name=de.pengutronix.rauc\n\
-Exec="TEST_SERVICES "/rauc -c test/test.conf --override-boot-slot=system0 service\n", NULL);
-	(void)filename;
-
-	fixture->dbus = g_test_dbus_new(G_TEST_DBUS_NONE);
-	g_test_dbus_add_service_dir(fixture->dbus, fixture->tmpdir);
-	g_test_dbus_up(fixture->dbus);
+	fixture_helper_set_up_bundle(fixture->tmpdir, NULL,
+			&(ManifestTestOptions) {
+		.custom_handler = FALSE,
+		.hooks = FALSE,
+		.slots = TRUE,
+	});
 }
 
 static void service_fixture_tear_down(ServiceFixture *fixture, gconstpointer user_data)
@@ -478,15 +467,15 @@ int main(int argc, char *argv[])
 			service_fixture_tear_down);
 
 	g_test_add("/service/info-bundle", ServiceFixture, NULL,
-			service_info_fixture_set_up, service_test_info_bundle,
+			service_fixture_set_up, service_test_info_bundle,
 			service_fixture_tear_down);
 
 	g_test_add("/service/info-deprecated", ServiceFixture, NULL,
-			service_info_fixture_set_up, service_test_info_deprecated,
+			service_fixture_set_up, service_test_info_deprecated,
 			service_fixture_tear_down);
 
 	g_test_add("/service/slot-status", ServiceFixture, NULL,
-			service_info_fixture_set_up, service_test_slot_status,
+			service_fixture_set_up, service_test_slot_status,
 			service_fixture_tear_down);
 
 	return g_test_run();


### PR DESCRIPTION
We need the same system setup in both cases, but the bundle in only one of them. Refactor the fixtures into a generic one (`service_fixture_set_up`) and one for install tests (`service_install_fixture_set_up`).