### PR TITLE
src/nbd: initialize info_headers to NULL

### DIFF
--- a/src/nbd.c
+++ b/src/nbd.c
@@ -562,7 +562,7 @@ static void start_configure(struct RaucNBDContext *ctx, struct RaucNBDTransfer *
 
 	/* only read from the client on the first try */
 	if (!ctx->url) {
-		GStrv info_headers; /* array of strings such as 'Foo: bar' */
+		GStrv info_headers = NULL; /* array of strings such as 'Foo: bar' */
 
 		res = r_read_exact(ctx->sock, (guint8*)data, xfer->request.len, NULL);
 		g_assert_true(res);

--- a/test/rauc.t
+++ b/test/rauc.t
@@ -237,6 +237,11 @@ test_expect_success "rauc info (verity, adaptive, meta)" "
     info ${SHARNESS_TEST_DIRECTORY}/good-adaptive-meta-bundle.raucb
 "
 
+test_expect_success STREAMING "rauc info (streaming)" "
+  rauc --keyring $SHARNESS_TEST_DIRECTORY/openssl-ca/dev-ca.pem \
+    info http://127.0.0.1/test/good-verity-bundle.raucb
+"
+
 test_expect_success "rauc info (casync, plain)" "
   cp -L ${SHARNESS_TEST_DIRECTORY}/good-casync-bundle-1.5.1.raucb ${TEST_TMPDIR}/ &&
   test_when_finished rm -f ${TEST_TMPDIR}/good-casync-bundle-1.5.1.raucb &&


### PR DESCRIPTION
When `g_variant_dict_lookup()` does not find the given key, it does not modify the values of the arguments provided.

This results in `info_headers` being undefined and can cause the rauc-nbd-server to crash, which will result in a broken request on client side that lets RAUC terminate hard with:

    (rauc:769): rauc-nbd-ERROR **: 15:40:30.553: failed to recv nbd config reply header

The behavior of `g_variant_dict_lookup()` has also recently been clarified in the glib documentation:
https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3334

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
