### PR TITLE
List Available Format Options for `rauc info` and `rauc status`

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -68,11 +68,11 @@ Obtaining Bundle Information
 The ``info`` command lists the basic meta data of a bundle (compatible, version,
 build-id, description) and the images and hooks contained in the bundle.
 
-You can control the output format depending on your needs.
-By default it will print a human readable representation of the bundle not
-intended for being processed programmatically.
-Alternatively you can obtain a shell-parsable description or a JSON
-representation of the bundle content.
+You can control the output ``<format>`` depending on your needs.
+By default (or with ``readable``), it will print a human readable representation of the
+bundle not intended for being processed programmatically.
+Alternatively, with ``shell`` you can obtain a shell-parsable description or a JSON
+representation of the bundle content with ``json-2``.
 
 Installing Bundles
 ------------------
@@ -97,10 +97,11 @@ The ``status`` command allows this:
 
   rauc status [--detailed] [--output-format=<format>]
 
-You can choose the output style of RAUC status depending on your needs.
-By default it will print a human readable representation of your system's most
-important properties. Alternatively you can obtain a shell-parsable description,
-or a JSON representation of the system status.
+You can choose the output ``<format>`` depending on your needs.
+By default (or with ``readable``), it will print a human readable representation
+of your system's most important properties.
+Alternatively, with ``shell`` you can obtain a shell-parsable description,
+or with ``json`` or ``json-pretty`` a JSON representation of the system status.
 If more information is needed such as the slots' :ref:`status <slot-status>` add
 the command line option ``--detailed``.
 

--- a/src/main.c
+++ b/src/main.c
@@ -2219,7 +2219,7 @@ static GOptionEntry entries_info[] = {
 	{"no-verify", '\0', 0, G_OPTION_ARG_NONE, &verification_disabled, "disable bundle verification", NULL},
 	{"no-check-time", '\0', 0, G_OPTION_ARG_NONE, &no_check_time, "don't check validity period of certificates against current time", NULL},
 	{"key", '\0', G_OPTION_FLAG_NOALIAS, G_OPTION_ARG_FILENAME, &keypath, "decryption key file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
-	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format", "FORMAT"},
+	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format (readable, shell, json, json-pretty, json-2)", "FORMAT"},
 	{"dump-cert", '\0', 0, G_OPTION_ARG_NONE, &info_dumpcert, "dump certificate", NULL},
 	{"dump-recipients", '\0', 0, G_OPTION_ARG_NONE, &info_dumprecipients, "dump recipients", NULL},
 	{0}
@@ -2227,7 +2227,7 @@ static GOptionEntry entries_info[] = {
 
 static GOptionEntry entries_status[] = {
 	{"detailed", '\0', 0, G_OPTION_ARG_NONE, &status_detailed, "show more status details", NULL},
-	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format", "FORMAT"},
+	{"output-format", '\0', 0, G_OPTION_ARG_STRING, &output_format, "output format (readable, shell, json, json-pretty)", "FORMAT"},
 #if ENABLE_SERVICE == 0
 	{"override-boot-slot", '\0', 0, G_OPTION_ARG_STRING, &bootslot, "override auto-detection of booted slot", "BOOTNAME"},
 #endif


### PR DESCRIPTION
These were listed only in the man page so far and are thus hard to guess for users.