### PR TITLE
Fix PKCS11 URI handling in /etc/rauc/system.conf

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -170,6 +170,9 @@ gchar *resolve_path(const gchar *basefile, const gchar *path)
 	if (path == NULL)
 		return NULL;
 
+	if (g_str_has_prefix(path, "pkcs11:"))
+		return g_strdup(path);
+
 	if (g_path_is_absolute(path))
 		return g_strdup(path);
 


### PR DESCRIPTION
- RAUC should not try to resolve a PKCS11 URI like a file path.  This would happen if a URI was given as the key in the [encryption] section of /etc/rauc/system.conf.
- If a PKCS11 URI is detected in the resolve function, just return it back to the caller.
- I think this only affected a URI given in system.conf.  A URI passed in on the command line was correctly unmodified - which is why the unit tests related to PKCS11 were passing.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
