### PR TITLE
Ensure Only Bootable Slots Can be Marked

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -494,6 +494,7 @@ static gboolean grub_get_state(RaucSlot* slot, gboolean *good, GError **error)
 	gboolean found = FALSE;
 
 	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(slot->bootname, FALSE);
 	g_return_val_if_fail(good, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
@@ -539,6 +540,7 @@ static gboolean grub_set_state(RaucSlot *slot, gboolean good, GError **error)
 	GError *ierror = NULL;
 
 	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(slot->bootname, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	if (good) {

--- a/src/mark.c
+++ b/src/mark.c
@@ -20,7 +20,7 @@ static RaucSlot* get_slot_by_identifier(const gchar *identifier, GError **error)
 		booted = NULL;
 	}
 
-	if (!g_strcmp0(identifier, "booted")) {
+	if (g_strcmp0(identifier, "booted") == 0) {
 		if (booted)
 			slot = booted;
 		else
@@ -29,7 +29,7 @@ static RaucSlot* get_slot_by_identifier(const gchar *identifier, GError **error)
 					R_SLOT_ERROR,
 					R_SLOT_ERROR_NO_SLOT_WITH_STATE_BOOTED,
 					"Did not find booted slot");
-	} else if (!g_strcmp0(identifier, "other")) {
+	} else if (g_strcmp0(identifier, "other") == 0) {
 		if (booted) {
 			g_hash_table_iter_init(&iter, r_context()->config->slots);
 			while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
@@ -217,7 +217,7 @@ gboolean mark_run(const gchar *state,
 		goto out;
 	}
 
-	if (!g_strcmp0(state, "good")) {
+	if (g_strcmp0(state, "good") == 0) {
 		if (!r_mark_good(slot, &ierror)) {
 			res = FALSE;
 			*message = g_strdup(ierror->message);
@@ -225,7 +225,7 @@ gboolean mark_run(const gchar *state,
 			res = TRUE;
 			*message = g_strdup_printf("marked slot %s as good", slot->name);
 		}
-	} else if (!g_strcmp0(state, "bad")) {
+	} else if (g_strcmp0(state, "bad") == 0) {
 		if (!r_mark_bad(slot, &ierror)) {
 			res = FALSE;
 			*message = g_strdup(ierror->message);
@@ -233,7 +233,7 @@ gboolean mark_run(const gchar *state,
 			res = TRUE;
 			*message = g_strdup_printf("marked slot %s as bad", slot->name);
 		}
-	} else if (!g_strcmp0(state, "active")) {
+	} else if (g_strcmp0(state, "active") == 0) {
 		if (!r_mark_active(slot, &ierror)) {
 			res = FALSE;
 			*message = g_strdup(ierror->message);

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -524,6 +524,22 @@ test_expect_success !SERVICE,GRUB "rauc status mark-active: internally" "
   rauc -c $SHARNESS_TEST_DIRECTORY/test.conf --override-boot-slot=system0 status mark-active
 "
 
+test_expect_success !SERVICE,GRUB "rauc status mark-good: booted" "
+  rauc -c $SHARNESS_TEST_DIRECTORY/test.conf --override-boot-slot=system0 status mark-good booted
+"
+
+test_expect_success !SERVICE,GRUB "rauc status mark-good: other" "
+  rauc -c $SHARNESS_TEST_DIRECTORY/test.conf --override-boot-slot=system0 status mark-good other
+"
+
+test_expect_success !SERVICE,GRUB "rauc status mark-good: any bootslot" "
+  rauc -c $SHARNESS_TEST_DIRECTORY/test.conf --override-boot-slot=system0 status mark-good rescue.0
+"
+
+test_expect_success !SERVICE,GRUB "rauc status mark-good: non-bootslot" "
+  test_must_fail rauc -c $SHARNESS_TEST_DIRECTORY/test.conf --override-boot-slot=system0 status mark-good bootloader.0
+"
+
 test_expect_success SERVICE,GRUB "rauc status mark-good: via D-Bus" "
   start_rauc_dbus_service \
     --conf=${SHARNESS_TEST_DIRECTORY}/test.conf \


### PR DESCRIPTION
So far, `rauc status mark-*` methods allow to mark slots that are not bootable. For them, what happens then depends on the actual invoked bootchooser backend.
Given the current grub backend, for example, this will slightly accept it and produce env variables like `(null)_OK`.