### PR TITLE
Add per-slot option for casync seed device

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -846,7 +846,9 @@ RAUC casync Support
   `git <https://github.com/systemd/casync>`_ repository).
 
   Also, for using UBI support, make sure to add casync patches from
-  https://github.com/systemd/casync/pull/227.
+  https://github.com/systemd/casync/pull/227. When using casync in blob mode
+  with UBI, seeding is disabled by default, which makes updates very inefficient
+  (refer :ref:`casync-seed-device <casync-seed-device>` per-slot option).
 
   If file system images are sufficient, also check the more lightweight
   `casync-nano <https://github.com/florolf/casync-nano>`_ tool which can be

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -518,6 +518,16 @@ hierarchical separator.
   Allows to specify custom mount options that will be passed to the slot's
   ``mount`` call as ``-o`` argument value.
 
+.. _casync-seed-device:
+
+``casync-seed-device=</path/to/dev>``
+  Block device that casync should use as a seed device when performing a blob
+  update, instead of ``device``. This can be useful if ``device`` is not
+  eligible as a seed, e.g. when it is a UBI character device. In this case an
+  equivalent ``/dev/ubiblock`` device could be used as a seed. Note that RAUC
+  will not create this device, the target needs to ensure that it exists during
+  the update (e.g. set up the ubiblock mapping with a systemd service).
+
 .. _ref-logger-sections:
 
 ``[log.<logger>]`` Sections

--- a/include/slot.h
+++ b/include/slot.h
@@ -35,6 +35,8 @@ typedef struct _RaucSlot {
 	const gchar *sclass;
 	/** device this slot uses */
 	gchar *device;
+	/** alternate block device for casync to use as a seed (if NULL, equal to slot device) */
+	gchar *casync_seed_device;
 	/** the slots partition type */
 	gchar *type;
 	/** extra mkfs options for this slot */

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -386,6 +386,9 @@ static GHashTable *parse_slots(const char *filename, const char *data_directory,
 			}
 			slot->device = value;
 
+			slot->casync_seed_device = resolve_path_take(filename,
+					key_file_consume_string(key_file, groups[i], "casync-seed-device", NULL));
+
 			value = key_file_consume_string(key_file, groups[i], "type", NULL);
 			if (!value)
 				value = g_strdup("raw");

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -578,17 +578,26 @@ static gboolean casync_extract_image(RaucImage *image, gchar *dest, int out_fd, 
 		seed = g_strdup(seedslot->mount_point);
 	} else {
 		GStatBuf seedstat;
+		gchar *seed_candidate = NULL;
+
+		if (seedslot->casync_seed_device) {
+			g_debug("Using configured casync-seed-device: %s", seedslot->casync_seed_device);
+			seed_candidate = seedslot->casync_seed_device;
+		} else {
+			g_debug("Adding as casync blob seed: %s", seedslot->device);
+			seed_candidate = seedslot->device;
+		}
 
 		/* For the moment do not utilize UBI volumes as seed because they are
 		 * character devices - additional logic is needed to (temporarily) map
 		 * them to UBIBLOCK devices which are suitable for that purpose */
-		if (g_stat(seedslot->device, &seedstat) < 0 || S_ISCHR(seedstat.st_mode)) {
-			g_message("Cannot use %s as seed device (non-existing or char device)", seedslot->device);
-			goto extract;
+		if (g_stat(seed_candidate, &seedstat) < 0 || S_ISCHR(seedstat.st_mode)) {
+			g_message("Cannot use %s as seed device (non-existing or char device). "
+					"Perhaps the casync-seed-device option should be added or fixed for this slot.",
+					seed_candidate);
+		} else {
+			seed = g_strdup(seed_candidate);
 		}
-
-		g_debug("Adding as casync blob seed: %s", seedslot->device);
-		seed = g_strdup(seedslot->device);
 	}
 
 extract:


### PR DESCRIPTION
As mentioned in #1200, using casync in blob mode with UBI volumes is kind of pointless at the moment, because casync cannot be effective without a seed.

The solution proposed in the comment in casync_extract_image sounds good and would make this use case effortless from a user perspective, but it would require some development effort to implement said logic.

This solution instead leaves the mapping logic to the user, which is likely pretty simple or even nothing at all (e.g. in the case of a squashfs root filesystem, which by necessity already has a ubiblock).

A typical configuration would look like this:

```
[slot.rootfs.0]
device=/dev/ubi0_0
casync-seed-device=/dev/ubiblock0_0
type=ubivol
```

Of course it is still possible for someone to implement the ubiblock mapping logic in RAUC in the future if they see a need for it. But with this change at least the use case is viable with minimal integration work.

---
__Additional details__

This patch was tested using the following configuration on an i.MX6 target:
```
[system]
compatible=testmachine
bootloader=uboot
boot-attempts=3
bundle-formats=-plain
data-directory=/var/rauc

[keyring]
path=/etc/rauc/ca.cert.pem

[slot.rootfs.0]
device=/dev/ubi0_0
casync-seed-device=/dev/ubiblock0_0
type=ubivol
bootname=A

[slot.rootfs.1]
device=/dev/ubi0_1
casync-seed-device=/dev/ubiblock0_1
type=ubivol
bootname=B
```

And the following bundle:
```
Compatible: 	'testmachine'
Version:    	'20240514150445'
Description:	'testbundle'
Build:      	'testbuild'
Hooks:      	''
Bundle Format: 	verity
  Verity Salt: 	'7a8e7d2a00d94b44d15e918695d536a8b37a8d49f368f3d89376ccbdd447f413'
  Verity Hash: 	'2a783ee00fcdc4d12e5669a43eca6cc6196df91e0bc6fc590b92693888998d68'
  Verity Size: 	503808
Manifest Hash:	'49696809d12177f71a723d7158bd5e3221914dc91f11ed04590941277e7f76ea'

1 Image:
  [rootfs]
	Filename:  rootfs.squashfs
	Checksum:  5122f3529dd35b8ad0c44ad936b42e2ff44a76a9eaa9536558d19084a65fb90e
	Size:      63.9?MB (63856640 bytes)
```

Note that for testing this feature it is also necessary to apply #1419, because that bug is a dealbreaker for casync blob updates on UBI volumes.