### PR TITLE
build multiarch CI containers, use podman and run user-level tests

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
       - 'container'
     paths:
+      - '.github/workflows/container.yml'
       - 'test/Dockerfile'
   workflow_dispatch: {}
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -41,6 +41,12 @@ jobs:
         echo "Image: ${{ steps.build-image.outputs.image }}"
         echo "Tags: ${{ steps.build-image.outputs.tags }}"
         echo "Tagged Image: ${{ steps.build-image.outputs.image-with-tag }}"
+    - name: List Images
+      run: |
+        buildah images
+    - name: Inspect Manifest
+      run: |
+        buildah manifest inspect "${{ steps.build-image.outputs.image-with-tag }}"
     - name: Push Images
       id: push-to-github
       uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -34,7 +34,7 @@ jobs:
         image: rauc-ci
         tags: latest
         platforms: linux/amd64, linux/386, linux/arm/v5, linux/arm/v7, linux/arm64/v8
-        dockerfiles: |
+        containerfiles: |
           ./test/Dockerfile
     - name: Echo Outputs for Build
       run: |

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -14,15 +14,35 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Install QEMU
+      run: |
+        sudo apt-get update
+        DEBIAN_FRONTEND='noninteractive' sudo apt-get install -qy qemu-user-static
+    # remove this when Ubuntu 24.04 is available on GitHub Actions
+    - name: Enable Ubuntu noble and update buildah
+      run: |
+        echo 'deb http://archive.ubuntu.com/ubuntu/ noble main restricted universe' | sudo tee -a /etc/apt/sources.list.d/lunar.list
+        echo 'deb http://archive.ubuntu.com/ubuntu/ noble-updates main restricted universe' | sudo tee -a /etc/apt/sources.list.d/lunar.list
+        sudo apt-get update
+        DEBIAN_FRONTEND='noninteractive' sudo apt-get install -qy buildah
+        buildah version
     - uses: actions/checkout@v3
-    - id: build-image
+    - name: Build Images
+      id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
         image: rauc-ci
         tags: latest
+        platforms: linux/amd64, linux/386, linux/arm/v5, linux/arm/v7, linux/arm64/v8
         dockerfiles: |
           ./test/Dockerfile
-    - id: push-to-github
+    - name: Echo Outputs for Build
+      run: |
+        echo "Image: ${{ steps.build-image.outputs.image }}"
+        echo "Tags: ${{ steps.build-image.outputs.tags }}"
+        echo "Tagged Image: ${{ steps.build-image.outputs.image-with-tag }}"
+    - name: Push Images
+      id: push-to-github
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build-image.outputs.image }}
@@ -30,4 +50,5 @@ jobs:
         registry: ghcr.io/${{ github.repository }}
         username: ${{ github.actor }}
         password: ${{ github.token }}
-    - run: echo "Image pushed to ${{ steps.push-to-github.outputs.registry-paths }}"
+    - name: Echo Output for Push
+      run: echo "Image pushed to ${{ steps.push-to-github.outputs.registry-paths }}"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,23 @@
+name: style check
+
+on: [push, pull_request]
+
+jobs:
+  style:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install codespell
+      run: |
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND='noninteractive' apt-get install -qy codespell
+
+    - name: Run uncrustify check
+      run: |
+        ./uncrustify.sh
+        git diff --exit-code
+
+    - name: Run codespell check
+      run: |
+        codespell -L parms,cas -S 'openssl-ca,build,*.log' src include test docs

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   style:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,7 @@ jobs:
   cross:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         architecture:
         - "arm/v5"
@@ -117,6 +118,7 @@ jobs:
   stable:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         release:
         - "ubuntu:20.04"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,22 +179,3 @@ jobs:
         cat test/*.log || true
         cat test-suite.log || true
         cat rauc-*/_build/sub/test-suite.log || true
-
-  uncrustify:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Install codespell
-      run: |
-        sudo apt-get update
-        sudo DEBIAN_FRONTEND='noninteractive' apt-get install -qy codespell
-
-    - name: Run uncrustify check
-      run: |
-        ./uncrustify.sh
-        git diff --exit-code
-
-    - name: Run codespell check
-      run: |
-        codespell -L parms,cas -S 'openssl-ca,build,*.log' src include test docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,10 @@ jobs:
       run: |
         podman exec -i cross meson setup -Dgpt=enabled -Dwerror=true build
         podman exec -i cross meson compile -C build
-        # don't run 'meson test' here, as we don't have full access to the kernel (mount, loopback, dm)
+
+    - name: Test
+      run: |
+        podman exec -i cross meson test -C build --timeout-multiplier 3
 
     - name: Show logs
       if: ${{ failure() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,21 +93,31 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Prepare ${{ matrix.architecture }} container
+    - name: Install QEMU
       run: |
         sudo apt-get update
-        sudo DEBIAN_FRONTEND='noninteractive' apt-get install -qy qemu-user-static
-        docker run --name cross -di --platform linux/${{ matrix.architecture }} -v "$PWD":/home -w /home debian:bookworm bash
-        docker logs cross
-        docker exec -i cross uname -a
-        docker exec -i cross apt-get update
-        docker exec -e DEBIAN_FRONTEND='noninteractive' -i cross apt-get install -qy build-essential meson libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev libfdisk-dev libnl-genl-3-dev squashfs-tools
+        DEBIAN_FRONTEND='noninteractive' sudo apt-get install -qy qemu-user-static
+
+    # remove this when Ubuntu 24.04 is available on GitHub Actions
+    - name: Enable Ubuntu noble and update podman
+      run: |
+        echo 'deb http://archive.ubuntu.com/ubuntu/ noble main restricted universe' | sudo tee -a /etc/apt/sources.list.d/lunar.list
+        echo 'deb http://archive.ubuntu.com/ubuntu/ noble-updates main restricted universe' | sudo tee -a /etc/apt/sources.list.d/lunar.list
+        sudo apt-get update
+        DEBIAN_FRONTEND='noninteractive' sudo apt-get install -qy podman
+        podman version
+
+    - name: Prepare ${{ matrix.architecture }} container
+      run: |
+        podman run --name cross -di --platform linux/${{ matrix.architecture }} --userns=keep-id:uid=1000,gid=1000 -v "$PWD":/home -w /home ghcr.io/rauc/rauc/rauc-ci:latest bash
+        podman logs cross
+        podman exec -i cross uname -a
+        podman exec -i cross id
 
     - name: Build
       run: |
-        docker exec -i cross whoami
-        docker exec -i cross meson setup -Dgpt=enabled -Dwerror=true build
-        docker exec -i cross meson compile -C build
+        podman exec -i cross meson setup -Dgpt=enabled -Dwerror=true build
+        podman exec -i cross meson compile -C build
         # don't run 'meson test' here, as we don't have full access to the kernel (mount, loopback, dm)
 
     - name: Show logs
@@ -128,26 +138,35 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    # remove this when Ubuntu 24.04 is available on GitHub Actions
+    - name: Enable Ubuntu noble and update podman
+      run: |
+        echo 'deb http://archive.ubuntu.com/ubuntu/ noble main restricted universe' | sudo tee -a /etc/apt/sources.list.d/lunar.list
+        echo 'deb http://archive.ubuntu.com/ubuntu/ noble-updates main restricted universe' | sudo tee -a /etc/apt/sources.list.d/lunar.list
+        sudo apt-get update
+        DEBIAN_FRONTEND='noninteractive' sudo apt-get install -qy podman
+        podman version
+
     - name: Prepare ${{ matrix.release }} container for meson build
       run: |
-        docker run --name stable -di -v "$PWD":/home -w /home ${{ matrix.release }} bash
-        docker exec -i stable uname -a
-        docker exec -i stable apt-get update
-        docker exec -e DEBIAN_FRONTEND='noninteractive' -i stable apt-get install -qy build-essential meson libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev libfdisk-dev libnl-genl-3-dev squashfs-tools
+        podman version
+        podman run --name stable -di --userns=keep-id:uid=1000,gid=1000 -v "$PWD":/home -w /home ${{ matrix.release }} bash
+        podman exec -i stable uname -a
+        podman exec -i stable id
+        podman exec -i -u root stable apt-get update
+        podman exec -e DEBIAN_FRONTEND='noninteractive' -i -u root stable apt-get install -qy build-essential meson libtool libglib2.0-dev libcurl3-dev libssl-dev libjson-glib-dev libdbus-1-dev libfdisk-dev libnl-genl-3-dev squashfs-tools
 
     - name: Patch & prepare
       run: |
-        docker exec -i stable whoami
-        docker exec -i stable uname -a
-        docker exec -i stable find .github/workflows/patches/${{ matrix.release }}/ -type f -name "*.patch" -print0 | sort -z | xargs -t -n 1 -r -0 patch -p1 -f -i
+        podman exec -i stable find .github/workflows/patches/${{ matrix.release }}/ -type f -name "*.patch" -print0 | sort -z | xargs -t -n 1 -r -0 patch -p1 -f -i
 
     - name: Configure
       run: |
-        docker exec -i stable meson setup -Dgpt=disabled -Dwerror=true build
+        podman exec -i stable meson setup -Dgpt=disabled -Dwerror=true build
 
     - name: Build
       run: |
-        docker exec -i stable ninja -C build
+        podman exec -i stable ninja -C build
 
     - name: Show logs
       if: ${{ failure() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,6 @@ jobs:
       run: |
         whoami
         gcc --version
-        apt-get update
-        DEBIAN_FRONTEND='noninteractive' apt-get install -qy meson
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
       run: |
         whoami
         gcc --version
+        ls -l /dev/kvm || true
 
     - uses: actions/checkout@v3
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get install -q -y --no-install-recommends \
 
 # Required for test environment setup
 RUN apt-get install -q -y --no-install-recommends \
+  sudo \
   python3-pip \
   git \
   curl && \
@@ -75,6 +76,7 @@ RUN mkdir -p /lib/modules /var/run/dbus
 # Remove apt lists
 RUN rm -rf /var/lib/apt/lists/*
 
-RUN adduser --disabled-password --gecos "" rauc-ci
+RUN adduser --disabled-password --gecos "" rauc-ci && \
+    echo "rauc-ci ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/rauc-ci
 
 USER rauc-ci

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -56,7 +56,6 @@ RUN apt-get install -q -y --no-install-recommends \
   python3-pip \
   git \
   curl && \
-  rm -rf /var/lib/apt/lists/* && \
   curl -sLo /usr/bin/codecov https://codecov.io/bash && \
   chmod +x /usr/bin/codecov
 
@@ -71,6 +70,9 @@ RUN git clone https://github.com/folbricht/desync.git /tmp/desync && \
 
 # Create required directories for bind mounts
 RUN mkdir -p /lib/modules /var/run/dbus
+
+# Remove apt lists
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN adduser --disabled-password --gecos "" rauc-ci
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get install -q -y --no-install-recommends \
   dbus \
   dbus-x11 \
   grub-common \
-  softhsm2 \
   opensc \
   opensc-pkcs11 \
   libengine-pkcs11-openssl \
@@ -58,6 +57,10 @@ RUN apt-get install -q -y --no-install-recommends \
   curl && \
   curl -sLo /usr/bin/codecov https://codecov.io/bash && \
   chmod +x /usr/bin/codecov
+
+# Install softhsm2 only on working architectures (32 bit arm seems broken)
+RUN test "$(uname -m)" = "armv7l" && exit 0; \
+    apt-get install -q -y --no-install-recommends softhsm2
 
 # Build and install the optional desync (pinned to version 0.9.3) only on x86_64
 ENV GOPATH=/go

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -62,10 +62,6 @@ RUN git clone https://github.com/folbricht/desync.git /tmp/desync && \
 RUN mkdir -p /lib/modules && \
     mkdir -p /var/run/dbus
 
-# We want to run as non-root user equaling uid of Travis' user 'travis' (2000)
-ENV user travis
+RUN adduser --disabled-password --gecos "" rauc-ci
 
-RUN useradd -u 2000 -m -d /home/${user} ${user} \
- && chown -R ${user} /home/${user}
-
-USER ${user}
+USER rauc-ci

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -63,8 +63,6 @@ RUN git clone https://github.com/folbricht/desync.git /tmp/desync && \
 RUN mkdir -p /lib/modules && \
     mkdir -p /var/run/dbus
 
-RUN pip3 install --upgrade cpp-coveralls
-
 # We want to run as non-root user equaling uid of Travis' user 'travis' (2000)
 ENV user travis
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -y \
   python3-sphinx \
   python3-sphinx-rtd-theme \
   dbus-x11 \
-  user-mode-linux \
   grub-common \
   softhsm2 \
   opensc \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -70,8 +70,7 @@ RUN git clone https://github.com/folbricht/desync.git /tmp/desync && \
     rm -rf /tmp/desync
 
 # Create required directories for bind mounts
-RUN mkdir -p /lib/modules && \
-    mkdir -p /var/run/dbus
+RUN mkdir -p /lib/modules /var/run/dbus
 
 RUN adduser --disabled-password --gecos "" rauc-ci
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,9 @@
 FROM debian:bullseye
 
 # Required for building
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
+  gcc \
+  g++ \
   meson \
   libtool \
   libglib2.0-dev \
@@ -12,21 +14,31 @@ RUN apt-get update && apt-get install -y \
   libfdisk-dev \
   libnl-genl-3-dev
 
+# Required for building the cgi example
+RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
+  autoconf \
+  automake \
+  make \
+  xz-utils
+
 # Required for testing
-RUN apt-get update && apt-get install -y \
+RUN apt-get install -q -y --no-install-recommends \
   squashfs-tools \
   dosfstools \
   lcov \
   slirp \
   python3-sphinx \
   python3-sphinx-rtd-theme \
+  dbus \
   dbus-x11 \
   grub-common \
   softhsm2 \
   opensc \
   opensc-pkcs11 \
   libengine-pkcs11-openssl \
+  fakeroot \
   faketime \
+  pseudo \
   time \
   kmod \
   uncrustify \
@@ -40,10 +52,9 @@ RUN apt-get update && apt-get install -y \
   golang
 
 # Required for test environment setup
-RUN apt-get update && apt-get install -y \
+RUN apt-get install -q -y --no-install-recommends \
   python3-pip \
   git \
-  gcc-10 \
   curl && \
   rm -rf /var/lib/apt/lists/* && \
   curl -sLo /usr/bin/codecov https://codecov.io/bash && \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -79,7 +79,7 @@ RUN mkdir -p /lib/modules /var/run/dbus
 # Remove apt lists
 RUN rm -rf /var/lib/apt/lists/*
 
-RUN adduser --disabled-password --gecos "" rauc-ci && \
+RUN adduser --disabled-password --comment "" rauc-ci && \
     echo "rauc-ci ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/rauc-ci
 
 USER rauc-ci

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -67,7 +67,7 @@ RUN test "$(uname -m)" != "x86_64" && exit 0; \
     git checkout c508eeb0865a5a7c2c9b1158a5f0414265d869df && \
     go install && \
     cp /go/bin/desync /usr/bin/desync && \
-    rm -rf /tmp/desync
+    rm -rf /tmp/desync /go
 
 # Create required directories for bind mounts
 RUN mkdir -p /lib/modules /var/run/dbus

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -48,8 +48,7 @@ RUN apt-get install -q -y --no-install-recommends \
   mtd-utils \
   python3-aiohttp \
   nginx-light \
-  fdisk \
-  golang
+  fdisk
 
 # Required for test environment setup
 RUN apt-get install -q -y --no-install-recommends \
@@ -59,9 +58,11 @@ RUN apt-get install -q -y --no-install-recommends \
   curl -sLo /usr/bin/codecov https://codecov.io/bash && \
   chmod +x /usr/bin/codecov
 
-# Install the optional desync (pinned to version 0.9.3)
+# Build and install the optional desync (pinned to version 0.9.3) only on x86_64
 ENV GOPATH=/go
-RUN git clone https://github.com/folbricht/desync.git /tmp/desync && \
+RUN test "$(uname -m)" != "x86_64" && exit 0; \
+    apt-get install -q -y --no-install-recommends golang && \
+    git clone https://github.com/folbricht/desync.git /tmp/desync && \
     cd /tmp/desync/cmd/desync && \
     git checkout c508eeb0865a5a7c2c9b1158a5f0414265d869df && \
     go install && \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 # Required for building
 RUN apt-get update -q && apt-get install -q -y --no-install-recommends \


### PR DESCRIPTION
This PR refactors our CI container builds to use podman instead of docker.

It also adds pre-built containers for arm/v5, arm/v7, arm64/v8 and 386, which allows us to drop the dependency installation under QEMU.

For now, we need to install a newer buildah/podman from Ubuntu noble, but we'll be able to drop that step when GitHub Actions adds an image for the Ubuntu 24.04 LTS release.

To show how the containers work, I've added one commit to pull them from jluebbe/rauc instead of the main repo. When this PR is reviewed, I'd drop that commit.