### PR TITLE
Slightly Stricter Style Checks

### DIFF
--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -1,6 +1,7 @@
 # Uncrustify-0.70.1
 string_replace_tab_chars        = true
 sp_assign                       = force
+sp_bool                         = force
 sp_before_sparen                = add
 sp_func_proto_paren             = remove
 sp_func_def_paren               = remove

--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -1,6 +1,6 @@
 # Uncrustify-0.70.1
 string_replace_tab_chars        = true
-sp_assign                       = add
+sp_assign                       = force
 sp_before_sparen                = add
 sp_func_proto_paren             = remove
 sp_func_def_paren               = remove

--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -2,6 +2,7 @@
 string_replace_tab_chars        = true
 sp_assign                       = force
 sp_bool                         = force
+sp_compare                      = force
 sp_before_sparen                = add
 sp_func_proto_paren             = remove
 sp_func_def_paren               = remove

--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -8,6 +8,7 @@ sp_func_call_paren              = remove
 sp_else_brace                   = add
 sp_brace_else                   = add
 sp_cond_ternary_short           = remove
+sp_after_comma                  = add
 indent_func_call_param          = true
 indent_func_def_param           = true
 indent_func_proto_param         = true

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -903,7 +903,7 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 	g_print("Creating '%s' format bundle\n", r_manifest_bundle_format_to_str(manifest->bundle_format));
 
 	/* print warnings collected while parsing */
-	for (guint i =  0; i < manifest->warnings->len; i++) {
+	for (guint i = 0; i < manifest->warnings->len; i++) {
 		g_print("%s\n", (gchar *)g_ptr_array_index(manifest->warnings, i));
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -2045,9 +2045,9 @@ static void r_event_log_booted(const RaucSlot *booted_slot)
 	fields[0].value = message;
 	fields[4].value = r_context()->boot_id;
 	if (booted_slot->status && booted_slot->status->bundle_hash) {
-		fields[5].value =  booted_slot->status->bundle_hash;
+		fields[5].value = booted_slot->status->bundle_hash;
 	} else {
-		fields[5].value =  "unknown";
+		fields[5].value = "unknown";
 	}
 	g_log_structured_array(G_LOG_LEVEL_INFO, fields, G_N_ELEMENTS(fields));
 }
@@ -2356,15 +2356,15 @@ static void create_option_groups(void)
 		g_option_group_add_entries(install_group, entries_bundle_access);
 
 	if (ENABLE_CREATE) {
-		bundle_group  = g_option_group_new("bundle", "Bundle options:", "help dummy", NULL, NULL);
+		bundle_group = g_option_group_new("bundle", "Bundle options:", "help dummy", NULL, NULL);
 		g_option_group_add_entries(bundle_group, entries_bundle);
 		g_option_group_add_entries(bundle_group, entries_signing);
 
-		resign_group  = g_option_group_new("resign", "Resign options:", "help dummy", NULL, NULL);
+		resign_group = g_option_group_new("resign", "Resign options:", "help dummy", NULL, NULL);
 		g_option_group_add_entries(resign_group, entries_resign);
 		g_option_group_add_entries(resign_group, entries_signing);
 
-		replace_group  = g_option_group_new("replace-signature", "Replace signature options:", "help dummy", NULL, NULL);
+		replace_group = g_option_group_new("replace-signature", "Replace signature options:", "help dummy", NULL, NULL);
 		g_option_group_add_entries(replace_group, entries_replace);
 
 		convert_group = g_option_group_new("convert", "Convert options:", "help dummy", NULL, NULL);
@@ -2381,15 +2381,15 @@ static void create_option_groups(void)
 	extract_group = g_option_group_new("extract", "Extract options:", "help dummy", NULL, NULL);
 	g_option_group_add_entries(extract_group, entries_extract);
 
-	info_group    = g_option_group_new("info", "Info options:", "help dummy", NULL, NULL);
+	info_group = g_option_group_new("info", "Info options:", "help dummy", NULL, NULL);
 	g_option_group_add_entries(info_group, entries_info);
 	if (ENABLE_STREAMING)
 		g_option_group_add_entries(info_group, entries_bundle_access);
 
-	status_group  = g_option_group_new("status", "Status options:", "help dummy", NULL, NULL);
+	status_group = g_option_group_new("status", "Status options:", "help dummy", NULL, NULL);
 	g_option_group_add_entries(status_group, entries_status);
 
-	service_group  = g_option_group_new("service", "Service options:", "help dummy", NULL, NULL);
+	service_group = g_option_group_new("service", "Service options:", "help dummy", NULL, NULL);
 	g_option_group_add_entries(service_group, entries_service);
 }
 

--- a/src/nbd.c
+++ b/src/nbd.c
@@ -741,7 +741,7 @@ static gboolean finish_configure(struct RaucNBDContext *ctx, struct RaucNBDTrans
 	code = curl_easy_getinfo(xfer->easy, CURLINFO_EFFECTIVE_URL, &effective_url);
 	if (code == CURLE_OK) {
 		if (!g_str_equal(ctx->url, effective_url))
-			g_message("redirected from %s to %s",ctx->url, effective_url);
+			g_message("redirected from %s to %s", ctx->url, effective_url);
 		g_free(ctx->url);
 		ctx->url = g_strdup(effective_url);
 	}

--- a/test/dm.c
+++ b/test/dm.c
@@ -231,7 +231,7 @@ static void dm_verity_simple_test(void)
 	g_assert_no_error(error);
 	g_assert_true(res);
 
-	for (int i = 0; i<129; i++) {
+	for (int i = 0; i < 129; i++) {
 		int r = read(fd, buf, sizeof(buf));
 		g_assert_cmpint(r, ==, 4096);
 		g_assert_cmpint(buf[0], ==, 0);

--- a/test/fakerand.c
+++ b/test/fakerand.c
@@ -14,7 +14,7 @@ int main(int argc, char **argv)
 	int count = 1024;
 
 	if (ioctl(fd, RNDADDTOENTCNT, &count) != 0) {
-		printf("RNDADDENTROPY failed: %s\n",strerror(errno));
+		printf("RNDADDENTROPY failed: %s\n", strerror(errno));
 		return 1;
 	}
 

--- a/test/service.c
+++ b/test/service.c
@@ -186,12 +186,12 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Updating slots", 2));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Checking slot rootfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  43, "Checking slot rootfs.1 done.", 3));
-	for (gint32 i = 43; i<= 69; i++)
+	for (gint32 i = 43; i <= 69; i++)
 		g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)", i, "Copying image to rootfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  70, "Copying image to rootfs.1 done.", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  70, "Checking slot appfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  73, "Checking slot appfs.1 done.", 3));
-	for (gint32 i = 73; i<= 99; i++)
+	for (gint32 i = 73; i <= 99; i++)
 		g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)", i, "Copying image to appfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  99, "Copying image to appfs.1 done.", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  99, "Updating slots done.", 2));

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -342,7 +342,7 @@ static void test_update_handler(UpdateHandlerFixture *fixture,
 	/* prepare image and slot information */
 	image_size = IMAGE_SIZE;
 	imagename = g_strconcat("image.", test_pair->imagetype, NULL);
-	if (g_strcmp0(test_pair->slottype, "ubivol") == 0||
+	if (g_strcmp0(test_pair->slottype, "ubivol") == 0 ||
 	    g_strcmp0(test_pair->slottype, "ubifs") == 0) {
 		slotpath = g_strdup(g_getenv("RAUC_TEST_MTD_UBIVOL"));
 		if (!slotpath) {

--- a/test/utils.c
+++ b/test/utils.c
@@ -175,7 +175,7 @@ static void fakeroot_test(void)
 	g_autofree gchar *stdout = NULL;
 	gboolean res = FALSE;
 
-	if (g_strcmp0(g_get_host_name(), "qemu-test") !=0) {
+	if (g_strcmp0(g_get_host_name(), "qemu-test") != 0) {
 		g_test_message("fakeroot test is only supported under qemu-test");
 		g_test_skip("not running under qemu-test");
 		return;


### PR DESCRIPTION
This makes three uncrustify options stricter that have a manageable impact on the current code but can help to keep the style even more readable and consistent:

* enforce spaces around assignments, comparisons, and boolean operators
* add spaces after commas

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
