### PR TITLE
Simplify and Fix Bootslot Handling

### DIFF
--- a/include/slot.h
+++ b/include/slot.h
@@ -111,6 +111,15 @@ RaucSlot *r_slot_find_by_bootname(GHashTable *slots, const gchar *bootname)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Returns booted slot.
+ *
+ * @param slots a GHashTable containing (gchar, RaucSlot) entries
+ *
+ * @return a RaucSlot pointer or NULL
+ */
+RaucSlot *r_slot_get_booted(GHashTable *slots);
+
+/**
  * Get string representation of slot state
  *
  * @param slotstate state to turn into string

--- a/include/slot.h
+++ b/include/slot.h
@@ -100,17 +100,6 @@ RaucSlot *r_slot_find_by_device(GHashTable *slots, const gchar *device)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
- * Finds a slot given its bootname
- *
- * @param slots a GHashTable containing (gchar, RaucSlot) entries
- * @param botname the bootname to search for
- *
- * @return a RaucSlot pointer or NULL
- */
-RaucSlot *r_slot_find_by_bootname(GHashTable *slots, const gchar *bootname)
-G_GNUC_WARN_UNUSED_RESULT;
-
-/**
  * Returns booted slot.
  *
  * @param slots a GHashTable containing (gchar, RaucSlot) entries

--- a/src/main.c
+++ b/src/main.c
@@ -1413,9 +1413,7 @@ static gchar* r_status_formatter_readable(RaucStatusPrint *status)
 
 	g_return_val_if_fail(status, NULL);
 
-	bootedfrom = r_slot_find_by_device(status->slots, status->bootslot);
-	if (!bootedfrom)
-		bootedfrom = r_slot_find_by_bootname(status->slots, status->bootslot);
+	bootedfrom = r_slot_get_booted(status->slots);
 
 	g_string_append(text, "=== System Info ===\n");
 	g_string_append_printf(text, "Compatible:  %s\n", status->compatible);

--- a/src/main.c
+++ b/src/main.c
@@ -2123,9 +2123,7 @@ static gboolean service_start(int argc, char **argv)
 			if (g_strcmp0(r_context()->bootslot, "_external_") == 0) {
 				r_event_log_booted_external();
 			} else {
-				RaucSlot *booted_slot = r_slot_find_by_device(r_context()->config->slots, r_context()->bootslot);
-				if (!booted_slot)
-					booted_slot = r_slot_find_by_bootname(r_context()->config->slots, r_context()->bootslot);
+				RaucSlot *booted_slot = r_slot_get_booted(r_context()->config->slots);
 
 				r_slot_status_load(booted_slot);
 

--- a/src/slot.c
+++ b/src/slot.c
@@ -75,27 +75,6 @@ out:
 	return slot;
 }
 
-RaucSlot *r_slot_find_by_bootname(GHashTable *slots, const gchar *bootname)
-{
-	GHashTableIter iter;
-	RaucSlot *slot;
-
-	g_return_val_if_fail(slots, NULL);
-	g_return_val_if_fail(bootname, NULL);
-
-	g_hash_table_iter_init(&iter, slots);
-	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
-		if (g_strcmp0(slot->bootname, bootname) == 0) {
-			goto out;
-		}
-	}
-
-	slot = NULL;
-
-out:
-	return slot;
-}
-
 RaucSlot *r_slot_get_booted(GHashTable *slots)
 {
 	GHashTableIter iter;

--- a/src/slot.c
+++ b/src/slot.c
@@ -96,6 +96,26 @@ out:
 	return slot;
 }
 
+RaucSlot *r_slot_get_booted(GHashTable *slots)
+{
+	GHashTableIter iter;
+	RaucSlot *slot;
+
+	g_return_val_if_fail(slots, NULL);
+
+	g_hash_table_iter_init(&iter, slots);
+	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
+		if (slot->state == ST_BOOTED) {
+			goto out;
+		}
+	}
+
+	slot = NULL;
+
+out:
+	return slot;
+}
+
 /* returns string representation of slot state */
 const gchar* r_slot_slotstate_to_str(SlotState slotstate)
 {


### PR DESCRIPTION
* Introduces a helper `r_slot_get_booted()` to get the determined boot slot
* Replace indirect re-determination of bootslot
* remove obsolete helper `r_slot_find_by_bootname()` then

Fixes #1360