### PR TITLE
src/bundle: prefix manifest load errors with hint on manifest

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -896,7 +896,8 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 
 	res = load_manifest_file(manifestpath, &manifest, &ierror);
 	if (!res) {
-		g_propagate_error(error, ierror);
+		g_propagate_prefixed_error(error, ierror,
+				"Failed to load manifest: ");
 		goto out;
 	}
 
@@ -1126,7 +1127,8 @@ static gboolean convert_to_casync_bundle(RaucBundle *bundle, const gchar *outbun
 	/* Load manifest from content/ dir */
 	res = load_manifest_file(mfpath, &manifest, &ierror);
 	if (!res) {
-		g_propagate_error(error, ierror);
+		g_propagate_prefixed_error(error, ierror,
+				"Failed to load manifest: ");
 		goto out;
 	}
 
@@ -2219,7 +2221,8 @@ gboolean replace_signature(RaucBundle *bundle, const gchar *insig, const gchar *
 	} else {
 		res = load_manifest_from_bundle(bundle, &loaded_manifest, &ierror);
 		if (!res) {
-			g_propagate_error(error, ierror);
+			g_propagate_prefixed_error(error, ierror,
+					"Failed to load manifest: ");
 			goto out;
 		}
 		manifest = loaded_manifest;


### PR DESCRIPTION
If we only forward the parsing errors from load_manifest_*() methods, they will look like:

 >Failed to create bundle: Key file contains line 'EOF' which is not a key-value pair, group, or comment

This does no real indication that it's the manifest that RAUC failed to read and will thus not be very helpful for people who are not that deep into RAUC.

With the prefix, we get a better hint now:

> Failed to create bundle: Failed to load manifest: Key file contains line 'EOF' which is not a key-value pair, group, or comment

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
