### PR TITLE
Resolve Conflict With OpenSSL's built-in Check Purpose 'codesign'

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -960,6 +960,12 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		g_propagate_error(error, ierror);
 		return FALSE;
 	}
+	/* Rewrite 'codesign' check-purpose to RAUC's internal 'codesign-rauc' check-purpose
+	 * to avoid conflicts with purpose definition from OpenSSL 3.2.0. */
+	if (g_strcmp0(c->keyring_check_purpose, "codesign") == 0) {
+		g_free(c->keyring_check_purpose);
+		c->keyring_check_purpose = g_strdup("codesign-rauc");
+	}
 
 	if (!check_remaining_keys(key_file, "keyring", &ierror)) {
 		g_propagate_error(error, ierror);

--- a/src/signature.c
+++ b/src/signature.c
@@ -66,6 +66,14 @@ static int check_purpose_code_sign(const X509_PURPOSE *xp, const X509 *const_x, 
 		return 0;
 	}
 
+	/* Despite we do not enforce it, CA browser forum notes a MUST on key usage.
+	 * (https://cabforum.org/wp-content/uploads/Baseline-Requirements-for-the-Issuance-and-Management-of-Code-Signing.v3.2.pdf
+	 * Section 7.1.2.3f)
+	 * For now, do not fail here, but at least emit a warning. */
+	if (!(ex_flags & EXFLAG_KUSAGE)) {
+		g_warning("Signer certificate should specify 'Key Usage' and mark it 'critical' to be fully CAB Forum compliant.");
+	}
+
 	return 1;
 }
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -96,7 +96,7 @@ gboolean signature_init(GError **error)
 	}
 
 	/* X509_TRUST_OBJECT_SIGN maps to the Code Signing ID (via OpenSSL's NID_code_sign) */
-	ret = X509_PURPOSE_add(id, X509_TRUST_OBJECT_SIGN, 0, check_purpose_code_sign, "Code signing", "codesign", NULL);
+	ret = X509_PURPOSE_add(id, X509_TRUST_OBJECT_SIGN, 0, check_purpose_code_sign, "Code signing", "codesign-rauc", NULL);
 	if (!ret) {
 		g_set_error(
 				error,

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -111,7 +111,7 @@ static void bundle_fixture_set_up_bundle_codesign(BundleFixture *fixture,
 	replace_strdup(&r_context_conf()->keypath, "test/openssl-ca/dev/private/xku-codeSigning.pem");
 	/* cert is already checked once during signing */
 	g_free(r_context()->config->keyring_check_purpose);
-	r_context()->config->keyring_check_purpose = g_strdup("codesign");
+	r_context()->config->keyring_check_purpose = g_strdup("codesign-rauc");
 
 	prepare_bundle(fixture, user_data);
 }
@@ -651,7 +651,7 @@ static void bundle_test_purpose_default(BundleFixture *fixture,
 	g_clear_pointer(&bundle, free_bundle);
 
 	g_message("testing purpose 'codesign' with default cert");
-	replace_strdup(&r_context()->config->keyring_check_purpose, "codesign");
+	replace_strdup(&r_context()->config->keyring_check_purpose, "codesign-rauc");
 	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
@@ -694,7 +694,7 @@ static void bundle_test_purpose_email(BundleFixture *fixture,
 	g_clear_pointer(&bundle, free_bundle);
 
 	g_message("testing purpose 'codesign' with 'smimesign' cert");
-	replace_strdup(&r_context()->config->keyring_check_purpose, "codesign");
+	replace_strdup(&r_context()->config->keyring_check_purpose, "codesign-rauc");
 	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_error(ierror, R_SIGNATURE_ERROR, R_SIGNATURE_ERROR_INVALID);
 	g_clear_error(&ierror);
@@ -738,7 +738,7 @@ static void bundle_test_purpose_codesign(BundleFixture *fixture,
 	g_assert_null(bundle);
 
 	g_message("testing purpose 'codesign' with 'codesign' cert");
-	replace_strdup(&r_context()->config->keyring_check_purpose, "codesign");
+	replace_strdup(&r_context()->config->keyring_check_purpose, "codesign-rauc");
 	res = check_bundle(fixture->bundlename, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -1016,7 +1016,7 @@ check-purpose=codesign\n";
 	g_assert_nonnull(config);
 	g_assert_true(config->keyring_allow_partial_chain);
 	g_assert_true(config->keyring_check_crl);
-	g_assert_cmpstr(config->keyring_check_purpose, ==, "codesign");
+	g_assert_cmpstr(config->keyring_check_purpose, ==, "codesign-rauc");
 }
 
 static void config_file_bundle_formats(ConfigFileFixture *fixture,


### PR DESCRIPTION
OpenSSL so far defined a number of certificate check purposes but none for 'codesign'. Thus RAUC added its own purpose check for this.

Since v3.2.0, OpenSSL now defines a 'codesign' check purpose itself which not only conflicts with the RAUC variant in naming, but also has some differences compared to the RAUC check:

* OpenSSL enforces `Key Usage` existence, while RAUC only checks that it allows digital signatures if it exists
* RAUC enforces that `Extended Key Usage` on CA certs allows code signing if it exists

While RAUC is stricter on the one hand and OpenSSL on the other hand, we tend to preserve the RAUC check first of all.
For this, the RAUC check purpose is renamed internally to `codesign-rauc` and the config file setting `check-purpose=codesign` will be mapped to this.

For where RAUC is actually too lazy (by not enforcing `Key Usage`) at least add a warning to point users to this and give them the opportunity to adapt their certificates.

Fixes #1311