### PR TITLE
qemu-test-init: fix support for faketime

### DIFF
--- a/qemu-test-init
+++ b/qemu-test-init
@@ -13,6 +13,10 @@ mount -t tmpfs none /root
 mount -t tmpfs none /run
 mount -t tmpfs none /tmp
 
+# create /dev/shm for faketime
+mkdir /dev/shm
+mount -t tmpfs none /dev/shm
+
 # create overlay for /etc
 mkdir /tmp/etc-overlay /tmp/etc-work
 mount -t overlay overlay -o lowerdir=/etc,upperdir=/tmp/etc-overlay,workdir=/tmp/etc-work /etc


### PR DESCRIPTION
Without `/dev/shm`, `faketime` fails with `faketime: sem_open: No such file or directory`.