### PR TITLE
src/bundle: add ntfs3 kernel driver magic to known fs list

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -63,6 +63,9 @@
 #ifndef NTFS_SB_MAGIC
 #define NTFS_SB_MAGIC 0x5346544e
 #endif
+#ifndef NTFS3_SUPER_MAGIC
+#define NTFS3_SUPER_MAGIC 0x7366746e
+#endif
 #ifndef OVERLAYFS_SUPER_MAGIC
 #define OVERLAYFS_SUPER_MAGIC 0x794c7630
 #endif
@@ -1484,6 +1487,7 @@ static gboolean check_bundle_access(int bundle_fd, GError **error)
 			case JFFS2_SUPER_MAGIC:
 			case MSDOS_SUPER_MAGIC:
 			case NTFS_SB_MAGIC:
+			case NTFS3_SUPER_MAGIC:
 			case ROMFS_MAGIC:
 			case SQUASHFS_MAGIC:
 			case UDF_SUPER_MAGIC:


### PR DESCRIPTION
The ntfs3 kernel driver [1] uses this super block magic.

Refer to libfuse for a similar extension:
https://github.com/libfuse/libfuse/commit/869a4a6fa550ae054df01f9d50db68871f88ca4f

[1] https://lore.kernel.org/lkml/20210729162459.GA3601405@magnolia/T/

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
