### PR TITLE
test/rauc.t: test faketime before relying on it

### DIFF
--- a/test/rauc.t
+++ b/test/rauc.t
@@ -158,7 +158,10 @@ test -f ${SOFTHSM2_MOD} &&
   test_set_prereq PKCS11
 
 # Prerequisite: faketime available [FAKETIME]
+# On some platforms faketime is broken, see e.g. https://github.com/wolfcw/libfaketime/issues/418
+# Only use it if it works for date
 faketime "2018-01-01" date &&
+faketime "2018-01-01" date -R | grep "Jan 2018" &&
   test_set_prereq FAKETIME
 
 # Prerequisite: grub-editenv available [GRUB]


### PR DESCRIPTION
On some platforms faketime doesn't work as intended due to not supporting the libc functions that provide 64bit time_t on 32bit architectures.

This problem already made rauc fail to build in Debian unstable, see [Debian bug #1032177 ](https://bugs.debian.org/1032177). With the expectation that the problem will also affect rauc mainline at some time in the future, precautionarily check faketime being functional before using it.

