### PR TITLE
manifest: ensure that size always defaults to -1 in RaucImage

### DIFF
--- a/include/checksum.h
+++ b/include/checksum.h
@@ -14,6 +14,7 @@ GQuark r_checksum_error_quark(void);
 typedef struct {
 	GChecksumType type;
 	gchar *digest;
+	/* image size (-1 indicates no size in manifest) */
 	goffset size;
 } RaucChecksum;
 

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -188,6 +188,12 @@ GVariant *r_manifest_to_dict(const RaucManifest *manifest)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Creates a rauc image
+ */
+RaucImage *r_new_image(void)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
  * Frees a rauc image
  */
 void r_free_image(gpointer data);

--- a/src/main.c
+++ b/src/main.c
@@ -440,7 +440,7 @@ out:
 static gboolean write_slot_start(int argc, char **argv)
 {
 	GError *ierror = NULL;
-	g_autoptr(RaucImage) image = g_new0(RaucImage, 1);
+	g_autoptr(RaucImage) image = r_new_image();
 	RaucSlot *slot = NULL;
 	g_autoptr(GFileInfo) info = NULL;
 	g_autoptr(GInputStream) instream = NULL;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -17,7 +17,7 @@ GQuark r_manifest_error_quark(void)
 
 static gboolean parse_image(GKeyFile *key_file, const gchar *group, RaucImage **image, GError **error)
 {
-	g_autoptr(RaucImage) iimage = g_new0(RaucImage, 1);
+	g_autoptr(RaucImage) iimage = r_new_image();
 	g_auto(GStrv) groupsplit = NULL;
 	gchar *value;
 	g_auto(GStrv) hooks = NULL;
@@ -49,6 +49,7 @@ static gboolean parse_image(GKeyFile *key_file, const gchar *group, RaucImage **
 	iimage->checksum.size = g_key_file_get_uint64(key_file,
 			group, "size", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+		/* restore size to the default of -1 */
 		iimage->checksum.size = -1;
 		g_clear_error(&ierror);
 	} else if (ierror) {
@@ -890,6 +891,15 @@ GVariant* r_manifest_to_dict(const RaucManifest *manifest)
 	g_variant_dict_insert(&root_dict, "meta", "v", g_variant_builder_end(&builder));
 
 	return g_variant_dict_end(&root_dict);
+}
+
+RaucImage *r_new_image(void)
+{
+	RaucImage *image = g_new0(RaucImage, 1);
+
+	image->checksum.size = -1;
+
+	return image;
 }
 
 void r_free_image(gpointer data)

--- a/test/boot_raw_fallback.c
+++ b/test/boot_raw_fallback.c
@@ -143,7 +143,7 @@ static RaucImage* create_source_image(const gchar *dirname,
 
 	imagepath = g_build_filename(dirname, imagename, NULL);
 
-	image = g_new0(RaucImage, 1);
+	image = r_new_image();
 	image->slotclass = g_strdup("rootfs");
 	image->filename = g_strdup(imagepath);
 	image->checksum.size = size;

--- a/test/boot_switch.c
+++ b/test/boot_switch.c
@@ -308,7 +308,7 @@ static void test_boot_switch(BootSwitchFixture *fixture,
 	clear_device(slotpath);
 
 	/* create source image */
-	image = g_new0(RaucImage, 1);
+	image = r_new_image();
 	image->slotclass = g_strdup("rootfs");
 	image->filename = g_strdup(imagepath);
 	image->checksum.size = IMAGE_SIZE;

--- a/test/common.c
+++ b/test/common.c
@@ -196,14 +196,14 @@ int test_prepare_manifest_file(const gchar *dirname, const gchar *filename, cons
 	}
 
 	if (options->slots) {
-		img = g_new0(RaucImage, 1);
+		img = r_new_image();
 		img->slotclass = g_strdup("rootfs");
 		img->filename = g_strdup("rootfs.ext4");
 		if (options->hooks)
 			img->hooks.post_install = TRUE;
 		rm->images = g_list_append(rm->images, img);
 
-		img = g_new0(RaucImage, 1);
+		img = r_new_image();
 		img->slotclass = g_strdup("appfs");
 		img->filename = g_strdup("appfs.ext4");
 		rm->images = g_list_append(rm->images, img);

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -145,8 +145,7 @@ static void test_save_load_manifest(void)
 	rm->hook_name = g_strdup("hook.sh");
 	rm->hooks.install_check = TRUE;
 
-	new_image = g_new0(RaucImage, 1);
-
+	new_image = r_new_image();
 	new_image->slotclass = g_strdup("rootfs");
 	new_image->checksum.type = G_CHECKSUM_SHA256;
 	new_image->checksum.digest = g_strdup("c8af04e62bad4ab75dafd22119026e5e3943f385bdcbe7731a4938102453754c");
@@ -155,8 +154,7 @@ static void test_save_load_manifest(void)
 	new_image->hooks.post_install = TRUE;
 	rm->images = g_list_append(rm->images, new_image);
 
-	new_image = g_new0(RaucImage, 1);
-
+	new_image = r_new_image();
 	new_image->slotclass = g_strdup("rootfs");
 	new_image->variant = g_strdup("variant-1");
 	new_image->checksum.type = G_CHECKSUM_SHA256;
@@ -167,8 +165,7 @@ static void test_save_load_manifest(void)
 	new_image->adaptive = g_strsplit("invalid-method;another-invalid-method", ";", 0);
 	rm->images = g_list_append(rm->images, new_image);
 
-	new_image = g_new0(RaucImage, 1);
-
+	new_image = r_new_image();
 	new_image->slotclass = g_strdup("appfs");
 	new_image->checksum.type = G_CHECKSUM_SHA256;
 	new_image->checksum.digest = g_strdup("4e7e45db749b073eda450d30c978c7e2f6035b057d3e33ac4c61d69ce5155313");

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -54,7 +54,7 @@ static void test_get_update_handler(UpdateHandlerFixture *fixture, gconstpointer
 	UpdateHandlerTestPair *test_pair = (UpdateHandlerTestPair*) user_data;
 	GError *ierror = NULL;
 
-	image = g_new0(RaucImage, 1);
+	image = r_new_image();
 	image->slotclass = g_strdup("rootfs");
 	image->filename = g_strconcat("rootfs.", test_pair->imagetype, NULL);
 
@@ -87,7 +87,7 @@ static void test_get_custom_update_handler(UpdateHandlerFixture *fixture, gconst
 	img_to_slot_handler handler;
 	GError *ierror = NULL;
 
-	image = g_new0(RaucImage, 1);
+	image = r_new_image();
 	image->slotclass = g_strdup("rootfs");
 	image->filename = g_strdup("rootfs.custom");
 	image->hooks.install = TRUE;
@@ -389,7 +389,7 @@ static void test_update_handler(UpdateHandlerFixture *fixture,
 	}
 
 	/* create source image */
-	image = g_new0(RaucImage, 1);
+	image = r_new_image();
 	image->slotclass = g_strdup("rootfs");
 	image->filename = g_strdup(imagepath);
 	image->checksum.size = image_size;


### PR DESCRIPTION
A size of -1 indicates that no `size` key was given in the manifest. Instead of hardcoding that in everywhere, create a `r_new_image()` constructor function and use it instead.
