### PR TITLE
remove dashes from message IDs and add note in changelog

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,16 @@ Release 1.11 (development)
 * Remove autotools build system.
   Support for meson was added in 1.9 and supported in parallel to autotools
   until 1.10.1.
+* Add log events for slot update, start/end of an installation, good/bad/active
+  marking and boot/service restart.
+  For an overview over the event logging framework in RAUC and its purpose, have
+  a look at :ref:`sec-advanced-event-log`.
+
+.. note::
+   We don't consider the details of the new log events fixed yet, so please use
+   them as a preview and for testing.
+   In a future release, they will be documented in a `journald message catalog
+   <https://www.freedesktop.org/wiki/Software/systemd/catalog/>`_.
 
 .. rubric:: Bug fixes
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1603,6 +1603,12 @@ https://pypi.org/project/upparat/
 RAUC Installation History and Event logging
 -------------------------------------------
 
+.. note::
+   We don't consider the details of the new log events fixed yet, so please use
+   them as a preview and for testing.
+   In a future release, they will be documented in a `journald message catalog
+   <https://www.freedesktop.org/wiki/Software/systemd/catalog/>`_.
+
 Even if RAUC mainly focuses on logging information to stdout or into the
 journal (when using systemd), this might be insufficient for some purposes and
 especially for keeping long-term history of what RAUC changed on the system.

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1600,8 +1600,8 @@ https://pypi.org/project/upparat/
 
 .. _sec-advanced-event-log:
 
-RAUC Installation History and Event logging
--------------------------------------------
+Installation History and Event Logging
+--------------------------------------
 
 .. note::
    We don't consider the details of the new log events fixed yet, so please use

--- a/src/event_log.c
+++ b/src/event_log.c
@@ -63,7 +63,7 @@ void r_event_log_free_logger(REventLogger *logger)
  * | {
  * |   "TS": "2023-06-14T21:15:41Z"
  * |   "MESSAGE" : "Booted into rootfs.0 (A)",
- * |   "MESSAGE_ID" : "e60e0add-d345-4cb8-b796-eae0d497af96",
+ * |   "MESSAGE_ID" : "e60e0addd3454cb8b796eae0d497af96",
  * |   "GLIB_DOMAIN" : "rauc-event",
  * |   "RAUC_EVENT_TYPE" : "boot",
  * |   "BOOT_ID" : "16655d2c-c5ca-48d3-bea8-7b95c803b4b2",
@@ -72,7 +72,7 @@ void r_event_log_free_logger(REventLogger *logger)
  * | {
  * |   "TS": "2023-06-14T21:42:41Z"
  * |   "MESSAGE" : "Marked slot rootfs.0 as active.",
- * |   "MESSAGE_ID" : "8b5e7435-e105-4d86-8582-78e7544fe6da",
+ * |   "MESSAGE_ID" : "8b5e7435e1054d86858278e7544fe6da",
  * |   "GLIB_DOMAIN" : "rauc-event",
  * |   "RAUC_EVENT_TYPE" : "mark",
  * |   "SLOT_NAME" : "rootfs.0",

--- a/src/install.c
+++ b/src/install.c
@@ -1099,10 +1099,10 @@ static RaucSlot* get_boot_mark_slot(const GPtrArray *install_plans)
 	return bootslot;
 }
 
-#define MESSAGE_ID_INSTALLATION_STARTED   "b05410e8-a933-4538-9cd0-61aab1e9516d"
-#define MESSAGE_ID_INSTALLATION_SUCCEEDED "0163db54-68ac-4237-b090-d28490c301ed"
-#define MESSAGE_ID_INSTALLATION_FAILED    "c48141f7-fd49-443a-afff-862b4809168f"
-#define MESSAGE_ID_INSTALLATION_REJECTED  "60bea7e4-fea5-49cc-ad68-af457308b13a"
+#define MESSAGE_ID_INSTALLATION_STARTED   "b05410e8a93345389cd061aab1e9516d"
+#define MESSAGE_ID_INSTALLATION_SUCCEEDED "0163db5468ac4237b090d28490c301ed"
+#define MESSAGE_ID_INSTALLATION_FAILED    "c48141f7fd49443aafff862b4809168f"
+#define MESSAGE_ID_INSTALLATION_REJECTED  "60bea7e4fea549ccad68af457308b13a"
 
 static void log_event_installation_started(RaucInstallArgs *args)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -2003,7 +2003,7 @@ static gboolean status_start(int argc, char **argv)
 	return TRUE;
 }
 
-#define MESSAGE_ID_BOOTED "e60e0add-d345-4cb8-b796-eae0d497af96"
+#define MESSAGE_ID_BOOTED "e60e0addd3454cb8b796eae0d497af96"
 
 static void r_event_log_booted(const RaucSlot *booted_slot)
 {

--- a/src/mark.c
+++ b/src/mark.c
@@ -76,9 +76,9 @@ static RaucSlot* get_slot_by_identifier(const gchar *identifier, GError **error)
 	return slot;
 }
 
-#define MESSAGE_ID_MARKED_ACTIVE "8b5e7435-e105-4d86-8582-78e7544fe6da"
-#define MESSAGE_ID_MARKED_GOOD   "3304e15a-7a9a-4478-85eb-208ba7ae3a05"
-#define MESSAGE_ID_MARKED_BAD    "ccb0e584-a470-43d7-a531-6994bce77ae5"
+#define MESSAGE_ID_MARKED_ACTIVE "8b5e7435e1054d86858278e7544fe6da"
+#define MESSAGE_ID_MARKED_GOOD   "3304e15a7a9a447885eb208ba7ae3a05"
+#define MESSAGE_ID_MARKED_BAD    "ccb0e584a47043d7a5316994bce77ae5"
 
 static void r_event_log_mark_active(RaucSlot *slot)
 {

--- a/test/event_log.c
+++ b/test/event_log.c
@@ -54,7 +54,7 @@ static void event_log_test_log_write_simple(EventLogFixture *fixture,
 	g_autoptr(REventLogger) logger = NULL;
 	GLogField fields[] = {
 		{"MESSAGE", "This is a test (mark) log message", -1 },
-		{"MESSAGE_ID", "1d1b7a5a-a908-4c3a-9004-650c9d2ce850", -1 },
+		{"MESSAGE_ID", "1d1b7a5aa9084c3a9004650c9d2ce850", -1 },
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "mark", -1},
 		{"SLOT_NAME", "rootfs.0", -1},
@@ -84,7 +84,7 @@ static void event_log_test_log_write_broken(EventLogFixture *fixture,
 	g_autoptr(REventLogger) logger = NULL;
 	GLogField fields[] = {
 		{"MESSAGE", "This is a test (mark) log message", -1 },
-		{"MESSAGE_ID", "1d1b7a5a-a908-4c3a-9004-650c9d2ce850", -1 },
+		{"MESSAGE_ID", "1d1b7a5aa9084c3a9004650c9d2ce850", -1 },
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "mark", -1},
 		{"SLOT_NAME", "rootfs.0", -1},
@@ -115,7 +115,7 @@ static void event_log_test_log_no_space_left(EventLogFixture *fixture,
 	g_autoptr(REventLogger) logger = NULL;
 	GLogField fields[] = {
 		{"MESSAGE", "This is a test (mark) log message", -1 },
-		{"MESSAGE_ID", "1d1b7a5a-a908-4c3a-9004-650c9d2ce850", -1 },
+		{"MESSAGE_ID", "1d1b7a5aa9084c3a9004650c9d2ce850", -1 },
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "mark", -1},
 		{"BUNDLE_HASH", "b970468f-89e4-4793-9904-06c922902b25", -1},
@@ -143,7 +143,7 @@ static void event_log_test_log_write_json(EventLogFixture *fixture,
 	g_autoptr(REventLogger) logger = NULL;
 	GLogField fields[] = {
 		{"MESSAGE", "This is a test (mark) log message", -1 },
-		{"MESSAGE_ID", "1d1b7a5a-a908-4c3a-9004-650c9d2ce850", -1 },
+		{"MESSAGE_ID", "1d1b7a5aa9084c3a9004650c9d2ce850", -1 },
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "mark", -1},
 		{"BUNDLE_HASH", "b970468f-89e4-4793-9904-06c922902b25", -1},
@@ -162,7 +162,7 @@ static void event_log_test_log_write_json(EventLogFixture *fixture,
 	g_assert_true(g_file_get_contents(logger->filename, &contents, NULL, NULL));
 
 	g_assert_nonnull(strstr(contents, "\"MESSAGE\":\"This is a test (mark) log message\""));
-	g_assert_nonnull(strstr(contents, "\"MESSAGE_ID\":\"1d1b7a5a-a908-4c3a-9004-650c9d2ce850\""));
+	g_assert_nonnull(strstr(contents, "\"MESSAGE_ID\":\"1d1b7a5aa9084c3a9004650c9d2ce850\""));
 }
 
 /* Test setting a maxsize and logging until exceeding it */
@@ -173,7 +173,7 @@ static void event_log_test_max_size(EventLogFixture *fixture,
 	g_autoptr(REventLogger) logger = NULL;
 	GLogField fields[] = {
 		{"MESSAGE", "This is a test (mark) log message", -1 },
-		{"MESSAGE_ID", "1d1b7a5a-a908-4c3a-9004-650c9d2ce850", -1 },
+		{"MESSAGE_ID", "1d1b7a5aa9084c3a9004650c9d2ce850", -1 },
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "mark", -1},
 		{"BUNDLE_HASH", "b970468f-89e4-4793-9904-06c922902b25", -1},
@@ -208,7 +208,7 @@ static void event_log_test_max_files_rotation(EventLogFixture *fixture,
 	g_autoptr(REventLogger) logger = NULL;
 	GLogField fields[] = {
 		{"MESSAGE", "This is a test (mark) log message", -1 },
-		{"MESSAGE_ID", "1d1b7a5a-a908-4c3a-9004-650c9d2ce850", -1 },
+		{"MESSAGE_ID", "1d1b7a5aa9084c3a9004650c9d2ce850", -1 },
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "mark", -1},
 		{"BUNDLE_HASH", "b970468f-89e4-4793-9904-06c922902b25", -1},
@@ -275,7 +275,7 @@ static void event_log_test_structured_logging(EventLogFixture *fixture,
 	REventLogger *logger = NULL;
 	GLogField fields[] = {
 		{"MESSAGE", "This is a test (mark) log message", -1 },
-		{"MESSAGE_ID", "1d1b7a5a-a908-4c3a-9004-650c9d2ce850", -1 },
+		{"MESSAGE_ID", "1d1b7a5aa9084c3a9004650c9d2ce850", -1 },
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "mark", -1},
 		{"BUNDLE_HASH", "b970468f-89e4-4793-9904-06c922902b25", -1},


### PR DESCRIPTION
The journald catalog uses UUIDs without dashes, as generated by `systemd-id128 new` (without `-u`), so remove the dashes while the change won't cause backwards-compatibility issues.

We don't consider the details of the new log events fixed yet, so please use them as a preview and for testing.
In a future release, they will be documented in a [journald message catalog](https://www.freedesktop.org/wiki/Software/systemd/catalog/).