### PR TITLE
ignore SIGPIPE to handle broken pipes explicitly

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -792,6 +792,9 @@ RaucContext *r_context_conf(void)
 	if (context == NULL) {
 		GError *ierror = NULL;
 
+		// let us handle broken pipes explicitly
+		signal(SIGPIPE, SIG_IGN);
+
 		if (!network_init(&ierror)) {
 			g_warning("%s", ierror->message);
 			g_error_free(ierror);

--- a/src/nbd.c
+++ b/src/nbd.c
@@ -831,6 +831,9 @@ gboolean r_nbd_run_server(gint sock, GError **error)
 		return FALSE;
 	}
 
+	// let us handle broken pipes explicitly
+	signal(SIGPIPE, SIG_IGN);
+
 	g_message("nbd server running as UID %d, GID %d", getuid(), getgid());
 
 	ctx.dl_size = r_stats_new("nbd dl_size");


### PR DESCRIPTION
Glib already sets SIGPIPE to ignore when using gsocket and will do the same for gsubprocess from 2.82 as well [1]. As we want to handle all broken pipe errors explicitly, we should do it globally.

We add the call in r_context_conf instead of in main() to catch the relevant tests as well. For the nbd helper (which doesn't use a context), we do it on startup.

[1] https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3991