### PR TITLE
test/update_handler: check return value of g_rmdir()

### DIFF
--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -598,7 +598,7 @@ out:
 		g_assert(g_remove(hookpath) == 0);
 	}
 
-	g_rmdir(mountprefix);
+	g_assert(g_rmdir(mountprefix) == 0);
 
 	g_free(slotpath);
 	g_free(imagename);


### PR DESCRIPTION
Fixes a non-severe defect in test code reported by Coverity.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
