### PR TITLE
avoid using the term artifacts in the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ RAUC - Robust Auto-Update Controller
 
 RAUC controls the update process on embedded Linux systems. It is both a target
 application that runs as an update client and a host/target tool
-that allows you to create, inspect and modify installation artifacts.
+that allows you to create, inspect and modify update files ("*bundles*").
 
 Source Code: https://github.com/rauc/rauc
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -860,7 +860,7 @@ RAUC casync Support
 
 Using the Content-Addressable Data Synchronization tool `casync` for updating
 embedded / IoT devices provides a couple of benefits.
-By splitting and chunking the update artifacts into reusable pieces, casync
+By splitting and chunking the payload images into reusable pieces, casync
 allows to
 
  * stream remote bundles to the target without occupying storage / NAND
@@ -955,7 +955,7 @@ Simply call::
 
   rauc convert --cert=<certfile> --key=<keyfile> --keyring=<keyring> conventional-bundle.raucb casync-bundle.raucb
 
-The conversion process will create two new artifacts:
+The conversion process will create two new files:
 
  1. The converted bundle `casync-bundle.raucb` with casnyc index files instead
     of image files

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -855,7 +855,7 @@ RAUC casync Support
   Since 1.8, RAUC also supports the alternative `desync
   <https://github.com/folbricht/desync>`_ written in Go.
 
-  For compatiblitiy and comparison with RAUC's built-in streaming support,
+  For compatibility and comparison with RAUC's built-in streaming support,
   refer to :ref:`sec-casync-vs-streaming`.
 
 Using the Content-Addressable Data Synchronization tool `casync` for updating

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -4,9 +4,9 @@ RAUC Basics
 From a top view, the RAUC update framework provides a solution for four basic
 tasks:
 
-* generating update artifacts
-* signing and verification of update artifacts
-* robust installation handling
+* generating the update bundles
+* signing and verification of update bundles
+* robust installation of the payload(s)
 * interfacing with the boot process
 
 RAUC is basically an image-based updater, i.e. it installs file images on
@@ -18,13 +18,13 @@ specific partition size or type.
 RAUC ensures that the target file system will be set up correctly before
 unpacking the archive.
 
-Update Artifacts -- Bundles
----------------------------
+Update Bundles
+---------------
 
 In order to know how to pack multiple file system images, properly handle
-installation, being able to check system compatibility and for other
-meta-information RAUC uses a well-defined update artifact format, simply
-referred to as *bundles* in the following.
+installation, check target system compatibility and for other meta-information
+RAUC uses its own update file format, simply referred to as a *bundle* in the
+following.
 
 A RAUC bundle consists of the file system image(s) or archive(s) to be installed
 on the system, a *manifest* that lists the images to install and contains

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ RAUC is a lightweight update client that runs on your embedded device and
 reliably controls the procedure of updating your device with a new firmware
 revision.
 RAUC is also the tool on your host system that lets you create, inspect and
-modify update artifacts for your device.
+modify update files ("*bundles*") for your device.
 
 The decision to design was made after having worked on custom update solutions
 for different projects again and again while always facing different issues and
@@ -88,7 +88,7 @@ appropriate target to boot, but it provides a well-defined interface to
 incorporate with all common bootloaders.
 
 RAUC does NOT intend to be a deployment server.
-On your host side, it only creates the update artifacts.
+On your host side, it only creates the update bundles.
 You may want to have a look at
 `rauc-hawkbit-updater <https://github.com/rauc/rauc-hawkbit-updater>`_ for
 interfacing with the hawkBit deployment server.

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -1471,8 +1471,8 @@ For using the built-in bundle generation, you need to specify some variables:
   It currently defaults to ``plain``, but you should use ``verity`` if possible.
 
 ``RAUC_SLOT_<slotclass>``
-  For each slot class, set this to the image (recipe) name which builds the
-  artifact you intend to place in the slot class.
+  For each slot class, set this to the recipe name which builds the
+  image you intend to place in the slot class.
 
 ``RAUC_SLOT_<slotclass>[type]``
   For each slot class, set this to the *type* of image you intend to place in

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -902,8 +902,9 @@ loopback or network block device to authenticate and then decrypt each payload b
 External Signing and PKI
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Some industrialization procedures require signing artifacts in a dedicated
-secure room with restricted access (as Public Key Infrastructure aka PKI).
+Some industrialization procedures require signing updates in a dedicated
+secure room with restricted access.
+Only there, access to the Public Key Infrastructure (aka PKI), is allowed.
 
 For this case ``rauc extract-signature`` can extract the bundle signature and
 ``rauc replace-signature`` can replace the bundle signature with a new one.

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -38,7 +38,7 @@ sub-command:
   rauc bundle --cert=<certfile|certurl> --key=<keyfile|keyurl> <input-dir> <bundle-name>
 
 The ``<input-dir>`` must point to a directory containing all images, scripts
-and other artifacts that should be part of the created update bundle.
+and other files that should be part of the created update bundle.
 Additionally, a :ref:`RAUC manifest <sec_ref_manifest>` file ``manifest.raucm``
 is expected in ``<input-dir>``.
 The manifest describes the bundle content and the purpose of each included

--- a/rauc.1
+++ b/rauc.1
@@ -43,7 +43,7 @@ RAUC is a lightweight update client that runs on an Embedded Linux device and
 reliably controls the procedure of updating the device with a new firmware.
 
 RAUC is also the tool on the host system that is used to create, inspect and
-modify update artifacts for the device.
+modify update files ("bundles") for the device.
 
 This manual page documents briefly the
 .BR rauc


### PR DESCRIPTION
Before documenting artifact updates (for containers/external applications/data
files), we should avoid using the same term for different things in the
documentation.