### PR TITLE
test/service: run service tests only as root

### DIFF
--- a/test/service.c
+++ b/test/service.c
@@ -353,6 +353,10 @@ static void service_test_info(ServiceFixture *fixture, gconstpointer user_data, 
 		return;
 	}
 
+	/* needs to run as root */
+	if (!test_running_as_root())
+		return;
+
 	bundlepath = g_build_filename(fixture->tmpdir, "good-bundle.raucb", NULL);
 	g_assert_true(test_copy_file("test", "good-bundle.raucb", fixture->tmpdir, "good-bundle.raucb"));
 
@@ -419,6 +423,10 @@ static void service_test_slot_status(ServiceFixture *fixture, gconstpointer user
 		g_test_skip("Test requires RAUC being configured with \"-Dservice=true\".");
 		return;
 	}
+
+	/* needs to run as root */
+	if (!test_running_as_root())
+		return;
 
 	installer = r_installer_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
 			G_DBUS_PROXY_FLAGS_NONE,


### PR DESCRIPTION
With the rework of 8e2c45ed, these tests cannot be run as unpriviledged user anymore.

Fixes #1283.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
