### PR TITLE
Fix slot skipping (install-same) handling twice

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -980,22 +980,6 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 		return FALSE;
 	}
 
-	/* For global slot status: Clear checksum info and make status
-	 * 'pending' to prevent the slot status from looking valid later in
-	 * case we crash while installing. */
-	if (g_strcmp0(r_context()->config->statusfile_path, "per-slot") != 0) {
-		g_clear_pointer(&slot_state->status, g_free);
-		slot_state->status = g_strdup("pending");
-		g_clear_pointer(&slot_state->checksum.digest, g_free);
-		slot_state->checksum.size = 0;
-
-		if (!r_slot_status_save(plan->target_slot, &ierror)) {
-			g_propagate_prefixed_error(error, ierror, "Error while writing status file: ");
-			r_context_end_step("check_slot", FALSE);
-			return FALSE;
-		}
-	}
-
 	/* if explicitly enabled, skip update of up-to-date slots */
 	if (!plan->target_slot->install_same && g_strcmp0(plan->image->checksum.digest, slot_state->checksum.digest) == 0) {
 		install_args_update(args, "Skipping update for correct image %s", plan->image->filename);
@@ -1018,6 +1002,22 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 
 		install_args_update(args, "Updating slot %s done", plan->target_slot->name);
 		return TRUE;
+	}
+
+	/* For global slot status: Clear checksum info and make status
+	 * 'pending' to prevent the slot status from looking valid later in
+	 * case we crash while installing. */
+	if (g_strcmp0(r_context()->config->statusfile_path, "per-slot") != 0) {
+		g_clear_pointer(&slot_state->status, g_free);
+		slot_state->status = g_strdup("pending");
+		g_clear_pointer(&slot_state->checksum.digest, g_free);
+		slot_state->checksum.size = 0;
+
+		if (!r_slot_status_save(plan->target_slot, &ierror)) {
+			g_propagate_prefixed_error(error, ierror, "Error while writing status file: ");
+			r_context_end_step("check_slot", FALSE);
+			return FALSE;
+		}
 	}
 
 	g_free(slot_state->status);

--- a/src/install.c
+++ b/src/install.c
@@ -986,8 +986,8 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 		g_message("Skipping update for correct image %s", plan->image->filename);
 		r_context_end_step("check_slot", TRUE);
 
-		/* Dummy step to indicate slot was skipped */
-		r_context_begin_step("skip_image", "Copying image skipped", 0);
+		/* Dummy step to indicate slot was skipped and complete required 'update_slots' substeps */
+		r_context_begin_step_weighted_formatted("skip_image", 0, 9, "Copying image skipped");
 
 		/* Update the status also for skipped slots */
 		g_message("Updating slot %s status", plan->target_slot->name);

--- a/test/install.c
+++ b/test/install.c
@@ -176,6 +176,23 @@ adaptive=adaptive-test-method;block-hash-index";
 	fixture_helper_set_up_bundle(fixture->tmpdir, manifest_file, &data->manifest_test_options);
 }
 
+static void install_fixture_set_up_slot_skipping(InstallFixture *fixture,
+		gconstpointer user_data)
+{
+	InstallData *data = (InstallData*) user_data;
+	const gchar *manifest_file = "\
+[update]\n\
+compatible=Test Config\n\
+\n\
+[image.rootfs]\n\
+filename=rootfs.ext4";
+
+	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+
+	fixture_helper_set_up_system(fixture->tmpdir, "test/test-install-same-false.conf");
+	fixture_helper_set_up_bundle(fixture->tmpdir, manifest_file, &data->manifest_test_options);
+}
+
 static void install_fixture_set_up_system_conf(InstallFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1125,6 +1142,16 @@ static void install_test_bundle(InstallFixture *fixture,
 	args->cleanup(args);
 }
 
+static void install_test_bundle_twice(InstallFixture *fixture,
+		gconstpointer user_data)
+{
+	/* First run */
+	install_test_bundle(fixture, user_data);
+
+	/* Second run */
+	install_test_bundle(fixture, user_data);
+}
+
 static void install_test_bundle_thread(InstallFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1592,6 +1619,11 @@ int main(int argc, char *argv[])
 	g_test_add("/install/adaptive",
 			InstallFixture, install_data,
 			install_fixture_set_up_bundle_adaptive, install_test_bundle,
+			install_fixture_tear_down);
+
+	g_test_add("/install/slot-skipping",
+			InstallFixture, install_data,
+			install_fixture_set_up_slot_skipping, install_test_bundle_twice,
 			install_fixture_tear_down);
 
 	return g_test_run();

--- a/test/install.c
+++ b/test/install.c
@@ -1111,6 +1111,7 @@ static void install_test_bundle(InstallFixture *fixture,
 	g_assert(test_mount(slotfile, mountdir));
 	g_assert(g_file_test(testfilepath, G_FILE_TEST_IS_REGULAR));
 	g_assert(test_umount(fixture->tmpdir, "mnt"));
+	g_assert(test_rm_tree(fixture->tmpdir, "mnt"));
 
 	if (data != NULL && data->message_needles != NULL) {
 		const gchar **message_needles = data->message_needles;

--- a/test/test-install-same-false.conf
+++ b/test/test-install-same-false.conf
@@ -1,0 +1,23 @@
+# testsuite system configuration
+
+[system]
+compatible=Test Config
+bootloader=grub
+grubenv=grubenv.test
+data-directory=rauc-data-dir
+
+[keyring]
+path=openssl-ca/dev-ca.pem
+check-crl=true
+
+[slot.rootfs.0]
+device=images/rootfs-0
+type=ext4
+bootname=system0
+install-same=false
+
+[slot.rootfs.1]
+device=images/rootfs-1
+type=ext4
+bootname=system1
+install-same=false


### PR DESCRIPTION
This fixes slot skipping handling on two levels.

With v1.10, slot skipping got broken while with v1.11 the slot skipping *detection* got broken (and thus hides the previously introduced issue).

The error that will be raised by v1.10 is:

```
Not enough substeps: update_slots (12/20)
```

Fix both and add a minimal test case that triggers an installation twice.