### PR TITLE
Use meson TAP protocol parser

### DIFF
--- a/qemu-test-init
+++ b/qemu-test-init
@@ -185,7 +185,7 @@ if [ -n "$SERVICE" ]; then
   rauc status mark-good
 fi
 
-if meson test -C $BUILD_DIR "$MESON_TEST"; then
+if meson test -C $BUILD_DIR "$MESON_TEST" -v; then
   touch qemu-test-ok
   echo "RESULT: PASSED"
 else

--- a/test/bundle.c
+++ b/test/bundle.c
@@ -29,7 +29,7 @@ static void bundle_fixture_set_up(BundleFixture *fixture,
 {
 	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
 	g_assert_nonnull(fixture->tmpdir);
-	g_print("bundle tmpdir: %s\n", fixture->tmpdir);
+	g_test_message("bundle tmpdir: %s\n", fixture->tmpdir);
 }
 
 static void prepare_bundle(BundleFixture *fixture, gconstpointer user_data)

--- a/test/dm.c
+++ b/test/dm.c
@@ -30,7 +30,7 @@ static void dm_fixture_set_up(DMFixture *fixture,
 {
 	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
 	g_assert_nonnull(fixture->tmpdir);
-	g_print("dm tmpdir: %s\n", fixture->tmpdir);
+	g_test_message("dm tmpdir: %s\n", fixture->tmpdir);
 }
 
 static void dm_fixture_tear_down(DMFixture *fixture,

--- a/test/hash_index.c
+++ b/test/hash_index.c
@@ -20,7 +20,7 @@ static void fixture_set_up(Fixture *fixture,
 {
 	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
 	g_assert_nonnull(fixture->tmpdir);
-	g_print("hash_index tmpdir: %s\n", fixture->tmpdir);
+	g_test_message("hash_index tmpdir: %s\n", fixture->tmpdir);
 }
 
 static void fixture_tear_down(Fixture *fixture,

--- a/test/install.c
+++ b/test/install.c
@@ -258,7 +258,7 @@ device=/path/to/prebootloader";
 
 	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
 	g_assert_nonnull(fixture->tmpdir);
-	g_print("system conf tmpdir: %s\n", fixture->tmpdir);
+	g_test_message("system conf tmpdir: %s\n", fixture->tmpdir);
 
 	pathname = write_tmp_file(fixture->tmpdir, "system.conf", cfg_file, NULL);
 	g_assert_nonnull(pathname);

--- a/test/install_fixtures.c
+++ b/test/install_fixtures.c
@@ -15,7 +15,7 @@ void fixture_helper_fixture_set_up_system_user(gchar *tmpdir,
 	g_autofree gchar *capath = NULL;
 
 	g_assert_nonnull(tmpdir);
-	g_print("bundle tmpdir: %s\n", tmpdir);
+	g_test_message("bundle tmpdir: %s", tmpdir);
 
 	g_assert(test_mkdir_relative(tmpdir, "bin", 0777) == 0);
 	g_assert(test_mkdir_relative(tmpdir, "content", 0777) == 0);

--- a/test/meson.build
+++ b/test/meson.build
@@ -56,6 +56,7 @@ foreach test_name : tests
     exe,
     is_parallel : false,
     timeout : 240,
+    protocol: 'tap',
     workdir : meson.source_root())
 endforeach
 

--- a/test/nbd.c
+++ b/test/nbd.c
@@ -42,7 +42,7 @@ static void nbd_fixture_set_up(NBDFixture *fixture, gconstpointer user_data)
 {
 	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
 	g_assert_nonnull(fixture->tmpdir);
-	g_print("tmpdir: %s\n", fixture->tmpdir);
+	g_test_message("tmpdir: %s\n", fixture->tmpdir);
 }
 
 static void nbd_fixture_tear_down(NBDFixture *fixture, gconstpointer user_data)

--- a/test/network.c
+++ b/test/network.c
@@ -16,7 +16,7 @@ static void network_fixture_set_up(NetworkFixture *fixture,
 {
 	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
 	g_assert_nonnull(fixture->tmpdir);
-	g_print("network tmpdir: %s\n", fixture->tmpdir);
+	g_test_message("network tmpdir: %s\n", fixture->tmpdir);
 }
 
 static void network_fixture_tear_down(NetworkFixture *fixture,


### PR DESCRIPTION
An issue with the current test suite is that it is quite hard to see
what tests were actually executed and what tests were just skipped.

Since the glib test suite produces TAP-parsable output by default, we
could use this to gain more detailed information on skipped tests.

Also enable verbose subtest output for run-qemu.

A general known issue is that in glib versions shipped with recent distros, the test log output emitted is duplicated: One tap-conform output with `# ` prefixed and the non-tap-conform default logging output.
The latter will cause non-fatal parsing errors for meson >= 1.0 versions that slightly pollute the log still.

This is fixed by glib commit https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3140/diffs?commit_id=6c714c9f46344c37b10c6e42936a54977f888d2d

However, we still have some remaining direct writes to stdout (by using g_print() or by sub scripts) that are not fixable this way and might need to be addressed later, like:

> stdout: 1239: UNKNOWN: Creating 'verity' format bundle
> ERROR: Unknown TAP output lines for a supported TAP version.
> This is probably a bug in the test; if they are not TAP syntax, prefix them with a #
