### PR TITLE
src/main: more explicit handling of rauc install user interruption

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -316,7 +316,9 @@ static gboolean install_start(int argc, char **argv)
 				g_variant_dict_end(&dict), /* floating, no unref needed */
 				NULL,
 				&error)) {
-			g_printerr("Failed %s\n", error->message);
+			if (g_dbus_error_is_remote_error(error))
+				g_dbus_error_strip_remote_error(error);
+			g_printerr("Failed to contact rauc service: %s\n", error->message);
 			g_error_free(error);
 			goto out_loop;
 		}


### PR DESCRIPTION
When running 'rauc install ..' and pressing Ctrl+C, a common expectation is that this will interrupt the ongoing installation.

However, there is no current support for this in RAUC and it is also not really trivial.

Thus, to at least prevent wrong expectations, handle `SIGINT` explicitly and emit a message to the user to inform about the ongoing installation.

In the same enhance the message emitted when trying to run `rauc install` with an ongoing installation in the background.