### PR TITLE
Pass system version to all hooks

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1660,6 +1660,9 @@ variables.
   The system's variant as obtained by the variant source
   (refer :ref:`sec-variants`)
 
+``RAUC_SYSTEM_VERSION``
+  The system version obtained from the ``system-info`` handler.
+
 ``RAUC_CURRENT_BOOTNAME``
   Bootname of the slot the system is currently booted from
 
@@ -1738,6 +1741,9 @@ The following environment variables will be passed to the hook executable:
   The system's variant as obtained by the variant source
   (refer :ref:`sec-variants`)
 
+``RAUC_SYSTEM_VERSION``
+  The system version obtained from the ``system-info`` handler.
+
 ``RAUC_MF_COMPATIBLE``
   The compatible value provided by the current bundle,
   e.g. ``"My Other Product"``
@@ -1767,6 +1773,9 @@ The following environment variables will be passed to the hook executable:
 ``RAUC_SYSTEM_VARIANT``
   The system's variant as obtained by the variant source
   (refer :ref:`sec-variants`)
+
+``RAUC_SYSTEM_VERSION``
+  The system version obtained from the ``system-info`` handler.
 
 ``RAUC_SLOT_NAME``
   The name of the currently installed slot, e.g ``"rootfs.1"``.

--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -104,6 +104,8 @@
     <property name="Compatible" type="s" access="read"/>
     <!-- Variant: Represents the system's variant -->
     <property name="Variant" type="s" access="read"/>
+    <!-- SystemVersion: Represents the system's version -->
+    <property name="SystemVersion" type="s" access="read"/>
     <!-- BootSlot: Represents the slot booted from -->
     <property name="BootSlot" type="s" access="read"/>
     <!--

--- a/src/install.c
+++ b/src/install.c
@@ -685,6 +685,7 @@ static gchar **add_system_environment(gchar **envp)
 
 	envp = g_environ_setenv(envp, "RAUC_SYSTEM_CONFIG", r_context()->configpath, TRUE);
 	envp = g_environ_setenv(envp, "RAUC_SYSTEM_VARIANT", r_context()->config->system_variant ?: "", TRUE);
+	envp = g_environ_setenv(envp, "RAUC_SYSTEM_VERSION", r_context()->system_version ?: "", TRUE);
 	envp = g_environ_setenv(envp, "RAUC_CURRENT_BOOTNAME", r_context()->bootslot, TRUE);
 	envp = g_environ_setenv(envp, "RAUC_MOUNT_PREFIX", r_context()->config->mount_prefix, TRUE);
 
@@ -906,6 +907,7 @@ static gboolean run_bundle_hook(RaucManifest *manifest, gchar* bundledir, const 
 
 	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_COMPATIBLE", r_context()->config->system_compatible, TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_VARIANT", r_context()->config->system_variant ?: "", TRUE);
+	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_VERSION", r_context()->system_version ?: "", TRUE);
 
 	g_subprocess_launcher_setenv(launcher, "RAUC_MF_COMPATIBLE", manifest->update_compatible, TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_MF_VERSION", manifest->update_version ?: "", TRUE);

--- a/src/main.c
+++ b/src/main.c
@@ -1426,6 +1426,7 @@ typedef struct {
 	RaucSlot *primary;
 	gchar *compatible;
 	gchar *variant;
+	gchar *system_version;
 	gchar *bootslot;
 	GHashTable *slots;
 	GVariant *artifacts;
@@ -1438,6 +1439,7 @@ static void free_status_print(RaucStatusPrint *status)
 
 	g_free(status->compatible);
 	g_free(status->variant);
+	g_free(status->system_version);
 	g_free(status->bootslot);
 	if (status->slots)
 		g_hash_table_unref(status->slots);
@@ -1598,9 +1600,10 @@ static gchar* r_status_formatter_readable(RaucStatusPrint *status)
 	bootedfrom = r_slot_get_booted(status->slots);
 
 	g_string_append(text, "=== System Info ===\n");
-	g_string_append_printf(text, "Compatible:  %s\n", status->compatible);
-	g_string_append_printf(text, "Variant:     %s\n", status->variant);
-	g_string_append_printf(text, "Booted from: %s (%s)\n\n", bootedfrom ? bootedfrom->name : NULL, status->bootslot);
+	g_string_append_printf(text, "Compatible:     %s\n", status->compatible);
+	g_string_append_printf(text, "Variant:        %s\n", status->variant);
+	g_string_append_printf(text, "System Version: %s\n", status->system_version);
+	g_string_append_printf(text, "Booted from:    %s (%s)\n\n", bootedfrom ? bootedfrom->name : NULL, status->bootslot);
 
 	g_string_append(text, "=== Bootloader ===\n");
 	if (!status->primary)
@@ -1663,6 +1666,7 @@ static gchar* r_status_formatter_shell(RaucStatusPrint *status)
 
 	r_ptr_array_add_printf(entries, "RAUC_SYSTEM_COMPATIBLE=%s", status->compatible);
 	r_ptr_array_add_printf(entries, "RAUC_SYSTEM_VARIANT=%s", status->variant);
+	r_ptr_array_add_printf(entries, "RAUC_SYSTEM_VERSION=%s", status->system_version);
 	r_ptr_array_add_printf(entries, "RAUC_SYSTEM_BOOTED_BOOTNAME=%s", status->bootslot);
 	r_ptr_array_add_printf(entries, "RAUC_BOOT_PRIMARY=%s", status->primary ? status->primary->name : NULL);
 
@@ -1820,6 +1824,9 @@ static gchar* r_status_formatter_json(RaucStatusPrint *status, gboolean pretty)
 
 	json_builder_set_member_name(builder, "variant");
 	json_builder_add_string_value(builder, status->variant);
+
+	json_builder_set_member_name(builder, "system_version");
+	json_builder_add_string_value(builder, status->system_version);
 
 	json_builder_set_member_name(builder, "booted");
 	json_builder_add_string_value(builder, status->bootslot);
@@ -2135,6 +2142,7 @@ static gboolean retrieve_status_via_dbus(RaucStatusPrint **status_print, GError 
 	}
 
 	istatus->variant = r_installer_dup_variant(proxy);
+	istatus->system_version = r_installer_dup_system_version(proxy);
 	istatus->compatible = r_installer_dup_compatible(proxy);
 	istatus->bootslot = r_installer_dup_boot_slot(proxy);
 
@@ -2242,6 +2250,7 @@ static gboolean status_start(int argc, char **argv)
 
 		status_print->compatible = g_strdup(r_context()->config->system_compatible);
 		status_print->variant = g_strdup(r_context()->config->system_variant);
+		status_print->system_version = g_strdup(r_context()->system_version);
 		status_print->bootslot = g_strdup(r_context()->bootslot);
 		status_print->slots = g_hash_table_ref(r_context()->config->slots);
 		status_print->artifacts = r_artifacts_to_dict();

--- a/src/service.c
+++ b/src/service.c
@@ -612,6 +612,7 @@ static void r_on_bus_acquired(GDBusConnection *connection,
 
 	r_installer_set_compatible(r_installer, r_context()->config->system_compatible);
 	r_installer_set_variant(r_installer, r_context()->config->system_variant);
+	r_installer_set_system_version(r_installer, r_context()->system_version);
 	r_installer_set_boot_slot(r_installer, r_context()->bootslot);
 
 	r_polling_on_bus_acquired(connection);

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1406,6 +1406,7 @@ static gboolean run_slot_hook_extra_env(const gchar *hook_name, const gchar *hoo
 
 	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_COMPATIBLE", r_context()->config->system_compatible ?: "", TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_VARIANT", r_context()->config->system_variant ?: "", TRUE);
+	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_VERSION", r_context()->system_version ?: "", TRUE);
 
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_NAME", slot->name, TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_STATE", r_slot_slotstate_to_str(slot->state), TRUE);


### PR DESCRIPTION
Pass installed system version to bundle install-check hook script.

Fixes: #531

(This has been collecting dust downstream for a while now; time to get it upstreamed)
