### PR TITLE
test/conftest: avoid openssl help output

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,7 +65,7 @@ have_grub = pytest.mark.skipif(not _have_grub(), reason="Have no grub-editenv")
 
 
 def _have_openssl():
-    out, err, exitcode = run("openssl asn1parse -help")
+    out, err, exitcode = run("openssl version")
     return exitcode == 0
 
 


### PR DESCRIPTION
We can just use `openssl version` to check if we have OpenSSL and avoid the logging of asn1parse help output.