### PR TITLE
Adding CRYPTO_AES documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,7 @@ Required kernel options (either ``y`` or ``m``):
 -  ``CONFIG_CRYPTO_SHA256``
 -  ``CONFIG_BLK_DEV_NBD`` (for streaming support)
 -  ``CONFIG_DM_CRYPT`` (for encryption support)
+-  ``CONFIG_CRYPTO_AES`` (for encryption support)
 
 For using tar archive in RAUC bundles with Busybox tar, you have to enable the
 following Busybox feature:

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -294,7 +294,7 @@ In kernel Kconfig you have to enable the following options as either built-in
   CONFIG_CRYPTO_SHA256
 
 For streaming support, you have to add ``CONFIG_BLK_DEV_NBD``.
-For encryption support, you have to add ``CONFIG_DM_CRYPT``.
+For encryption support, you have to add ``CONFIG_DM_CRYPT``, ``CONFIG_CRYPTO_AES``.
 
 .. note::
    These drivers may also be loaded as modules. Kernel versions v5.0 to v5.7

--- a/src/dm.c
+++ b/src/dm.c
@@ -179,7 +179,8 @@ gboolean r_dm_setup(RaucDM *dm, GError **error)
 		g_set_error(error,
 				G_FILE_ERROR,
 				g_file_error_from_errno(err),
-				"Failed to load dm table: %s", g_strerror(err));
+				"Failed to load dm table: %s, "
+				"check DM_VERITY, DM_CRYPT or CRYPTO_AES kernel options.", g_strerror(err));
 		res = FALSE;
 		goto out_remove_dm;
 	}


### PR DESCRIPTION
CRYPTO_AES option is mandatory to have crypto support working in RAUC.

Adding a bit of documentation and a better error when RAUC fails setup DM for cypto format. 