### PR TITLE
test/common: add helper to build a GPtrArray from a ;-separated string

### DIFF
--- a/test/common.c
+++ b/test/common.c
@@ -422,6 +422,18 @@ void replace_strdup(gchar **dst, const gchar *src)
 	*dst = g_strdup(src);
 }
 
+GPtrArray *test_ptr_array_from_strsplit(const gchar *input)
+{
+	GPtrArray *result = g_ptr_array_new_with_free_func(g_free);
+	/* The strings will be owned by the returned GPtrArray, so we don't
+	 * want to free them via g_auto(GStrv). */
+	g_autofree GStrv strv = g_strsplit(input, ";", 0);
+
+	r_ptr_array_addv(result, strv, FALSE);
+
+	return result;
+}
+
 void* dup_test_mem(GPtrArray *ptrs, const void *mem, gsize len)
 {
 	void *result = g_memdup(mem, len);

--- a/test/common.h
+++ b/test/common.h
@@ -38,6 +38,12 @@ void flip_bits_fd(int fd, off_t offset, guint8 mask);
 void flip_bits_filename(gchar *filename, off_t offset, guint8 mask);
 void replace_strdup(gchar **dst, const gchar *src);
 
+/**
+ * Build a GPtrArray from a ;-separated string. The elements in the array are
+ * freed with the array itself.
+ */
+GPtrArray *test_ptr_array_from_strsplit(const gchar *input);
+
 void* dup_test_mem(GPtrArray *ptrs, const void *mem, gsize len);
 void* dup_test_printf(GPtrArray *ptrs, const gchar *str, ...)
 __attribute__((__format__(__printf__, 2, 3)));


### PR DESCRIPTION
This makes it easy to create a `GPtrArray` containing some strings for use in test cases.
It will be used in artifact tests.