### PR TITLE
src/config_file: add a hint that max-bundle-download-size is not used for streaming

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -175,6 +175,8 @@ Example configuration:
   Defines the maximum downloadable bundle size in bytes, and thus must be
   a simple integer value (without unit) greater than zero.
   It overwrites the compiled-in default value of 8388608 (8 MiB).
+  If RAUC is configured with streaming support, this has no effect, as the
+  bundle is not downloaded as a whole.
 
 ``variant-name`` (optional)
   String to be used as variant name for this board.

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -737,6 +737,8 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	} else if (ierror) {
 		g_propagate_error(error, ierror);
 		return FALSE;
+	} else if (ENABLE_STREAMING) {
+		g_message("Using max-bundle-download-size with streaming has no effect.");
 	}
 	if (c->max_bundle_download_size == 0) {
 		g_set_error(


### PR DESCRIPTION
We've seen this option set in some cases even when streaming was enabled, so warn that it has no effect.