### PR TITLE
avoid possible OOB read in bootchooser backends

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -350,3 +350,16 @@ void r_fakeroot_add_args(GPtrArray *args, const gchar *envpath);
  */
 gboolean r_fakeroot_cleanup(const gchar *envpath, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
+
+/**
+ * Returns the contents of the GBytes as a '\0'-terminated string.
+ *
+ * The provided GBytes pointer is freed and nulled.
+ * Internally, it uses g_strndup.
+ *
+ * @param bytes GBytes to take the contents from
+ *
+ * @return null-terminated string, to be freed by the caller
+ */
+gchar *r_bytes_unref_to_string(GBytes **bytes)
+G_GNUC_WARN_UNUSED_RESULT;

--- a/src/utils.c
+++ b/src/utils.c
@@ -746,3 +746,18 @@ gboolean r_fakeroot_cleanup(const gchar *envpath, GError **error)
 
 	return rm_tree(tmpdir, error);
 }
+
+gchar *r_bytes_unref_to_string(GBytes **bytes)
+{
+	g_autofree gchar *data = NULL;
+	gsize size = 0;
+
+	g_return_val_if_fail(bytes != NULL && *bytes != NULL, NULL);
+
+	data = g_bytes_unref_to_data(*bytes, &size);
+	*bytes = NULL;
+	if (size == 0)
+		return g_strdup("");
+
+	return g_strndup(data, size);
+}

--- a/test/utils.c
+++ b/test/utils.c
@@ -256,6 +256,36 @@ static void fakeroot_test(void)
 	g_assert_true(res);
 }
 
+static void test_bytes_unref_to_string(void)
+{
+	g_autoptr(GBytes) bytes = NULL;
+	g_autofree gchar *str = NULL;
+
+	bytes = g_bytes_new("", 0);
+	str = r_bytes_unref_to_string(&bytes);
+	g_assert_null(bytes);
+	g_assert_nonnull(str);
+	g_assert_cmpuint(strlen(str), ==, 0);
+	g_assert_cmpstr(str, ==, "");
+	g_clear_pointer(&str, g_free);
+
+	bytes = g_bytes_new("", 1);
+	str = r_bytes_unref_to_string(&bytes);
+	g_assert_null(bytes);
+	g_assert_nonnull(str);
+	g_assert_cmpuint(strlen(str), ==, 0);
+	g_assert_cmpstr(str, ==, "");
+	g_clear_pointer(&str, g_free);
+
+	bytes = g_bytes_new("test", 4);
+	str = r_bytes_unref_to_string(&bytes);
+	g_assert_null(bytes);
+	g_assert_nonnull(str);
+	g_assert_cmpuint(strlen(str), ==, 4);
+	g_assert_cmpstr(str, ==, "test");
+	g_clear_pointer(&str, g_free);
+}
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -269,6 +299,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/utils/get_device_size", get_device_size_test);
 	g_test_add_func("/utils/update_symlink", update_symlink_test);
 	g_test_add_func("/utils/fakeroot", fakeroot_test);
+	g_test_add_func("/utils/bytes_unref_to_string", test_bytes_unref_to_string);
 
 	return g_test_run();
 }


### PR DESCRIPTION
When using `g_subprocess_communicate`, we often need to process the stdout as a null-terminated string (instead of a `GBytes`). While there is `g_subprocess_communicate_utf8`, we can't be sure that the output is actually valid UTF-8, so we need our own helper.

While we've not seen any issues with this in CI or in the field, it's better do be careful.