### PR TITLE
src/install: remove redundant installation rejection log message

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -1355,7 +1355,6 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	}
 
 	if (bundle->manifest && bundle->manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT && !bundle->was_encrypted) {
-		r_event_log_message(R_EVENT_LOG_TYPE_INSTALL, "Installation %.8s rejected: Refusing to install unencrypted crypt bundles", args->transaction);
 		g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_REJECTED, "Refusing to install unencrypted crypt bundles");
 		res = FALSE;
 		goto out;


### PR DESCRIPTION
The log message for a rejected 'unencrypted crypt bundle' will be emitted by the call of `log_event_installation_done()` anyway (and with proper `MESSAGE_ID`, etc.).

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
