### PR TITLE
add bundle format to shell and json output of rauc info

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1125,6 +1125,9 @@ static gchar* info_formatter_json_base(RaucManifest *manifest, gboolean pretty)
 	json_builder_set_member_name(builder, "build");
 	json_builder_add_string_value(builder, manifest->update_build);
 
+	json_builder_set_member_name(builder, "format");
+	json_builder_add_string_value(builder, r_manifest_bundle_format_to_str(manifest->bundle_format));
+
 	json_builder_set_member_name(builder, "hooks");
 	json_builder_begin_array(builder);
 	if (manifest->hooks.install_check == TRUE) {

--- a/src/main.c
+++ b/src/main.c
@@ -892,6 +892,7 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 	formatter_shell_append(text, "RAUC_MF_DESCRIPTION", manifest->update_description);
 	formatter_shell_append(text, "RAUC_MF_BUILD", manifest->update_build);
 	formatter_shell_append(text, "RAUC_MF_HASH", manifest->hash);
+	formatter_shell_append(text, "RAUC_MF_FORMAT", r_manifest_bundle_format_to_str(manifest->bundle_format));
 	g_string_append_printf(text, "RAUC_MF_IMAGES=%d\n", g_list_length(manifest->images));
 
 	hooks = g_ptr_array_new();


### PR DESCRIPTION
The bundle format is displayed in the standard "readable" output format for rauc info but it is missing from the shell and JSON formatters. Add it now.

Notice that I only added the format and not the format specific details shown by the "readable" format. I currently don't have a need for those, but we could add it if needed.

Example of the shell formatter:
```
rauc --output-format=shell info foo.raucb
RAUC_MF_COMPATIBLE='...'
RAUC_MF_VERSION='...'
RAUC_MF_DESCRIPTION='..'
RAUC_MF_BUILD='...'
RAUC_MF_HASH='085860cd4e09a942c6ed1bf4682a3b7d8cfd0574b1df2371a260ca25bf7f7f05'
RAUC_MF_FORMAT='verity'
```