### PR TITLE
fix minor memory leaks in the D-Bus service and related tests

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -44,7 +44,7 @@ jobs:
         build/test/nbd-test
         build/test/network-test
         build/test/progress-test
-        build/test/service-test -l
+        build/test/service-test
         build/test/signature-test
         build/test/slot-test
         build/test/stats-test

--- a/qemu-test
+++ b/qemu-test
@@ -78,7 +78,7 @@ fi
 qemu-system-x86_64 \
   $QEMU_ARGS \
   -machine q35 \
-  -m 512M \
+  -m 1G \
   -smp 2 \
   -kernel bzImage \
   -nographic -serial mon:stdio \

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -17,6 +17,9 @@ mount -t tmpfs none /tmp
 mkdir /tmp/etc-overlay /tmp/etc-work
 mount -t overlay overlay -o lowerdir=/etc,upperdir=/tmp/etc-overlay,workdir=/tmp/etc-work /etc
 
+# switch to rauc dir
+cd "$(dirname "$0")"
+
 BUILD_DIR="build/"
 
 # parse cmdline
@@ -29,6 +32,7 @@ for x in $(cat /proc/cmdline); do
   elif [ "$x" = "asan" ]; then
     export G_SLICE=always-malloc G_DEBUG=gc-friendly
     export ASAN_OPTIONS=malloc_context_size=64:fast_unwind_on_malloc=0
+    export LSAN_OPTIONS=suppressions="$(pwd)/test/asan.supp"
   elif [ "$x" = "service-backtrace" ]; then
     SERVICE_BACKTRACE=1
   fi
@@ -49,9 +53,6 @@ ip addr add 10.0.2.15/24 dev eth0
 ip link set eth0 up
 ip route add default via 10.0.2.2
 echo "nameserver 10.0.2.3" > /etc/resolv.conf
-
-# switch to rauc dir
-cd "$(dirname "$0")"
 
 # allow git access to our repo
 git config --system --add safe.directory "$(pwd)"

--- a/src/install.c
+++ b/src/install.c
@@ -264,7 +264,7 @@ gboolean determine_boot_states(GError **error)
 	/* get boot state */
 	g_hash_table_iter_init(&iter, r_context()->config->slots);
 	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
-		GError *ierror = NULL;
+		g_autoptr(GError) ierror = NULL;
 
 		if (!slot->bootname)
 			continue;

--- a/src/service.c
+++ b/src/service.c
@@ -24,7 +24,7 @@ static gboolean service_install_notify(gpointer data)
 
 	g_mutex_lock(&args->status_mutex);
 	while (!g_queue_is_empty(&args->status_messages)) {
-		gchar *msg = g_queue_pop_head(&args->status_messages);
+		g_autofree gchar *msg = g_queue_pop_head(&args->status_messages);
 		g_message("installing %s: %s", args->name, msg);
 	}
 	g_mutex_unlock(&args->status_mutex);

--- a/test/asan.supp
+++ b/test/asan.supp
@@ -1,0 +1,1 @@
+leak:g_private_set_alloc0

--- a/test/boot_raw_fallback.c
+++ b/test/boot_raw_fallback.c
@@ -267,6 +267,7 @@ static void test_boot_raw_fallback(BootRawFallbackFixture *fixture,
 
 	if (data->options & OPT_EXPECT_FAIL) {
 		g_assert_error(ierror, data->err_domain, data->err_code);
+		g_clear_error(&ierror);
 		g_assert_false(res);
 		goto out;
 	} else {

--- a/test/boot_switch.c
+++ b/test/boot_switch.c
@@ -366,6 +366,7 @@ static void test_boot_switch(BootSwitchFixture *fixture,
 
 	if (data->params & BOOT_SWITCH_EXPECT_FAIL) {
 		g_assert_error(ierror, data->err_domain, data->err_code);
+		g_clear_error(&ierror);
 		g_assert_false(res);
 		goto out;
 	} else {

--- a/test/boot_switch.c
+++ b/test/boot_switch.c
@@ -52,7 +52,7 @@ typedef struct {
 
 static gchar *sfdisk_get(const gchar *device)
 {
-	GSubprocess *sub;
+	g_autoptr(GSubprocess) sub = NULL;
 	GError *error = NULL;
 	GBytes *stdout_buf = NULL;
 	gsize size;
@@ -129,7 +129,7 @@ static void sfdisk_check(const gchar *device, const gchar *expected)
 
 static void sfdisk_set(const gchar *device, const gchar *dump)
 {
-	GSubprocess *sub;
+	g_autoptr(GSubprocess) sub = NULL;
 	GError *error = NULL;
 	g_autoptr(GBytes) stdin_buf = NULL;
 	gboolean res = FALSE;

--- a/test/service.c
+++ b/test/service.c
@@ -73,6 +73,8 @@ static void service_fixture_tear_down(ServiceFixture *fixture, gconstpointer use
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_free(fixture->tmpdir);
+
+	g_clear_pointer(&testloop, g_main_loop_unref);
 }
 
 static void on_installer_changed(GDBusProxy *proxy, GVariant *changed,


### PR DESCRIPTION
To mark intentionally leaked memory (the glib thread local data), this also adds a suppression file.