### PR TITLE
simplify dbus fixtures

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -270,6 +270,7 @@ def _rauc_dbus_service(tmp_path, conf_file, bootslot):
     # Wait for de.pengutronix.rauc to appear on the bus
     timeout = time.monotonic() + 5.0
     while True:
+        time.sleep(0.1)
         try:
             proxy = bus.get("de.pengutronix.rauc", "/")
             break

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shutil
 import signal
 import subprocess
@@ -220,18 +219,10 @@ def pkcs11(tmp_path_factory):
     prepare_softhsm2(tmp_path_factory.mktemp("blub"), softhsm2_mod)
 
 
-# If running under qemu use the prepared system bus otherwise start a
-# dedicated session bus
 @pytest.fixture(scope="session")
-def select_system_or_session_bus():
+def dbus_session_bus():
     if not have_service():
         pytest.skip("No service")
-
-    with open("/proc/cmdline") as f:
-        if re.search("init=[^ ]*/qemu-test-init", f.read()):
-            print("Running from QEMU")
-        else:
-            print("Running locally")
 
     # Run the dbus-launch command and capture its output
     output = subprocess.check_output(["dbus-launch", "--sh-syntax"], universal_newlines=True, shell=True)
@@ -248,19 +239,14 @@ def select_system_or_session_bus():
         os.environ[key] = value
 
     dbus_session_bus_address = os.environ.get("DBUS_SESSION_BUS_ADDRESS")
-    if dbus_session_bus_address:
-        print(f"DBUS_SESSION_BUS_ADDRESS: {dbus_session_bus_address}")
+    assert dbus_session_bus_address
+    print(f"DBUS_SESSION_BUS_ADDRESS: {dbus_session_bus_address}")
 
     yield
 
     pid = os.environ["DBUS_SESSION_BUS_PID"]
     print(f"Killing PID {pid}")
     os.kill(int(pid), signal.SIGTERM)
-
-
-@pytest.fixture
-def rauc_service(select_system_or_session_bus):
-    pass
 
 
 @pytest.fixture
@@ -295,7 +281,7 @@ def _rauc_dbus_service(tmp_path, conf_file, bootslot):
 
 
 @pytest.fixture
-def rauc_dbus_service(tmp_path):
+def rauc_dbus_service(tmp_path, dbus_session_bus):
     service, bus = _rauc_dbus_service(tmp_path, "minimal-test.conf", "system0")
 
     yield bus
@@ -305,7 +291,7 @@ def rauc_dbus_service(tmp_path):
 
 
 @pytest.fixture
-def rauc_dbus_service_with_system(tmp_path, create_system_files):
+def rauc_dbus_service_with_system(tmp_path, dbus_session_bus, create_system_files):
     service, bus = _rauc_dbus_service(tmp_path, "minimal-test.conf", "system0")
 
     yield bus
@@ -315,7 +301,7 @@ def rauc_dbus_service_with_system(tmp_path, create_system_files):
 
 
 @pytest.fixture
-def rauc_dbus_service_with_system_crypt(tmp_path, create_system_files):
+def rauc_dbus_service_with_system_crypt(tmp_path, dbus_session_bus, create_system_files):
     service, bus = _rauc_dbus_service(tmp_path, "crypt-test.conf", "system0")
 
     yield bus
@@ -325,7 +311,7 @@ def rauc_dbus_service_with_system_crypt(tmp_path, create_system_files):
 
 
 @pytest.fixture
-def rauc_dbus_service_with_system_external(tmp_path, create_system_files):
+def rauc_dbus_service_with_system_external(tmp_path, dbus_session_bus, create_system_files):
     service, bus = _rauc_dbus_service(tmp_path, "crypt-test.conf", "_external_")
 
     yield bus

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -8,7 +8,7 @@ from helper import run
 pytestmark = root
 
 
-def test_install(rauc_service, rauc_dbus_service_with_system, tmp_path):
+def test_install(rauc_dbus_service_with_system, tmp_path):
     assert os.path.exists("images/rootfs-1")
     assert not os.path.getsize("images/rootfs-1") > 0
     assert os.path.isdir("/run/rauc/slots/active")
@@ -24,7 +24,7 @@ def test_install(rauc_service, rauc_dbus_service_with_system, tmp_path):
     assert os.path.getsize("images/rootfs-1") > 0
 
 
-def test_install_verity(rauc_service, rauc_dbus_service_with_system, tmp_path):
+def test_install_verity(rauc_dbus_service_with_system, tmp_path):
     assert os.path.exists("images/rootfs-1")
     assert not os.path.getsize("images/rootfs-1") > 0
 
@@ -37,7 +37,7 @@ def test_install_verity(rauc_service, rauc_dbus_service_with_system, tmp_path):
     assert os.path.getsize("images/rootfs-1") > 0
 
 
-def test_install_crypt(rauc_service, rauc_dbus_service_with_system_crypt, tmp_path):
+def test_install_crypt(rauc_dbus_service_with_system_crypt, tmp_path):
     assert os.path.exists("images/rootfs-1")
     assert not os.path.getsize("images/rootfs-1") > 0
 
@@ -51,7 +51,7 @@ def test_install_crypt(rauc_service, rauc_dbus_service_with_system_crypt, tmp_pa
 
 
 @have_casync
-def test_install_plain_casync_local(rauc_service, rauc_dbus_service_with_system, tmp_path):
+def test_install_plain_casync_local(rauc_dbus_service_with_system, tmp_path):
     assert os.path.exists("images/rootfs-1")
     assert not os.path.getsize("images/rootfs-1") > 0
 
@@ -67,7 +67,7 @@ def test_install_plain_casync_local(rauc_service, rauc_dbus_service_with_system,
 
 @have_casync
 @have_http
-def test_install_verity_casync_http(rauc_service, rauc_dbus_service_with_system, tmp_path):
+def test_install_verity_casync_http(rauc_dbus_service_with_system, tmp_path):
     assert os.path.exists("images/rootfs-1")
     assert not os.path.getsize("images/rootfs-1") > 0
 
@@ -78,7 +78,7 @@ def test_install_verity_casync_http(rauc_service, rauc_dbus_service_with_system,
 
 
 @have_streaming
-def test_install_streaming(rauc_service, rauc_dbus_service_with_system, tmp_path):
+def test_install_streaming(rauc_dbus_service_with_system, tmp_path):
     assert os.path.exists("images/rootfs-1")
     assert not os.path.getsize("images/rootfs-1") > 0
 
@@ -89,7 +89,7 @@ def test_install_streaming(rauc_service, rauc_dbus_service_with_system, tmp_path
 
 
 @have_streaming
-def test_install_streaming_error(rauc_service, rauc_dbus_service_with_system, tmp_path):
+def test_install_streaming_error(rauc_dbus_service_with_system, tmp_path):
     assert os.path.exists("images/rootfs-1")
     assert not os.path.getsize("images/rootfs-1") > 0
 
@@ -99,7 +99,7 @@ def test_install_streaming_error(rauc_service, rauc_dbus_service_with_system, tm
     assert not os.path.getsize("images/rootfs-1") > 0
 
 
-def test_install_progress(rauc_service, rauc_dbus_service_with_system, tmp_path):
+def test_install_progress(rauc_dbus_service_with_system, tmp_path):
     assert os.path.exists("images/rootfs-1")
     assert not os.path.getsize("images/rootfs-1") > 0
 
@@ -112,7 +112,7 @@ def test_install_progress(rauc_service, rauc_dbus_service_with_system, tmp_path)
     assert os.path.getsize("images/rootfs-1") > 0
 
 
-def test_install_rauc_external(rauc_service, rauc_dbus_service_with_system_external, tmp_path):
+def test_install_rauc_external(rauc_dbus_service_with_system_external, tmp_path):
     assert os.path.exists("images/rootfs-1")
     assert not os.path.getsize("images/rootfs-1") > 0
 

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -59,7 +59,7 @@ def test_status_mark_good_non_bootslot():
 
 
 @have_grub
-def test_status_mark_good_dbus(rauc_service, rauc_dbus_service):
+def test_status_mark_good_dbus(rauc_dbus_service):
     out, err, exitcode = run("rauc status mark-good")
 
     assert exitcode == 0
@@ -67,7 +67,7 @@ def test_status_mark_good_dbus(rauc_service, rauc_dbus_service):
 
 
 @have_grub
-def test_status_mark_bad_dbus(rauc_service, rauc_dbus_service):
+def test_status_mark_bad_dbus(rauc_dbus_service):
     out, err, exitcode = run("rauc status mark-bad")
 
     assert exitcode == 0
@@ -75,7 +75,7 @@ def test_status_mark_bad_dbus(rauc_service, rauc_dbus_service):
 
 
 @have_grub
-def test_status_mark_active_dbus(rauc_service, rauc_dbus_service):
+def test_status_mark_active_dbus(rauc_dbus_service):
     out, err, exitcode = run("rauc status mark-active")
 
     assert exitcode == 0

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -1,7 +1,7 @@
 from helper import run
 
 
-def test_service_double_init(rauc_service, rauc_dbus_service):
+def test_service_double_init(rauc_dbus_service):
     out, err, exitcode = run("rauc --conf=test.conf --override-boot-slot=system0 service")
 
     assert exitcode == 1

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -55,42 +55,42 @@ def test_status_no_service_output_nvalid():
     assert "Unknown output format: 'invalid'" in err
 
 
-def test_status(rauc_service, rauc_dbus_service):
+def test_status(rauc_dbus_service):
     out, err, exitcode = run("rauc status")
 
     assert exitcode == 0
     assert out.startswith("=== System Info ===")
 
 
-def test_status_readable(rauc_service, rauc_dbus_service):
+def test_status_readable(rauc_dbus_service):
     out, err, exitcode = run("rauc status --detailed --output-format=readable")
 
     assert exitcode == 0
     assert out.startswith("=== System Info ===")
 
 
-def test_status_shell(rauc_service, rauc_dbus_service):
+def test_status_shell(rauc_dbus_service):
     out, err, exitcode = run("rauc status --detailed --output-format=shell")
 
     assert exitcode == 0
     assert out.startswith("RAUC_SYSTEM_COMPATIBLE='Test Config'")
 
 
-def test_status_json(rauc_service, rauc_dbus_service):
+def test_status_json(rauc_dbus_service):
     out, err, exitcode = run("rauc status --detailed --output-format=json")
 
     assert exitcode == 0
     assert json.loads(out)
 
 
-def test_status_json_pretty(rauc_service, rauc_dbus_service):
+def test_status_json_pretty(rauc_dbus_service):
     out, err, exitcode = run("rauc status --detailed --output-format=json-pretty")
 
     assert exitcode == 0
     assert json.loads(out)
 
 
-def test_status_invalid(rauc_service, rauc_dbus_service):
+def test_status_invalid(rauc_dbus_service):
     out, err, exitcode = run("rauc status --detailed --output-format=invalid")
 
     assert exitcode == 1


### PR DESCRIPTION
The rauc_service fixture only pulled in the select_system_or_session_bus
fixture, which actually always set up a session bus. Also, each
individual tests pulled in the rauc_service fixture to ensure a D-Bus
bus was available.

Simplify this by replacing the select_system_or_session_bus and
rauc_service fixtures with a dbus_session_bus fixture. Then, pull it in
for the rauc_dbus_service* fixtures and drop it from the individual
tests.

Also add a short sleep to avoid busy-looping.