### PR TITLE
update-handler: fallbacks for unsupported sources

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -2630,6 +2630,11 @@ RaucUpdatePair updatepairs[] = {
 	{"*.ext4", "boot-gpt-switch", img_to_boot_gpt_switch_handler},
 	{"*.img", "boot-gpt-switch", img_to_boot_gpt_switch_handler},
 #endif
+	{"*", "ext4", img_to_raw_handler},
+	{"*", "raw", img_to_raw_handler},
+	{"*", "vfat", img_to_vfat_handler},
+	{"*", "ubivol", img_to_ubivol_handler},
+	{"*", "ubifs", img_to_ubifs_handler},
 	{"*", "boot-gpt-switch", NULL},
 	{"*.img", "boot-raw-fallback", img_to_boot_raw_fallback_handler},
 	{"*", "boot-raw-fallback", NULL},


### PR DESCRIPTION
Some sources are not supported and may require a fallback. The verity image generated by meta-security is an example.

This is a suggestion to fix #1177. Adding fallbacks per destination would let rauc ignore unknown sources such as verity images. All fallbacks are raw copy except for ubi types.

I haven't made any test so far. I can try on ext4 verity images if you think the idea is good.

tx