### PR TITLE
docs/using: be more explicit on current pre-install hook implementation

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -414,8 +414,11 @@ executable, see the :ref:`sec-slot-hook-interface` section.
 .. rubric:: Pre-Install Hook
 
 The pre-install hook will be called right before the update procedure for the
-respective slot will be started. For slot types that represent a mountable file
-system, the hook will be executed with having the file system mounted.
+respective slot will be started.
+For target slot types that represent a mountable file system, the hook will be
+executed with the target slots' file system mounted.
+Note that a broken or unformatted target slot will currently cause the
+installation to be aborted with an error.
 
 .. code-block:: cfg
 


### PR DESCRIPTION
Pre-install hooks currently offer a guarantee that the target slot will be mounted. For this, we explicitly error-out if the target slot is unmountable for any reason.

This can cause unexpected troubles when running this from a system that does not have the target slot formatted (yet) or where the target slot's file system is broken for any reason.

Be more explicit in the documentation about this fact.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
