### PR TITLE
src/nbd: fix nbd server 'no more retries' handling

### DIFF
--- a/src/nbd.c
+++ b/src/nbd.c
@@ -650,19 +650,25 @@ static void start_request(struct RaucNBDContext *ctx, struct RaucNBDTransfer *xf
 static gboolean finish_read(struct RaucNBDContext *ctx, struct RaucNBDTransfer *xfer)
 {
 	gboolean res = FALSE;
-	CURLcode code;
-	long response_code = 0;
 
 	if (!xfer->done) { /* retry */
 		res = TRUE;
 		goto out;
 	}
 
-	code = curl_easy_getinfo(xfer->easy, CURLINFO_RESPONSE_CODE, &response_code);
-	if (code != CURLE_OK)
-		g_error("unexpected error from curl_easy_getinfo in %s", G_STRFUNC);
-	if (response_code != 206)
-		g_error("unexpected HTTP response code %ld from curl_easy_getinfo in %s", response_code, G_STRFUNC);
+	/* If reply is considered error-free so far, check that response_code
+	 * is actually 206 */
+	if (xfer->reply.error == 0) {
+		long response_code = 0;
+		CURLcode code = curl_easy_getinfo(xfer->easy, CURLINFO_RESPONSE_CODE, &response_code);
+		if (code != CURLE_OK)
+			g_error("unexpected error from curl_easy_getinfo in %s", G_STRFUNC);
+
+		if (response_code != 206) {
+			g_warning("unexpected HTTP response code %ld from curl_easy_getinfo in %s", response_code, G_STRFUNC);
+			xfer->reply.error = GUINT32_TO_BE(5); /* NBD_EIO */
+		}
+	}
 
 	if (!r_write_exact(ctx->sock, (guint8*)&xfer->reply, sizeof(xfer->reply), NULL))
 		g_error("failed to send nbd read reply header");


### PR DESCRIPTION
When the running nbd server fails to read from the remote HTTP(S) server, it will trigger a retry.
After 5 retires, it sets `xfer->reply.error` to `GUINT32_TO_BE(5)` with the intention to signal an IO error to the NBD client, which is the kernel's nbd implementation in this case.

But, when entering finish_read(), there was a check for the HTTP response code being != 206 (Partial Content) with a hard `g_error()`.

This handling was wrong, since when entering the method after the retry abort, we have to expect that the last HTTP response code indicated an error.

The least invasive fix for this is to just change the g_error() to g_message(). (It might be worth discussing if checking the response code here gives any benefit at all.)

With this change, the NDB client will now receive an EIO after 5 failed retries. But the ndb server does not terminate. Instead, it will continue running and do another round of retries.
Tested with kernel v6.5.7, after the second EIO, the kernel NBD gives up and terminates the NBD client.

For reference, an example system log from the lost connection on would then be:

> rauc[1430]: Write image to inactive (second) half of boot partition region on /dev/sda
> rauc-nbd[1440]: request failed: Couldn't connect to server (retrying)
> rauc-nbd[1440]: request failed: Couldn't connect to server (retrying)
> rauc-nbd[1440]: request failed: Couldn't connect to server (retrying)
> rauc-nbd[1440]: request failed: Couldn't connect to server (retrying)
> rauc-nbd[1440]: request failed: Couldn't connect to server (retrying)
> rauc-nbd[1440]: request failed (no more retries)
> kernel: block nbd0: Other side returned error (5)
> kernel: I/O error, dev nbd0, sector 98816 op 0x0:(READ) flags 0x800 phys_seg 7 prio class 2
> kernel: SQUASHFS error: Failed to read block 0x3040d4e: -5
> kernel[250]: [10026.715676] block nbd0: Other side returned error (5)
> rauc-nbd[1440]: unexpected HTTP response code 0 from curl_easy_getinfo in finish_read
> kernel[250]: [10026.716923] I/O error, dev nbd0, sector 98816 op 0x0:(READ) flags 0x800 phys_seg 7 prio class 2
> rauc-nbd[1440]: request failed: Couldn't connect to server (retrying)
> kernel[250]: [10026.719776] SQUASHFS error: Failed to read block 0x3040d4e: -5
> rauc-nbd[1440]: request failed: Couldn't connect to server (retrying)
> rauc-nbd[1440]: request failed: Couldn't connect to server (retrying)
> rauc-nbd[1440]: request failed: Couldn't connect to server (retrying)
> rauc-nbd[1440]: request failed: Couldn't connect to server (retrying)
> rauc-nbd[1440]: request failed (no more retries)
> kernel: block nbd0: Other side returned error (5)
> kernel: I/O error, dev nbd0, sector 98816 op 0x0:(READ) flags 0x800 phys_seg 7 prio class 2
> kernel: SQUASHFS error: Failed to read block 0x3040d4e: -5
> kernel: SQUASHFS error: Unable to read data cache entry [3040d4e]
> kernel: SQUASHFS error: Unable to read page, block 3040d4e, size 57f1
> kernel[250]: [10031.785203] block nbd0: Other side returned error (5)
> rauc-nbd[1440]: unexpected HTTP response code 0 from curl_easy_getinfo in finish_read
> kernel[250]: [10031.786041] I/O error, dev nbd0, sector 98816 op 0x0:(READ) flags 0x800 phys_seg 7 prio class 2
> rauc[1430]: Updating slot efi.0 status
> kernel[250]: [10031.787585] SQUASHFS error: Failed to read block 0x3040d4e: -5
> kernel[250]: [10031.788211] SQUASHFS error: Unable to read data cache entry [3040d4e]
> kernel[250]: [10031.789460] SQUASHFS error: Unable to read page, block 3040d4e, size 57f1
> rauc[1430]: r_nbd_remove_device
> kernel: block nbd0: NBD_DISCONNECT
> kernel: block nbd0: Disconnected due to user request.
> kernel: block nbd0: shutting down sockets
> rauc-nbd[1440]: disconnect
> kernel[250]: [10031.931011] block nbd0: NBD_DISCONNECT
> rauc-nbd[1440]: nbd dl_size: count=47 sum=731132.000 min=0.000 max=131072.000 avg=15556.000 recent-avg=15556.000
> kernel[250]: [10031.931883] block nbd0: Disconnected due to user request.
> rauc-nbd[1440]: nbd dl_speed: count=47 sum=88465068.000 min=0.000 max=23285957.000 avg=1882235.489 recent-avg=1882235.489
> kernel[250]: [10031.932776] block nbd0: shutting down sockets
> rauc-nbd[1440]: nbd namelookup: count=47 sum=0.073 min=0.001 max=0.008 avg=0.002 recent-avg=0.002
> rauc-nbd[1440]: nbd connect: count=47 sum=0.166 min=0.000 max=0.016 avg=0.004 recent-avg=0.004
> rauc-nbd[1440]: nbd starttransfer: count=47 sum=0.252 min=0.000 max=0.019 avg=0.005 recent-avg=0.005
> rauc-nbd[1440]: nbd total: count=47 sum=0.312 min=0.003 max=0.031 avg=0.007 recent-avg=0.007
> rauc-nbd[1440]: exiting nbd server
> rauc[1430]: nbd server stopping
> rauc[1430]: nbd server stopped

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
