### PR TITLE
Implement Actual Log Events for Configurable Event Logging

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -15,6 +15,7 @@
 #include "bootchooser.h"
 #include "bundle.h"
 #include "context.h"
+#include "event_log.h"
 #include "install.h"
 #include "manifest.h"
 #include "mark.h"
@@ -1024,6 +1025,7 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 	r_context_end_step("check_slot", TRUE);
 
 	install_args_update(args, "Updating slot %s", plan->target_slot->name);
+	r_event_log_message(R_EVENT_LOG_TYPE_WRITE_SLOT, "Updating slot %s", plan->target_slot->name);
 
 	/* update slot */
 	if (plan->image->hooks.install) {

--- a/test/install.c
+++ b/test/install.c
@@ -1185,7 +1185,7 @@ static void install_test_bundle_hook_install_check(InstallFixture *fixture,
 	args->notify = install_notify;
 	args->cleanup = install_cleanup;
 	g_assert_false(do_install_bundle(args, &ierror));
-	g_assert_cmpstr(ierror->message, ==, "Installation error: Bundle rejected: Hook returned: No, I won't install this!");
+	g_assert_cmpstr(ierror->message, ==, "Bundle rejected: Hook returned: No, I won't install this!");
 
 	args->status_result = 0;
 	args->cleanup(args);


### PR DESCRIPTION
While #1230 provided the framework for configurable event logging, this now aims to implement the actual events to log.

The list of events logged:

* system boot or service start
* slot update
* installation start
* installation success/failure/reject
* slot marking (good/bad/active)

Most events have a distinct MESSAGE_ID to allow identifying them (e.g. for later systemd catalog entry handling).

This is the first proposal of event items to log.

<details>
<summary>example human-readable log file content</summary>

```
2023-12-20T11:32:15Z: Booted into rootfs.0 (A)
                      boot ID: 55304525-445b-45b2-95e3-71d6646ca437
                      bundle hash: unknown
2023-12-20T11:32:16Z: Marked slot rootfs.0 good
2023-12-20T11:32:33Z: Service restarted
2023-12-20T11:33:56Z: Installation 871dbf94 started
                      transaction ID: 871dbf94-75cf-4a6a-b3de-6b81d2013d9e
2023-12-20T11:33:56Z: Marked slot rootfs.1 bad
2023-12-20T11:33:56Z: Updating slot efi.0
2023-12-20T11:34:17Z: Updating slot rootfs.1
2023-12-20T11:35:05Z: Marked slot rootfs.1 active
                      bundle hash: ee3f0b6649cd1425efe69c3947f7c5e862ce0e3f91cb4d36904a1e99c2bff110
                      bootname: B
2023-12-20T11:35:06Z: Installation 871dbf94 succeeded
                      bundle hash: ee3f0b6649cd1425efe69c3947f7c5e862ce0e3f91cb4d36904a1e99c2bff110
                      bundle version: 1.0
                      transaction ID: 871dbf94-75cf-4a6a-b3de-6b81d2013d9e
2023-12-20T11:35:50Z: Booted into rootfs.1 (B)
                      boot ID: 3850cffb-2eca-4960-b682-ec95bd5a222c
                      bundle hash: ee3f0b6649cd1425efe69c3947f7c5e862ce0e3f91cb4d36904a1e99c2bff110
2023-12-20T11:35:51Z: Marked slot rootfs.1 good
2023-12-20T11:37:58Z: Marked slot rootfs.1 bad
2023-12-20T11:38:35Z: Booted into rootfs.0 (A)
                      boot ID: bdc77e95-da79-4ade-a122-15c5ff302e6b
                      bundle hash: unknown
2023-12-20T11:38:37Z: Marked slot rootfs.0 good
2023-12-20T11:41:34Z: Installation 5b1e12db started
                      transaction ID: 5b1e12db-2c7e-416a-8c9e-245fe0497f4c
2023-12-20T11:41:34Z: Marked slot rootfs.1 bad
2023-12-20T11:41:34Z: Updating slot efi.0
2023-12-20T11:42:19Z: Service restarted
2023-12-20T11:43:43Z: Installation 3d7084a4 started
                      transaction ID: 3d7084a4-44e9-4631-9073-94d2b8a6d1c6
2023-12-20T11:43:44Z: Marked slot rootfs.1 bad
2023-12-20T11:43:44Z: Updating slot efi.0
2023-12-20T11:44:06Z: Updating slot rootfs.1
2023-12-20T11:45:13Z: Marked slot rootfs.1 active
                      bundle hash: ee3f0b6649cd1425efe69c3947f7c5e862ce0e3f91cb4d36904a1e99c2bff110
                      bootname: B
2023-12-20T11:45:13Z: Installation 3d7084a4 succeeded
                      bundle hash: ee3f0b6649cd1425efe69c3947f7c5e862ce0e3f91cb4d36904a1e99c2bff110
                      bundle version: 1.0
                      transaction ID: 3d7084a4-44e9-4631-9073-94d2b8a6d1c6
2023-12-20T11:47:17Z: Booted into rootfs.0 (A)
                      boot ID: 8bad539f-c24c-467d-94e2-102ddb94769b
                      bundle hash: unknown
2023-12-20T11:47:18Z: Marked slot rootfs.0 good
```

</details>
<details>
<summary>example JSON log file content</summary>

```
{"TS":"2023-12-20T11:32:15Z","MESSAGE":"Booted into rootfs.0 (A)","MESSAGE_ID":"e60e0add-d345-4cb8-b796-eae0d497af96","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"boot","BOOT_ID":"55304525-445b-45b2-95e3-71d6646ca437","BUNDLE_HASH":"unknown"}
{"TS":"2023-12-20T11:32:16Z","MESSAGE":"Marked slot rootfs.0 good","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"mark","MESSAGE_ID":"3304e15a-7a9a-4478-85eb-208ba7ae3a05","RAUC_SLOT":"rootfs.0"}
{"TS":"2023-12-20T11:32:33Z","MESSAGE":"Service restarted","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"service"}
{"TS":"2023-12-20T11:33:56Z","MESSAGE":"Installation 871dbf94 started","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"install","MESSAGE_ID":"b05410e8-a933-4538-9cd0-61aab1e9516d","TRANSACTION_ID":"871dbf94-75cf-4a6a-b3de-6b81d2013d9e"}
{"TS":"2023-12-20T11:33:56Z","MESSAGE":"Marked slot rootfs.1 bad","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"mark","MESSAGE_ID":"ccb0e584-a470-43d7-a531-6994bce77ae5","RAUC_SLOT":"rootfs.1"}
{"TS":"2023-12-20T11:33:56Z","MESSAGE":"Updating slot efi.0","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"writeslot"}
{"TS":"2023-12-20T11:34:17Z","MESSAGE":"Updating slot rootfs.1","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"writeslot"}
{"TS":"2023-12-20T11:35:05Z","MESSAGE":"Marked slot rootfs.1 active","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"mark","MESSAGE_ID":"8b5e7435-e105-4d86-8582-78e7544fe6da","RAUC_SLOT":"rootfs.1","BUNDLE_HASH":"ee3f0b6649cd1425efe69c3947f7c5e862ce0e3f91cb4d36904a1e99c2bff110","SLOT_BOOTNAME":"B"}
{"TS":"2023-12-20T11:35:06Z","MESSAGE":"Installation 871dbf94 succeeded","MESSAGE_ID":"0163db54-68ac-4237-b090-d28490c301ed","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"install","BUNDLE_HASH":"ee3f0b6649cd1425efe69c3947f7c5e862ce0e3f91cb4d36904a1e99c2bff110","BUNDLE_DESCRIPTION":"qemu-demo-bundle version 1.0-r0","BUNDLE_VERSION":"1.0","TRANSACTION_ID":"871dbf94-75cf-4a6a-b3de-6b81d2013d9e"}
{"TS":"2023-12-20T11:35:50Z","MESSAGE":"Booted into rootfs.1 (B)","MESSAGE_ID":"e60e0add-d345-4cb8-b796-eae0d497af96","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"boot","BOOT_ID":"3850cffb-2eca-4960-b682-ec95bd5a222c","BUNDLE_HASH":"ee3f0b6649cd1425efe69c3947f7c5e862ce0e3f91cb4d36904a1e99c2bff110"}
{"TS":"2023-12-20T11:35:51Z","MESSAGE":"Marked slot rootfs.1 good","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"mark","MESSAGE_ID":"3304e15a-7a9a-4478-85eb-208ba7ae3a05","RAUC_SLOT":"rootfs.1"}
{"TS":"2023-12-20T11:37:58Z","MESSAGE":"Marked slot rootfs.1 bad","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"mark","MESSAGE_ID":"ccb0e584-a470-43d7-a531-6994bce77ae5","RAUC_SLOT":"rootfs.1"}
{"TS":"2023-12-20T11:38:35Z","MESSAGE":"Booted into rootfs.0 (A)","MESSAGE_ID":"e60e0add-d345-4cb8-b796-eae0d497af96","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"boot","BOOT_ID":"bdc77e95-da79-4ade-a122-15c5ff302e6b","BUNDLE_HASH":"unknown"}
{"TS":"2023-12-20T11:38:37Z","MESSAGE":"Marked slot rootfs.0 good","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"mark","MESSAGE_ID":"3304e15a-7a9a-4478-85eb-208ba7ae3a05","RAUC_SLOT":"rootfs.0"}
{"TS":"2023-12-20T11:41:34Z","MESSAGE":"Installation 5b1e12db started","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"install","MESSAGE_ID":"b05410e8-a933-4538-9cd0-61aab1e9516d","TRANSACTION_ID":"5b1e12db-2c7e-416a-8c9e-245fe0497f4c"}
{"TS":"2023-12-20T11:41:34Z","MESSAGE":"Marked slot rootfs.1 bad","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"mark","MESSAGE_ID":"ccb0e584-a470-43d7-a531-6994bce77ae5","RAUC_SLOT":"rootfs.1"}
{"TS":"2023-12-20T11:41:34Z","MESSAGE":"Updating slot efi.0","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"writeslot"}
{"TS":"2023-12-20T11:42:19Z","MESSAGE":"Service restarted","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"service"}
{"TS":"2023-12-20T11:43:43Z","MESSAGE":"Installation 3d7084a4 started","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"install","MESSAGE_ID":"b05410e8-a933-4538-9cd0-61aab1e9516d","TRANSACTION_ID":"3d7084a4-44e9-4631-9073-94d2b8a6d1c6"}
{"TS":"2023-12-20T11:43:44Z","MESSAGE":"Marked slot rootfs.1 bad","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"mark","MESSAGE_ID":"ccb0e584-a470-43d7-a531-6994bce77ae5","RAUC_SLOT":"rootfs.1"}
{"TS":"2023-12-20T11:43:44Z","MESSAGE":"Updating slot efi.0","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"writeslot"}
{"TS":"2023-12-20T11:44:06Z","MESSAGE":"Updating slot rootfs.1","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"writeslot"}
{"TS":"2023-12-20T11:45:13Z","MESSAGE":"Marked slot rootfs.1 active","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"mark","MESSAGE_ID":"8b5e7435-e105-4d86-8582-78e7544fe6da","RAUC_SLOT":"rootfs.1","BUNDLE_HASH":"ee3f0b6649cd1425efe69c3947f7c5e862ce0e3f91cb4d36904a1e99c2bff110","SLOT_BOOTNAME":"B"}
{"TS":"2023-12-20T11:45:13Z","MESSAGE":"Installation 3d7084a4 succeeded","MESSAGE_ID":"0163db54-68ac-4237-b090-d28490c301ed","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"install","BUNDLE_HASH":"ee3f0b6649cd1425efe69c3947f7c5e862ce0e3f91cb4d36904a1e99c2bff110","BUNDLE_DESCRIPTION":"qemu-demo-bundle version 1.0-r0","BUNDLE_VERSION":"1.0","TRANSACTION_ID":"3d7084a4-44e9-4631-9073-94d2b8a6d1c6"}
{"TS":"2023-12-20T11:47:17Z","MESSAGE":"Booted into rootfs.0 (A)","MESSAGE_ID":"e60e0add-d345-4cb8-b796-eae0d497af96","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"boot","BOOT_ID":"8bad539f-c24c-467d-94e2-102ddb94769b","BUNDLE_HASH":"unknown"}
{"TS":"2023-12-20T11:47:18Z","MESSAGE":"Marked slot rootfs.0 good","PRIORITY":"5","GLIB_DOMAIN":"rauc-event","RAUC_EVENT_TYPE":"mark","MESSAGE_ID":"3304e15a-7a9a-4478-85eb-208ba7ae3a05","RAUC_SLOT":"rootfs.0"}
```

</details>