### PR TITLE
Fix U-Boot contrib script checks

### DIFF
--- a/contrib/uboot.sh
+++ b/contrib/uboot.sh
@@ -11,14 +11,14 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   if test "x${bootargs}" != "x"; then
     # skip remaining slots
   elif test "x${BOOT_SLOT}" = "xA"; then
-    if test 0x${BOOT_A_LEFT} -gt 0; then
+    if test ${BOOT_A_LEFT} -gt 0; then
       echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       setenv load_kernel "nand read ${kernel_loadaddr} ${kernel_a_nandoffset} ${kernel_size}"
       setenv bootargs "${default_bootargs} root=/dev/mmcblk0p1 rauc.slot=A"
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
-    if test 0x${BOOT_B_LEFT} -gt 0; then
+    if test ${BOOT_B_LEFT} -gt 0; then
       echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       setenv load_kernel "nand read ${kernel_loadaddr} ${kernel_b_nandoffset} ${kernel_size}"


### PR DESCRIPTION
When adopting the provided U-Boot script for my system's configuration, I noticed `if test 0x${BOOT_A_LEFT} -gt 0; then` and `if test 0x${BOOT_B_LEFT} -gt 0; then` were failing due to trying to compare string with integers. Not sure if there was another intended purpose for this, but getting rid of the `0x` fixed the code in my case, so I thought I'd share.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
