### PR TITLE
test/conftest: avoid busy-waiting

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -284,6 +284,7 @@ def _rauc_dbus_service(tmp_path, conf_file, bootslot):
     # Wait for de.pengutronix.rauc to appear on the bus
     timeout = time.monotonic() + 5.0
     while True:
+        time.sleep(0.1)
         try:
             proxy = bus.get("de.pengutronix.rauc", "/")
             break


### PR DESCRIPTION
The service will need some time to be available on the bus, so wait a bit before each try. This also gives the service more CPU time, so it may be faster.