### PR TITLE
test/common: add test_lstat helper

### DIFF
--- a/test/common.c
+++ b/test/common.c
@@ -151,6 +151,19 @@ int test_remove(const gchar *dirname, const gchar *filename)
 	return res;
 }
 
+int test_lstat(const gchar *dirname, const gchar *filename, GStatBuf *buf)
+{
+	g_autofree gchar *path = NULL;
+	int res;
+
+	path = g_build_filename(dirname, filename, NULL);
+	g_assert_nonnull(path);
+
+	res = g_lstat(path, buf);
+
+	return res;
+}
+
 gboolean test_rm_tree(const gchar *dirname, const gchar *filename)
 {
 	g_autofree gchar *path = NULL;

--- a/test/common.h
+++ b/test/common.h
@@ -2,6 +2,7 @@
 
 #include <glib.h>
 
+#include "glib/gstdio.h"
 #include "manifest.h"
 
 typedef struct {
@@ -20,6 +21,7 @@ int test_prepare_dummy_file(const gchar *dirname, const gchar *filename,
 int test_mkdir_relative(const gchar *dirname, const gchar *filename, int mode);
 int test_rmdir(const gchar *dirname, const gchar *filename);
 int test_remove(const gchar *dirname, const gchar *filename);
+int test_lstat(const gchar *dirname, const gchar *filename, GStatBuf *buf);
 gboolean test_rm_tree(const gchar *dirname, const gchar *filename);
 int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, const ManifestTestOptions *options);
 gboolean test_make_filesystem(const gchar *dirname, const gchar *filename);


### PR DESCRIPTION
This will be used for artifact installation tests, where we need to check if file ownership and created device nodes are correct.