### PR TITLE
test/Dockerfile: add acl to control access to coverage files in qemu

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
 
 # Required for testing
 RUN apt-get install -q -y --no-install-recommends \
+  acl \
   squashfs-tools \
   dosfstools \
   lcov \


### PR DESCRIPTION
With some further changes, this will allow us to collect coverage data from the NBD helper as well.