### PR TITLE
Fix double close on ubivol descriptor

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1487,6 +1487,7 @@ static gboolean img_to_ubivol_handler(RaucImage *image, RaucSlot *dest_slot, con
 			g_propagate_error(error, ierror);
 			goto out;
 		}
+		/* at this point, out_fd has already been closed by glib */
 	} else {
 		/* copy */
 		res = copy_raw_image(image, outstream, 0, &ierror);
@@ -1494,12 +1495,12 @@ static gboolean img_to_ubivol_handler(RaucImage *image, RaucSlot *dest_slot, con
 			g_propagate_error(error, ierror);
 			goto out;
 		}
-	}
 
-	res = g_output_stream_close(G_OUTPUT_STREAM(outstream), NULL, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		return FALSE;
+		res = g_output_stream_close(G_OUTPUT_STREAM(outstream), NULL, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
 	}
 
 	/* run slot post install hook if enabled */
@@ -1556,6 +1557,7 @@ static gboolean img_to_ubifs_handler(RaucImage *image, RaucSlot *dest_slot, cons
 			g_propagate_error(error, ierror);
 			goto out;
 		}
+		/* at this point, out_fd has already been closed by glib */
 	} else {
 		/* copy */
 		res = copy_raw_image(image, outstream, 0, &ierror);
@@ -1563,12 +1565,12 @@ static gboolean img_to_ubifs_handler(RaucImage *image, RaucSlot *dest_slot, cons
 			g_propagate_error(error, ierror);
 			goto out;
 		}
-	}
 
-	res = g_output_stream_close(G_OUTPUT_STREAM(outstream), NULL, &ierror);
-	if (!res) {
-		g_propagate_error(error, ierror);
-		return FALSE;
+		res = g_output_stream_close(G_OUTPUT_STREAM(outstream), NULL, &ierror);
+		if (!res) {
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
 	}
 
 	/* run slot post install hook if enabled */


### PR DESCRIPTION
The g_output_stream_close call was introduced at some point after the casync functionality for UBI was introduced (#501). This close call is fine for the copy_raw_image branch, but for the casync branch it causes the update to fail:

`rauc[250]: Installation error: Failed updating slot rootfs.1: Error closing file descriptor: Bad file descriptor`

This was also mentioned in #1200. However it was not investigated there but instead sidestepped by using a different update approach.

Investigation with strace shows that the desciptor is closed twice:

```
290   openat(AT_FDCWD, "/dev/ubi0_1", O_WRONLY|O_EXCL|O_LARGEFILE <unfinished ...>
290   <... openat resumed>)             = 8
[snip]
290   close(8 <unfinished ...>
290   <... close resumed>)              = 0
290   close(8 <unfinished ...>
290   <... close resumed>)              = -1 EBADF (Bad file descriptor)
```

This can be explained by the documentation of
g_subprocess_launcher_close():

> Closes all the file descriptors previously passed to the object with
> g_subprocess_launcher_take_fd(), g_subprocess_launcher_take_stderr_fd(), etc.
> (...)
> This function is called automatically when the #GSubprocessLauncher is disposed
