### PR TITLE
prepare for 1.11.1 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@ Release 1.11.1 (released Jan 15, 2024)
 * Ensure that only bootable slots can be marked with ``rauc staus mark-*``.
 * Fix boot detection when using the ``rauc.external`` kernel command-line flag.
 * Fix compatibility with OpenSSL 3.2 when using the ``codesign`` certificate
-  purpuse.
+  purpose.
 * Fix a double free when trying to install two bundles using casync without a
   service restart. (by Arseniy Lartsev)
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'rauc',
   'c',
-  version : '1.11',
+  version : '1.11.1',
   meson_version : '>=0.51',
   default_options: [
     'c_std=gnu11',


### PR DESCRIPTION
Update the meson version and fix a typo in the changelog.