### PR TITLE
Tests: add option to install tests and fixes

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -76,6 +76,11 @@ option(
   value : 'true',
   description : 'Enable/Disable test suite')
 option(
+  'install-tests',
+  type : 'boolean',
+  value : 'false',
+  description : 'install test executables and assets')
+option(
   'fuzzing',
   type : 'boolean',
   value : 'false',

--- a/test/bin/grub-editenv
+++ b/test/bin/grub-editenv
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ $# -eq 1 ] && [ "$1" = "-V" ]; then
+	echo "grub-editenv (RAUC test drop-in) 0.0.0"
+	exit 0
+fi
+
 # Variable argument count
 if [ $# -lt 2 ]; then
 	echo "At least path to grubenv file and command must be specified!"
@@ -15,7 +20,8 @@ function variables_load()
 {
 	if ! [ -f "$GRUBENV" ]; then
 		echo "GRUB environment file not found: $GRUBENV"
-		exit 1
+		echo -n "" > "$GRUBENV"
+		return 0
 	fi
 
 	while read -r line; do
@@ -39,16 +45,27 @@ function variables_store()
 	variable_store "B_TRY"
 	variable_store "A_OK"
 	variable_store "B_OK"
+
+	variable_store "system0_TRY"
+	variable_store "system1_TRY"
+	variable_store "system0_OK"
+	variable_store "system1_OK"
+
 	variable_store "ORDER"
 }
 
 # Validates and sets variable value
 function variable_set {
 	if [ "$1" = "ORDER" ]; then
-		if ! [ "$2" = "A B" -o "$2" = "B A" ]; then
-			echo "Invalid argument for ORDER: '$2'"
-			exit 1
-		fi
+		case "$2" in
+			"A B"|"B A"|"system1 system0"|"system0 system1"|"system1 system0 factory0"|"system0 system1 factory0")
+				:
+			;;
+			*)
+				echo "Invalid argument for ORDER: '$2'"
+				exit 1
+			;;
+		esac
 	elif [ "$1" = "A_OK" ]; then
 		if ! [ "$2" -ge 0 -a "$2" -le 1 ]; then
 			echo "Invalid argument for A_OK: '$2'"
@@ -67,6 +84,26 @@ function variable_set {
 	elif [ "$1" = "B_TRY" ]; then
 		if ! [ "$2" -ge 0 -a "$2" -le 1 ]; then
 			echo "Invalid argument for B_TRY: '$2'"
+			exit 1
+		fi
+	elif [ "$1" = "system0_OK" ]; then
+		if ! [ "$2" -ge 0 -a "$2" -le 1 ]; then
+			echo "Invalid argument for system0_OK: '$2'"
+			exit 1
+		fi
+	elif [ "$1" = "system1_OK" ]; then
+		if ! [ "$2" -ge 0 -a "$2" -le 1 ]; then
+			echo "Invalid argument for system1_OK: '$2'"
+			exit 1
+		fi
+	elif [ "$1" = "system0_TRY" ]; then
+		if ! [ "$2" -ge 0 -a "$2" -le 1 ]; then
+			echo "Invalid argument for system0_TRY: '$2'"
+			exit 1
+		fi
+	elif [ "$1" = "system1_TRY" ]; then
+		if ! [ "$2" -ge 0 -a "$2" -le 1 ]; then
+			echo "Invalid argument for system1_TRY: '$2'"
 			exit 1
 		fi
 	else
@@ -107,6 +144,12 @@ function variables_list()
 	variable_print "B_TRY"
 	variable_print "A_OK"
 	variable_print "B_OK"
+
+	variable_print "system0_TRY"
+	variable_print "system1_TRY"
+	variable_print "system0_OK"
+	variable_print "system1_OK"
+
 	variable_print "ORDER"
 }
 
@@ -120,6 +163,9 @@ case $CMD in
 		;;
 	"list")
 		variables_list "$@"
+		;;
+	"create")
+		echo -n "" > "$GRUBENV"
 		;;
 	*)
 		echo "Invalid command: '$CMD'"

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,13 +16,16 @@ tests = [
   'update_handler',
   'utils',
   'install',
-  'service',
   'status_file',
   'bundle',
   'progress',
   'slot',
   'stats',
 ]
+
+if get_option('service')
+  tests += 'service'
+endif
 
 if get_option('network')
   tests += 'network'
@@ -49,6 +52,9 @@ foreach test_name : tests
     link_with : librauc,
     c_args : '-DTEST_SERVICES="' + meson.build_root() + '"',
     include_directories : incdir,
+    install_mode : 'rwxr-xr-x',
+    install : get_option('install-tests'),
+    install_dir : get_option('libdir') / 'rauc' / 'tests',
     dependencies : rauc_deps)
 
   test(
@@ -62,6 +68,9 @@ endforeach
 fakerand = executable(
   'fakerand',
   'fakerand.c',
+  install_mode : 'rwxr-xr-x',
+  install : get_option('install-tests'),
+  install_dir : get_option('libdir') / 'rauc' / 'tests',
 )
 
 rauc_t = find_program(
@@ -76,4 +85,14 @@ test(
   timeout : 360,
   env : ['SHARNESS_BUILD_DIRECTORY=' + meson.build_root()],
   workdir : meson.current_source_dir(),
+)
+
+install_data(
+  meson.build_root() / 'config.h',
+  install_dir: get_option('libdir') / 'rauc' / 'tests',
+)
+
+install_subdir(
+  meson.source_root() / 'test',
+  install_dir: get_option('libdir') / 'rauc' / 'tests',
 )


### PR DESCRIPTION
Add a build option to install the tests and assets. The intended use case is to run the tests on a target.

Filter the `rauc.t` tests  with the CREATE build config option. A feature that may be disabled for embedded systems builds.

Fix the `grub-editenv` mock script, that tests can succeed when using the script instead of the real program. 

Relates-To: #1399 
