### PR TITLE
src/main: fix and add support for boot detection with rauc.external

### DIFF
--- a/test/rauc.t
+++ b/test/rauc.t
@@ -1387,6 +1387,20 @@ test_expect_success ROOT,SERVICE "rauc install --progress" "
   test -s ${SHARNESS_TEST_DIRECTORY}/images/rootfs-1
 "
 
+test_expect_success ROOT,SERVICE "rauc install (rauc.external)" "
+  cp -L ${SHARNESS_TEST_DIRECTORY}/good-verity-bundle.raucb ${TEST_TMPDIR}/ &&
+  test_when_finished rm -f ${TEST_TMPDIR}/good-verity-bundle.raucb &&
+  start_rauc_dbus_service_with_system \
+    --conf=${SHARNESS_TEST_DIRECTORY}/minimal-test.conf \
+    --mount=${SHARNESS_TEST_DIRECTORY}/mnt \
+    --override-boot-slot=_external_ &&
+  test_when_finished stop_rauc_dbus_service_with_system &&
+  test ! -s ${SHARNESS_TEST_DIRECTORY}/images/rootfs-1 &&
+  rauc \
+    install ${TEST_TMPDIR}/good-verity-bundle.raucb &&
+  test -s ${SHARNESS_TEST_DIRECTORY}/images/rootfs-1
+"
+
 test_expect_success ROOT,!SERVICE "rauc install (no service)" "
   cp -L ${SHARNESS_TEST_DIRECTORY}/good-bundle.raucb ${TEST_TMPDIR}/ &&
   test_when_finished rm -f ${TEST_TMPDIR}/good-bundle.raucb &&


### PR DESCRIPTION
The current boot detection handling did not take into account that there is no booted slot when using `rauc.external` in cmdline and called `r_slot_status_load()` with `NULL` argument causing a

    (rauc:676): rauc-CRITICAL **: 16:16:16.336: r_slot_status_load: assertion 'dest_slot' failed

Fix this by explicitly checking for external boot and also emit a dedicated log message since this might be relevant for the log, too.

Fixes #1313
Fixes b9e4cdce0879862126aeb786bdd7f6672e392ca9 ("src/main: log boot and service restart")