### PR TITLE
Add extra-mkfs-opts to allow customising filesystem format options

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -465,6 +465,10 @@ hierarchical separator.
   See table :ref:`sec-slot-type` for a more detailed list of these different types.
   Defaults to ``raw`` if none given.
 
+``extra-mkfs-opts=<options>`` (optional)
+  Allows to specify custom filesystem creation options that will be passed to the slot's
+  ``mkfs.<type>`` call (ext4, vfat, and ubifs only).
+
 ``bootname=<name>`` (optional)
   Registers the slot for being handled by the
   :ref:`bootselection interface <bootloader-interaction>` with the ``<name>``
@@ -511,7 +515,7 @@ hierarchical separator.
   file system to an ext4 slot, i.e. if the slot has``type=ext4`` set.
 
 ``extra-mount-opts=<options>`` (optional)
-  Allows to specify custom mount options that will be passed to the slots
+  Allows to specify custom mount options that will be passed to the slot's
   ``mount`` call as ``-o`` argument value.
 
 .. _ref-logger-sections:

--- a/include/slot.h
+++ b/include/slot.h
@@ -37,6 +37,8 @@ typedef struct _RaucSlot {
 	gchar *device;
 	/** the slots partition type */
 	gchar *type;
+	/** extra mkfs options for this slot */
+	gchar **extra_mkfs_opts;
 	/** the name this slot is known to the bootloader */
 	gchar *bootname;
 	/** flag to indicate that this slot can be updated even if already mounted */

--- a/include/utils.h
+++ b/include/utils.h
@@ -82,11 +82,14 @@ G_GNUC_WARN_UNUSED_RESULT;
  * Adds elements of a zero-terminated GStrv/gchar** to an existing GPtrArray
  *
  * @param ptrarray GPtrArray to add to
- * @param argvp arguments to add
+ * @param argvp arguments to add (may be NULL)
  * @param copy whether to just add the pointer (FALSE) or copy the underlying data (TRUE)
  */
 static inline void r_ptr_array_addv(GPtrArray *ptrarray, gchar **argvp, gboolean copy)
 {
+	if (argvp == NULL)
+		return;
+
 	for (gchar **addarg = argvp; *addarg != NULL; addarg++) {
 		g_ptr_array_add(ptrarray, copy ? g_strdup(*addarg) : *addarg);
 	}

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -410,6 +410,16 @@ static GHashTable *parse_slots(const char *filename, const char *data_directory,
 				return NULL;
 			}
 
+			value = key_file_consume_string(key_file, groups[i], "extra-mkfs-opts", NULL);
+			if (value != NULL) {
+				if (!g_shell_parse_argv(value, NULL, &(slot->extra_mkfs_opts), &ierror)) {
+					g_free(value);
+					g_propagate_prefixed_error(error, ierror, "Failed to parse extra-mkfs-opts: ");
+					return NULL;
+				}
+				g_free(value);
+			}
+
 			value = key_file_consume_string(key_file, groups[i], "bootname", NULL);
 
 			slot->bootname = value;

--- a/src/slot.c
+++ b/src/slot.c
@@ -17,6 +17,7 @@ void r_slot_free(gpointer value)
 	g_free(slot->description);
 	g_free(slot->device);
 	g_free(slot->type);
+	g_strfreev(slot->extra_mkfs_opts);
 	g_free(slot->bootname);
 	g_free(slot->extra_mount_opts);
 	g_free(slot->parent_name);

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -952,6 +952,7 @@ static gboolean ubifs_format_slot(RaucSlot *dest_slot, GError **error)
 
 	g_ptr_array_add(args, g_strdup("mkfs.ubifs"));
 	g_ptr_array_add(args, g_strdup("-y"));
+	r_ptr_array_addv(args, dest_slot->extra_mkfs_opts, TRUE);
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 
@@ -995,7 +996,7 @@ static gboolean ext4_format_slot(RaucSlot *dest_slot, GError **error)
 {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
-	g_autoptr(GPtrArray) args = g_ptr_array_new_full(4, g_free);
+	g_autoptr(GPtrArray) args = g_ptr_array_new_full(6, g_free);
 
 	g_ptr_array_add(args, g_strdup("mkfs.ext4"));
 	g_ptr_array_add(args, g_strdup("-F"));
@@ -1004,6 +1005,7 @@ static gboolean ext4_format_slot(RaucSlot *dest_slot, GError **error)
 		g_ptr_array_add(args, g_strdup(dest_slot->name));
 	}
 	g_ptr_array_add(args, g_strdup("-I256"));
+	r_ptr_array_addv(args, dest_slot->extra_mkfs_opts, TRUE);
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 
@@ -1073,6 +1075,7 @@ static gboolean vfat_format_slot(RaucSlot *dest_slot, GError **error)
 	g_ptr_array_add(args, g_strdup("mkfs.vfat"));
 	g_ptr_array_add(args, g_strdup("-n"));
 	g_ptr_array_add(args, vfat_label_generator(dest_slot->name));
+	r_ptr_array_addv(args, dest_slot->extra_mkfs_opts, TRUE);
 	g_ptr_array_add(args, g_strdup(dest_slot->device));
 	g_ptr_array_add(args, NULL);
 


### PR DESCRIPTION
This PR adds an `extra-mkfs-opts` parameter to the system.conf file which can be used to provide extra options to `mkfs.ext4`/`mkfs.vfat`/`mkfs.ubifs` for each configured slot. 

An example configuration:
```
[slot.rootfs.0]
device=/dev/mmcblk0p5
type=ext4
extra-mkfs-opts=-i 8192 -L ROOT_A
bootname=SLOT_A

[slot.bootfs.0]
device=/dev/mmcblk0p2
type=vfat
extra-mkfs-opts=-F 32 -S 512 -n BOOT_A
parent=rootfs.0

[slot.rootfs.1]
device=/dev/mmcblk0p6
type=ext4
extra-mkfs-opts=-i 8192 -L ROOT_B
bootname=SLOT_B

[slot.bootfs.1]
device=/dev/mmcblk0p3
type=vfat
extra-mkfs-opts=-F 32 -S 512 -n BOOT_B
parent=rootfs.1
```

The meaning of the options depends on the type, see of course the man pages for `mkfs.ext4`/`mkfs.vfat`/`mkfs.ubifs` as appropriate.

See also issue #457, although note that this PR only allows setting the above in the system.conf file and not in the update manifest. 
