### PR TITLE
refactor shell and environment variable preparation

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -96,6 +96,40 @@ static inline void r_ptr_array_addv(GPtrArray *ptrarray, gchar **argvp, gboolean
 }
 
 /**
+ * Adds a formatted string to the end of a GPtrArray
+ *
+ * This is a shorter alternative to:
+ * g_ptr_array_add(arr, g_strdup_printf("%s: %s", ...));
+ *
+ * @param ptrarray GPtrArray to add to
+ * @param format the printf-like format string
+ * @param ... the parameters for the format string
+ */
+void r_ptr_array_add_printf(GPtrArray *ptrarray, const gchar *format, ...)
+__attribute__((__format__(__printf__, 2, 3)));
+
+/**
+ * Converts an array of 'key=value' strings to a shell quoted string.
+ *
+ * This is useful when generating shell-parsable output.
+ *
+ * @param ptrarray the GPtrArray to print
+ */
+gchar *r_ptr_array_env_to_shell(const GPtrArray *ptrarray);
+
+/**
+ * Calls g_environ_setenv for each 'key=value' string in the array.
+ *
+ * This is useful when setting up the environment for a subprocess.
+ *
+ * @param envp an environment list
+ * @param ptrarray the GPtrArray to add to the environment
+ * @param overwrite whether to change existing variables
+ */
+gchar **r_environ_setenv_ptr_array(gchar **envp, const GPtrArray *ptrarray, gboolean overwrite)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
  * Read file content into a GBytes.
  *
  * @param filename Filename to read from

--- a/src/main.c
+++ b/src/main.c
@@ -865,21 +865,6 @@ out:
 #define KWHT  "\x1B[37m"
 #define KBLD  "\x1B[1m"
 
-/* Takes a shell variable and its desired argument as input and appends it to
- * the provided text with taking care of correct shell quoting */
-static void formatter_shell_append(GString* text, const gchar* varname, const gchar* argument)
-{
-	g_autofree gchar* quoted = g_shell_quote(argument ?: "");
-	g_string_append_printf(text, "%s=%s\n", varname, quoted);
-}
-/* Same as above, expect that it has a cnt argument to add per-slot-number
- * strings */
-static void formatter_shell_append_n(GString* text, const gchar* varname, gint cnt, const gchar* argument)
-{
-	g_autofree gchar* quoted = g_shell_quote(argument ?: "");
-	g_string_append_printf(text, "%s_%d=%s\n", varname, cnt, quoted);
-}
-
 static gchar *info_formatter_shell(RaucManifest *manifest)
 {
 	g_autoptr(GPtrArray) entries = g_ptr_array_new_with_free_func(g_free);

--- a/src/main.c
+++ b/src/main.c
@@ -1515,25 +1515,17 @@ static gchar* r_status_formatter_shell(RaucStatusPrint *status)
 		else
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_BOOT_STATUS_%d=", slotcnt);
 		if (status_detailed && slot_state) {
-			gchar *str;
-
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_BUNDLE_COMPATIBLE_%d=%s", slotcnt, slot_state->bundle_compatible ?: "");
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_BUNDLE_VERSION_%d=%s", slotcnt, slot_state->bundle_version ?: "");
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_BUNDLE_DESCRIPTION_%d=%s", slotcnt, slot_state->bundle_description ?: "");
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_BUNDLE_BUILD_%d=%s", slotcnt, slot_state->bundle_build ?: "");
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_BUNDLE_HASH_%d=%s", slotcnt, slot_state->bundle_hash ?: "");
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_CHECKSUM_SHA256_%d=%s", slotcnt, slot_state->checksum.digest ?: "");
-			str = g_strdup_printf("%"G_GOFFSET_FORMAT, slot_state->checksum.size);
-			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_CHECKSUM_SIZE_%d=%s", slotcnt, str);
-			g_free(str);
+			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_CHECKSUM_SIZE_%d=%"G_GOFFSET_FORMAT, slotcnt, slot_state->checksum.size);
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_INSTALLED_TIMESTAMP_%d=%s", slotcnt, slot_state->installed_timestamp ?: "");
-			str = g_strdup_printf("%u", slot_state->installed_count);
-			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_INSTALLED_COUNT_%d=%s", slotcnt, str);
-			g_free(str);
+			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_INSTALLED_COUNT_%d=%u", slotcnt, slot_state->installed_count);
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_ACTIVATED_TIMESTAMP_%d=%s", slotcnt, slot_state->activated_timestamp ?: "");
-			str = g_strdup_printf("%u", slot_state->activated_count);
-			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_ACTIVATED_COUNT_%d=%s", slotcnt, str);
-			g_free(str);
+			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_ACTIVATED_COUNT_%d=%u", slotcnt, slot_state->activated_count);
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_STATUS_%d=%s", slotcnt, slot_state->status ?: "");
 		}
 	}


### PR DESCRIPTION
We currently prepare the env variables for subprocesses and
shell-parsable output separately. To unify them, handle the shell
quoting at the end, during collection into a string.