### PR TITLE
src/install: add bundle/manifest build value to hook environment

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1245,6 +1245,10 @@ The following environment variables will be passed to the hook executable:
   The value of the version field as provided by the current bundle,
   e.g. ``"V1.2.1-2020-02-28"``
 
+``RAUC_MF_BUILD``
+  The value of the build field as provided by the current bundle,
+  e.g. ``"20240205092747"``
+
 ``RAUC_MOUNT_PREFIX``
   The global RAUC mount prefix path, e.g. ``"/run/mount/rauc"``
 

--- a/src/install.c
+++ b/src/install.c
@@ -777,6 +777,7 @@ static gboolean run_bundle_hook(RaucManifest *manifest, gchar* bundledir, const 
 
 	g_subprocess_launcher_setenv(launcher, "RAUC_MF_COMPATIBLE", manifest->update_compatible, TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_MF_VERSION", manifest->update_version ?: "", TRUE);
+	g_subprocess_launcher_setenv(launcher, "RAUC_MF_BUILD", manifest->update_build ?: "", TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_MOUNT_PREFIX", r_context()->config->mount_prefix, TRUE);
 
 	sproc = g_subprocess_launcher_spawn(


### PR DESCRIPTION
Add the value as RAUC_MF_BUILD to the execution environment of the install hook.
