### PR TITLE
Update CodeQL Workflow for Code Security Analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "tseting2" ]
+    branches: [ "master", "codeql" ]
+  pull_request:
+    branches: [ "master", "codeql" ]
+  schedule:
+    - cron: "23 8 * * 5"
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,11 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master", "codeql" ]
-  pull_request:
-    branches: [ "master", "codeql" ]
-  schedule:
-    - cron: "23 8 * * 5"
+    branches: [ "tseting2" ]
 
 jobs:
   analyze:
@@ -41,3 +37,39 @@ jobs:
         uses: github/codeql-action/analyze@v2
         with:
           category: "/language:cpp"
+          upload: false
+        id: step1
+
+      - name: Filter out unwanted errors and warnings
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -**:cpp/path-injection
+            -**:cpp/world-writable-file-creation
+            -**:cpp/poorly-documented-function
+            -**:cpp/potentially-dangerous-function
+            -**:cpp/use-of-goto
+            -**:cpp/integer-multiplication-cast-to-long
+            -**:cpp/comparison-with-wider-type
+            -**:cpp/leap-year/*
+            -**:cpp/ambiguously-signed-bit-field
+            -**:cpp/suspicious-pointer-scaling
+            -**:cpp/suspicious-pointer-scaling-void
+            -**:cpp/unsigned-comparison-zero
+            -**/cmake*/Modules/**
+          input: ${{ steps.step1.outputs.sarif-output }}/cpp.sarif
+          output: ${{ steps.step1.outputs.sarif-output }}/cpp.sarif
+
+      - name: Upload CodeQL results to code scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.step1.outputs.sarif-output }}
+          category: "/language:cpp"
+
+      - name: Upload CodeQL results as an artifact
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: codeql-results
+          path: ${{ steps.step1.outputs.sarif-output }}
+          retention-days: 5


### PR DESCRIPTION
We are researchers at Purdue University in the USA. We are studying the potential benefits and costs of using CodeQL on open-source repositories of embedded software.

We wrote up a report of our findings so far. The TL;DR is “CodeQL outperforms the other freely-available static analysis tools, with fairly low false positive rates and lots of real defects”. You can read about the report here: https://arxiv.org/abs/2310.00205

This PR builds on the previous workflow functionality by allowing for rule filtration, uploading CodeQL results to Code scanning, and uploading CodeQL results as an artifact.

False positives: We find that around 20% of errors are false positives, but that these FPs are polarized and only a few rules contribute to most FPs. We find that the top rules contributing to FPs are: cpp/uninitialized-local, cpp/missing-check-scanf, cpp/suspicious-pointer-scaling, cpp/unbounded-write, cpp/constant-comparison, and cpp/inconsistent-null-check. Adding a filter to filter out certain rules that contribute to a high FP rate can be done simply in the workflow file.

Uploading to Code scanning: This workflow uploads the results to Code scanning under the Security tab on GitHub:
![image](https://github.com/rauc/rauc/assets/89487381/e7535738-47e8-41ff-b7c6-a0157c88367f)
From here, vulnerabilities can be addressed simply by clicking the bug or dismissed for various reasons:
![image](https://github.com/rauc/rauc/assets/89487381/a60dcd88-f907-4164-abc9-6a9e3ea23fe4)

Uploading as an artifact: This workflow also uploads the results as an artifact with a retention period of 5 days.
      