### PR TITLE
src/bundle: remove signature size sanity check

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1697,13 +1697,6 @@ static gboolean open_local_bundle(RaucBundle *bundle, GError **error)
 		res = FALSE;
 		goto out;
 	}
-	/* sanity check: signature should be smaller than bundle size */
-	if (sigsize > (guint64)offset) {
-		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE,
-				"Signature size (%"G_GUINT64_FORMAT ") exceeds bundle size", sigsize);
-		res = FALSE;
-		goto out;
-	}
 	/* sanity check: signature should be smaller than 64KiB */
 	if (sigsize > MAX_BUNDLE_SIGNATURE_SIZE) {
 		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE,
@@ -1784,13 +1777,6 @@ static gboolean open_remote_bundle(RaucBundle *bundle, GError **error)
 	if (sigsize == 0) {
 		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE,
 				"Signature size is 0");
-		res = FALSE;
-		goto out;
-	}
-	/* sanity check: signature should be smaller than bundle size */
-	if (sigsize > offset) {
-		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_SIGNATURE,
-				"Signature size (%"G_GUINT64_FORMAT ") exceeds bundle size", sigsize);
 		res = FALSE;
 		goto out;
 	}


### PR DESCRIPTION
Historically, checking that the signature size is smaller than the bundle size was a sensible test.
However, with the added support for encrypted bundles, we may run in cases where the bundle size is actually smaller than the signature size. This happens because the CMS structure holds the individual recipients for encrypted bundles and with having thousands of recipients, the CMS structure size can reach a notable size. If that's combined with a quite small update image, the sanity check can be triggered and prevents from installing such a bundle.

Since this is just a sanity check, since we have other sanity checks and since we intend to support large amounts of encryption recipients, simply remove the sanity check.

Fixes #1308.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
