### PR TITLE
bootchooser: add efibootguard bootloader support

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -532,6 +532,8 @@ tool to interact with it:
 :U-Boot: fw_setenv/fw_getenv (from `u-boot <http://git.denx.de/?p=u-boot.git;a=summary>`_)
 :GRUB: grub-editenv
 :EFI: efibootmgr
+:EFI Boot Guard: bg_printenv/bg_setenv
+                 (from `efibootguard <https://github.com/siemens/efibootguard>`_)
 
 Note that for running ``rauc info`` on the target (as well as on the host), you
 also need to have the ``unsquashfs`` tool installed.
@@ -1359,6 +1361,147 @@ argument in the ``efibootmgr`` call above:
   device=/dev/sdX4
   type=ext4
   parent=efi.1
+
+.. _sec-efibootguard:
+
+EFI Boot Guard
+~~~~~~~~~~~~~~
+
+`EFI Boot Guard <https://github.com/siemens/efibootguard>`_ is an EFI-based
+bootloader from Siemens designed for embedded systems with A/B redundancy.
+It stores a boot environment per EFI partition. This environment contains a
+``USTATE`` value which records the current state of the slot and a ``REVISION``
+counter which is incremented for each update and is used to prefer the newest
+valid slot when selecting the slot to boot.
+
+
+The ``USTATE`` values are encoded as follows:
+
+.. code-block:: text
+
+  OK        = 0
+  INSTALLED = 1
+  TESTING   = 2
+  FAILED    = 3
+
+EFI Boot Guard will boot the slot with the highest ``REVISION`` whose ``USTATE``
+is not ``FAILED``.
+
+RAUC uses the ``bg_printenv`` and ``bg_setenv`` tools to read and write these
+variables.
+
+The slot selection logic in RAUC is as follows:
+
+* **Primary slot** - the slot with the highest ``REVISION`` value whose
+  ``USTATE`` is not ``FAILED`` is selected as primary. When RAUC marks a slot
+  as primary, it sets the slot state to ``INSTALLED`` and assigns it a
+  ``REVISION`` to one higher than the current maximum across all slots.
+* **Slot state** - a slot is considered *good* when its ``USTATE`` is not
+  ``FAILED``. RAUC marks a slot as bad by setting ``USTATE`` to ``FAILED`` (and
+  resets its ``REVISION`` to ``0`` so it cannot be re-selected as the primary).
+  RAUC marks a slot as good by setting ``USTATE`` to ``OK``.
+
+The full update lifecycle, with the responsibilities split between RAUC and
+EFI Boot Guard, looks like this:
+
+.. code-block:: text
+
+   ┌─────────────────┐          ┌─────────────────┐         ┌─────────────────┐
+   │ initial:        │   RAUC   │ after install:  │  EBG    │ first boot of   │
+   │ USTATE    = OK  ├─────────>│ USTATE = INST.  ├────────>│ new slot:       │
+   │ (highest REV    │ install  │ REVISION = max+1│ reboot  │ USTATE = TESTING│
+   │  is current)    │          │                 │         │                 │
+   └─────────────────┘          └─────────────────┘         └───────┬─────────┘
+                                                                    │
+   ┌─────────────────┐          ┌─────────────────┐                 │
+   │ RAUC mark-good: │          │ application     │     boot ok     │
+   │ USTATE    = OK  │<─────────┤ confirms the    │<────────────────┤
+   │                 │          │ update          │                 │
+   └─────────────────┘          └─────────────────┘                 │
+                                                                    │
+   ┌─────────────────┐          ┌─────────────────┐                 │
+   │ RAUC mark-bad   │          │ EFI Boot Guard: │  boot failure   │
+   │ (optional):     │<─────────┤ USTATE = FAILED ├<────────────────┘
+   │ USTATE = FAILED │          │ (auto, via      │  (watchdog or   │
+   │ REVISION = 0    │          │  watchdog)      │   max retries)  │
+   └─────────────────┘          └─────────────────┘
+
+In words:
+
+#. **Install** - RAUC writes the new image to the inactive slot and calls
+   ``bg_setenv`` to set its ``USTATE`` to ``INSTALLED`` and its ``REVISION``
+   to one higher than the current maximum. The currently-running slot is
+   untouched.
+#. **Reboot** - on the next boot, EFI Boot Guard picks the slot with the
+   highest ``REVISION`` whose ``USTATE`` is not ``FAILED``. As it hands
+   control to that slot, EFI Boot Guard transitions ``USTATE`` from
+   ``INSTALLED`` to ``TESTING``.
+#. **Confirm** - once the application running on the new slot has verified
+   the system is healthy, it calls ``rauc status mark-good``, which sets
+   ``USTATE`` back to ``OK``.
+#. **Failure** - if the new slot fails to boot or hangs, EFI Boot Guard's
+   watchdog / retry logic sets ``USTATE`` to ``FAILED`` automatically and
+   the next boot falls back to the previous slot (which still has
+   ``USTATE = OK`` and the next-highest ``REVISION``). RAUC's
+   ``rauc status mark-bad`` performs the same transition explicitly and
+   additionally resets the slot's ``REVISION`` to ``0``.
+
+To enable EFI Boot Guard support in RAUC, write in your ``system.conf``:
+
+.. code-block:: cfg
+
+  [system]
+  ...
+  bootloader=efibootguard
+
+Assuming a simple A/B redundancy with two EFI Boot Guard partitions and two
+rootfs partitions, set up ``system.conf`` as follows.
+The ``bootname`` for each slot must match the partition index as accepted by
+the ``--part`` flag of ``bg_printenv`` and ``bg_setenv``:
+
+.. code-block:: cfg
+
+  [slot.efi.0]
+  device=/dev/sda1
+  type=vfat
+  bootname=0
+
+  [slot.efi.1]
+  device=/dev/sda2
+  type=vfat
+  bootname=1
+
+  [slot.rootfs.0]
+  device=/dev/sda3
+  type=ext4
+  parent=efi.0
+
+  [slot.rootfs.1]
+  device=/dev/sda4
+  type=ext4
+  parent=efi.1
+
+.. note::
+
+   EFI Boot Guard does not pass the active slot name via the kernel command
+   line automatically.
+   You must pass ``rauc.slot=<bootname>`` explicitly in the kernel command line
+   of each slot so that RAUC can identify the currently booted slot, e.g.:
+
+   .. code-block:: cfg
+
+     rauc.slot=0
+
+   See :ref:`sec-integration-boot-slot-detection` for the full list of slot
+   detection mechanisms.
+
+Before using RAUC with EFI Boot Guard, ensure each partition's environment has
+been initialised. For example, to prefer booting from slot ``0``:
+
+.. code-block:: console
+
+  # bg_setenv -p 0 -s OK -r 1
+  # bg_setenv -p 1 -s OK -r 0
 
 .. _sec-custom-bootloader-backend:
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -99,7 +99,7 @@ Example configuration:
   The bootloader implementation RAUC should use for its slot switching
   mechanism.
   Currently supported values (and bootloaders) are ``barebox``, ``grub``,
-  ``uboot``, ``efi``, ``custom``, ``noop``.
+  ``uboot``, ``efi``, ``efibootguard``, ``custom``, ``noop``.
 
 .. _bundle-formats:
 

--- a/meson.build
+++ b/meson.build
@@ -116,6 +116,7 @@ sources_rauc = files([
   'src/bootloaders/barebox.c',
   'src/bootloaders/custom.c',
   'src/bootloaders/efi.c',
+  'src/bootloaders/efibootguard.c',
   'src/bootloaders/grub.c',
   'src/bootloaders/uboot.c',
   'src/bundle.c',

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -2,6 +2,7 @@
 #include "bootloaders/barebox.h"
 #include "bootloaders/custom.h"
 #include "bootloaders/efi.h"
+#include "bootloaders/efibootguard.h"
 #include "bootloaders/grub.h"
 #include "bootloaders/uboot.h"
 #include "config_file.h"
@@ -12,7 +13,7 @@ GQuark r_bootchooser_error_quark(void)
 	return g_quark_from_static_string("r_bootchooser_error_quark");
 }
 
-static const gchar *supported_bootloaders[] = {"barebox", "grub", "uboot", "efi", "custom", "noop", NULL};
+static const gchar *supported_bootloaders[] = {"barebox", "grub", "uboot", "efi", "efibootguard", "custom", "noop", NULL};
 
 gboolean r_boot_is_supported_bootloader(const gchar *bootloader)
 {
@@ -93,6 +94,8 @@ gboolean r_boot_get_state(RaucSlot *slot, gboolean *good, GError **error)
 		res = r_uboot_get_state(slot, good, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "efi") == 0) {
 		res = r_efi_get_state(slot, good, &ierror);
+	} else if (g_strcmp0(r_context()->config->system_bootloader, "efibootguard") == 0) {
+		res = r_efibootguard_get_state(slot, good, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "custom") == 0) {
 		res = r_custom_get_state(slot, good, &ierror);
 	} else {
@@ -131,6 +134,8 @@ gboolean r_boot_set_state(RaucSlot *slot, gboolean good, GError **error)
 		res = r_uboot_set_state(slot, good, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "efi") == 0) {
 		res = r_efi_set_state(slot, good, &ierror);
+	} else if (g_strcmp0(r_context()->config->system_bootloader, "efibootguard") == 0) {
+		res = r_efibootguard_set_state(slot, good, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "custom") == 0) {
 		res = r_custom_set_state(slot, good, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "noop") == 0) {
@@ -171,6 +176,8 @@ RaucSlot *r_boot_get_primary(GError **error)
 		slot = r_uboot_get_primary(&ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "efi") == 0) {
 		slot = r_efi_get_primary(&ierror);
+	} else if (g_strcmp0(r_context()->config->system_bootloader, "efibootguard") == 0) {
+		slot = r_efibootguard_get_primary(&ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "custom") == 0) {
 		slot = r_custom_get_primary(&ierror);
 	} else {
@@ -209,6 +216,8 @@ gboolean r_boot_set_primary(RaucSlot *slot, GError **error)
 		res = r_uboot_set_primary(slot, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "efi") == 0) {
 		res = r_efi_set_primary(slot, &ierror);
+	} else if (g_strcmp0(r_context()->config->system_bootloader, "efibootguard") == 0) {
+		res = r_efibootguard_set_primary(slot, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "custom") == 0) {
 		res = r_custom_set_primary(slot, &ierror);
 	} else if (g_strcmp0(r_context()->config->system_bootloader, "noop") == 0) {

--- a/src/bootloaders/efibootguard.c
+++ b/src/bootloaders/efibootguard.c
@@ -1,0 +1,314 @@
+#include "efibootguard.h"
+#include "bootchooser.h"
+#include "context.h"
+#include "utils.h"
+
+#define BG_PRINTENV_NAME "bg_printenv"
+#define BG_SETENV_NAME   "bg_setenv"
+
+/* Fetch a variable from efibootguard environment for a slot.
+ *
+ * @slot: bootname of the slot
+ * @key: variable to fetch
+ * @value: (out) string value (allocated, must be NULL on entry)
+ * @error: (out) error
+ */
+static gboolean efibootguard_env_get(const gchar *slot, const gchar *key, GString **value, GError **error)
+{
+	g_autoptr(GSubprocess) sub = NULL;
+	GError *ierror = NULL;
+	g_autoptr(GBytes) sub_stdout_buf = NULL;
+	g_autoptr(GPtrArray) sub_args = g_ptr_array_new_full(5, g_free);
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(key, FALSE);
+	g_return_val_if_fail(value && *value == NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	g_ptr_array_add(sub_args, g_strdup(BG_PRINTENV_NAME));
+	g_ptr_array_add(sub_args, g_strdup("--raw"));
+	g_ptr_array_add(sub_args, g_strdup("--part"));
+	g_ptr_array_add(sub_args, g_strdup(slot));
+	g_ptr_array_add(sub_args, NULL);
+
+	sub = r_subprocess_newv(
+			sub_args,
+			G_SUBPROCESS_FLAGS_STDOUT_PIPE | G_SUBPROCESS_FLAGS_STDERR_MERGE,
+			&ierror);
+	if (!sub) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to start " BG_PRINTENV_NAME ": ");
+		return FALSE;
+	}
+
+	if (!g_subprocess_communicate(sub, NULL, NULL, &sub_stdout_buf, NULL, &ierror)) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to run " BG_PRINTENV_NAME ": ");
+		return FALSE;
+	}
+
+	if (!g_subprocess_get_if_exited(sub)) {
+		g_set_error_literal(
+				error,
+				G_SPAWN_ERROR,
+				G_SPAWN_ERROR_FAILED,
+				BG_PRINTENV_NAME " did not exit normally");
+		return FALSE;
+	}
+
+	gint ret = g_subprocess_get_exit_status(sub);
+	if (ret != 0) {
+		g_set_error(
+				error,
+				G_SPAWN_EXIT_ERROR,
+				ret,
+				BG_PRINTENV_NAME " failed with exit code: %i", ret);
+		return FALSE;
+	}
+
+	const gchar *sub_stdout = g_bytes_get_data(sub_stdout_buf, NULL);
+	if (sub_stdout) {
+		g_autofree gchar *key_prefix = g_strdup_printf("%s=", key);
+		g_auto(GStrv) variables = g_strsplit(sub_stdout, "\n", -1);
+		for (gchar **variable = variables; *variable; variable++) {
+			if (g_str_has_prefix(*variable, key_prefix)) {
+				gsize offset = strlen(key_prefix);
+				gsize size = strlen(*variable);
+				*value = g_string_new_len(*variable + offset, size - offset);
+				g_strchomp((*value)->str);
+				return TRUE;
+			}
+		}
+	}
+
+	g_set_error(
+			error,
+			R_BOOTCHOOSER_ERROR,
+			R_BOOTCHOOSER_ERROR_PARSE_FAILED,
+			"Variable %s not set in efibootguard environment", key);
+	return FALSE;
+}
+
+/* Fetch a variable from efibootguard environment for a slot and parse it as an integer.
+ *
+ * @slot: bootname of the slot
+ * @key: variable name
+ * @value_num: (out) integer value
+ * @error: (out) error
+ */
+static gboolean efibootguard_env_get_int(const gchar *slot, const gchar *key, guint64 *value_num, GError **error)
+{
+	GError *ierror = NULL;
+	g_autoptr(GString) value = NULL;
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(key, FALSE);
+	g_return_val_if_fail(value_num, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (!efibootguard_env_get(slot, key, &value, &ierror)) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+	if (!value->len) {
+		g_set_error_literal(
+				error,
+				R_BOOTCHOOSER_ERROR,
+				R_BOOTCHOOSER_ERROR_PARSE_FAILED,
+				"Variable is empty");
+		return FALSE;
+	}
+	*value_num = g_ascii_strtoull(value->str, NULL, 10);
+	return TRUE;
+}
+
+gboolean r_efibootguard_set_state(RaucSlot *slot, gboolean good, GError **error)
+{
+	g_autoptr(GSubprocess) sub = NULL;
+	GError *ierror = NULL;
+	g_autoptr(GPtrArray) args = g_ptr_array_new_with_free_func(g_free);
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	g_message("efibootguard: setting slot %s state to %s", slot->name, good ? "OK" : "FAILED");
+
+	g_ptr_array_add(args, g_strdup(BG_SETENV_NAME));
+	g_ptr_array_add(args, g_strdup("--part"));
+	g_ptr_array_add(args, g_strdup(slot->bootname));
+
+	if (good) {
+		g_ptr_array_add(args, g_strdup("--ustate"));
+		g_ptr_array_add(args, g_strdup("OK"));
+	} else {
+		g_ptr_array_add(args, g_strdup("--ustate"));
+		g_ptr_array_add(args, g_strdup("FAILED"));
+
+		/* reset the slot revision when setting to FAILED */
+		g_ptr_array_add(args, g_strdup("--revision"));
+		g_ptr_array_add(args, g_strdup("0"));
+	}
+
+	g_ptr_array_add(args, NULL);
+
+	sub = r_subprocess_newv(
+			args,
+			G_SUBPROCESS_FLAGS_STDOUT_PIPE | G_SUBPROCESS_FLAGS_STDERR_MERGE,
+			&ierror);
+	if (!sub) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to start " BG_SETENV_NAME ": ");
+		return FALSE;
+	}
+
+	if (!g_subprocess_wait_check(sub, NULL, &ierror)) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to run " BG_SETENV_NAME ": ");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+RaucSlot *r_efibootguard_get_primary(GError **error)
+{
+	RaucSlot *slot;
+	RaucSlot *primary = NULL;
+	gboolean primary_found = FALSE;
+	guint64 highest_revision = 0;
+	GHashTableIter iter;
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	g_hash_table_iter_init(&iter, r_context()->config->slots);
+
+	/* the primary slot is the slot with the highest revision */
+	while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &slot)) {
+		guint64 slot_revision, slot_ustate;
+
+		if (!slot->bootname)
+			continue;
+		if (!efibootguard_env_get_int(slot->bootname, "REVISION", &slot_revision, &ierror)) {
+			g_propagate_error(error, ierror);
+			return NULL;
+		}
+		if (!efibootguard_env_get_int(slot->bootname, "USTATE", &slot_ustate, &ierror)) {
+			g_propagate_error(error, ierror);
+			return NULL;
+		}
+		g_debug("efibootguard: slot %s revision=%" G_GUINT64_FORMAT ", ustate=%" G_GUINT64_FORMAT,
+				slot->name, slot_revision, slot_ustate);
+
+		/* skip failed slots (could be set at runtime with e.g. `rauc status mark-bad`) */
+		if (slot_ustate == R_EFIBOOTGUARD_USTATE_FAILED) {
+			g_debug("efibootguard: skipping slot %s; ustate failed", slot->name);
+			continue;
+		}
+
+		if (!primary_found || slot_revision > highest_revision) {
+			highest_revision = slot_revision;
+			primary_found = TRUE;
+			primary = slot;
+		}
+	}
+
+	if (!primary) {
+		g_set_error(
+				error,
+				R_BOOTCHOOSER_ERROR,
+				R_BOOTCHOOSER_ERROR_PARSE_FAILED,
+				"Couldn't determine primary slot");
+	}
+
+	return primary;
+}
+
+gboolean r_efibootguard_set_primary(RaucSlot *slot, GError **error)
+{
+	guint64 highest_revision = 0;
+	GHashTableIter iter;
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	g_hash_table_iter_init(&iter, r_context()->config->slots);
+
+	RaucSlot *slot_iter;
+	while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &slot_iter)) {
+		guint64 slot_revision;
+
+		if (!slot_iter->bootname)
+			continue;
+		if (g_strcmp0(slot_iter->bootname, slot->bootname) == 0)
+			continue;
+		if (!efibootguard_env_get_int(slot_iter->bootname, "REVISION", &slot_revision, &ierror)) {
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
+		g_debug("efibootguard: slot %s revision=%" G_GUINT64_FORMAT, slot_iter->name, slot_revision);
+		if (slot_revision > highest_revision)
+			highest_revision = slot_revision;
+	}
+
+	guint64 bg_revision = highest_revision + 1;
+	g_autofree gchar *bg_revision_str = g_strdup_printf("%" G_GUINT64_FORMAT, bg_revision);
+	g_message("efibootguard: setting slot %s state to INSTALLED, revision to %" G_GUINT64_FORMAT,
+			slot->name, bg_revision);
+
+	g_autoptr(GSubprocess) sub = r_subprocess_new(
+			G_SUBPROCESS_FLAGS_NONE,
+			&ierror,
+			BG_SETENV_NAME,
+			"-p", slot->bootname,
+			"-s", "INSTALLED",
+			"-r", bg_revision_str,
+			NULL);
+	if (!sub) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to start " BG_SETENV_NAME ": ");
+		return FALSE;
+	}
+	if (!g_subprocess_wait_check(sub, NULL, &ierror)) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to run " BG_SETENV_NAME ": ");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+gboolean r_efibootguard_get_state(RaucSlot *slot, gboolean *good, GError **error)
+{
+	GError *ierror = NULL;
+	guint64 slot_ustate;
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(good, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* Function must not be called for slots without a bootname! */
+	g_assert_nonnull(slot->bootname);
+
+	if (!efibootguard_env_get_int(slot->bootname, "USTATE", &slot_ustate, &ierror)) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+	g_debug("efibootguard: slot %s ustate=%" G_GUINT64_FORMAT, slot->name, slot_ustate);
+	*good = (slot_ustate != R_EFIBOOTGUARD_USTATE_FAILED);
+
+	return TRUE;
+}

--- a/src/bootloaders/efibootguard.h
+++ b/src/bootloaders/efibootguard.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <glib.h>
+
+#include <slot.h>
+
+typedef enum {
+	R_EFIBOOTGUARD_USTATE_OK = 0,
+	R_EFIBOOTGUARD_USTATE_INSTALLED = 1,
+	R_EFIBOOTGUARD_USTATE_TESTING = 2,
+	R_EFIBOOTGUARD_USTATE_FAILED = 3,
+	/* The unknown state is used internally in efibootguard and is not user-facing */
+	R_EFIBOOTGUARD_USTATE_UNKNOWN = 4,
+} RaucEfibootguardUstate;
+
+gboolean r_efibootguard_set_state(RaucSlot *slot, gboolean good, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+gboolean r_efibootguard_set_primary(RaucSlot *slot, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+RaucSlot *r_efibootguard_get_primary(GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+gboolean r_efibootguard_get_state(RaucSlot *slot, gboolean *good, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;

--- a/test/bin/bg_printenv
+++ b/test/bin/bg_printenv
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import argparse
+import configparser
+import os
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="bg_printenv mock for RAUC testing (use EFIBOOTGUARD_VAR_FILE for persisting data)"
+    )
+    parser.add_argument("-r", "--raw", action="store_true", help="Output raw variable values")
+    parser.add_argument("-p", "--part", dest="partition", help="Select EFI partition")
+    args = parser.parse_args()
+
+    if not args.partition:
+        print("Error: partition not specified", file=sys.stderr)
+        sys.exit(1)
+
+    vars_file = os.environ.get("EFIBOOTGUARD_VAR_FILE")
+    if not vars_file:
+        print("Error: EFIBOOTGUARD_VAR_FILE not set", file=sys.stderr)
+        sys.exit(1)
+
+    cfg = configparser.ConfigParser()
+    cfg.optionxform = str  # preserve key case
+    cfg.read(vars_file)
+
+    slot_name = f"slot.{args.partition}"
+    if not cfg.has_section(slot_name):
+        print(f"Error: partition {args.partition!r} not found", file=sys.stderr)
+        sys.exit(1)
+
+    for key, value in cfg.items(slot_name):
+        print(f"{key}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/bin/bg_setenv
+++ b/test/bin/bg_setenv
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import argparse
+import configparser
+import os
+import sys
+
+
+USTATE_MAP = {
+    "OK": "0",
+    "INSTALLED": "1",
+    "TESTING": "2",
+    "FAILED": "3",
+    "UNKNOWN": "4",
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="bg_setenv mock for RAUC testing (use EFIBOOTGUARD_VAR_FILE for persisting data)"
+    )
+    parser.add_argument("-p", "--part", dest="partition", help="Select EFI partition")
+    parser.add_argument("-s", "--ustate", dest="state", help="Set update state (OK, INSTALLED, TESTING, FAILED, UNKNOWN)")
+    parser.add_argument("-r", "--revision", dest="revision", help="Set revision counter")
+    args = parser.parse_args()
+
+    if not args.partition:
+        print("Error: partition not specified", file=sys.stderr)
+        sys.exit(1)
+
+    vars_file = os.environ.get("EFIBOOTGUARD_VAR_FILE")
+    if not vars_file:
+        print("Error: EFIBOOTGUARD_VAR_FILE not set", file=sys.stderr)
+        sys.exit(1)
+
+    cfg = configparser.ConfigParser()
+    cfg.optionxform = str  # preserve key case
+    cfg.read(vars_file)
+
+    slot_name = f"slot.{args.partition}"
+    if not cfg.has_section(slot_name):
+        print(f"Error: partition {args.partition!r} not found", file=sys.stderr)
+        sys.exit(1)
+
+    if args.state is not None:
+        if args.state not in USTATE_MAP:
+            print(f"Error: unknown state {args.state!r}", file=sys.stderr)
+            sys.exit(1)
+        cfg.set(slot_name, "USTATE", USTATE_MAP[args.state])
+
+    if args.revision is not None:
+        cfg.set(slot_name, "REVISION", args.revision)
+
+    with open(vars_file, "w") as f:
+        cfg.write(f)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -6,6 +6,8 @@
 #include <context.h>
 #include <utils.h>
 
+#include "../src/bootloaders/efibootguard.h"
+
 #include "common.h"
 
 typedef struct {
@@ -972,6 +974,152 @@ bootname=system1\n";
 	g_assert_nonnull(bootname);
 }
 
+/* Write initial efibootguard environment for mock tools (bg_printenv/bg_setenv).
+ * Stores per-partition state as an INI file at EFIBOOTGUARD_VAR_FILE.
+ */
+static void test_efibootguard_initialize_state(const BootchooserFixture *fixture,
+		RaucEfibootguardUstate slot0_ustate, gint slot0_revision,
+		RaucEfibootguardUstate slot1_ustate, gint slot1_revision)
+{
+	g_autofree gchar *vars_file = g_build_filename(fixture->tmpdir, "efibootguard-vars.ini", NULL);
+	g_autofree gchar *content = g_strdup_printf(
+			"[slot.0]\n"
+			"USTATE=%d\n"
+			"REVISION=%d\n"
+			"\n"
+			"[slot.1]\n"
+			"USTATE=%d\n"
+			"REVISION=%d\n",
+			slot0_ustate, slot0_revision,
+			slot1_ustate, slot1_revision);
+	g_assert_true(g_file_set_contents(vars_file, content, -1, NULL));
+	g_assert_true(g_setenv("EFIBOOTGUARD_VAR_FILE", vars_file, TRUE));
+}
+
+/* Read a single integer variable from the efibootguard state INI file. */
+static gint test_efibootguard_get_var(const gchar *partition, const gchar *key)
+{
+	const gchar *vars_file = g_getenv("EFIBOOTGUARD_VAR_FILE");
+	g_autoptr(GKeyFile) kf = g_key_file_new();
+
+	g_assert_nonnull(vars_file);
+	g_assert_true(g_key_file_load_from_file(kf, vars_file, G_KEY_FILE_NONE, NULL));
+
+	return g_key_file_get_integer(kf, partition, key, NULL);
+}
+
+static void bootchooser_efibootguard(BootchooserFixture *fixture,
+		gconstpointer user_data)
+{
+	RaucSlot *rootfs0 = NULL, *rootfs1 = NULL, *primary = NULL;
+	gboolean good;
+	GError *error = NULL;
+
+	const gchar *cfg_file = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=efibootguard\n\
+mountprefix=/mnt/myrauc/\n\
+\n\
+[keyring]\n\
+path=/etc/rauc/keyring/\n\
+\n\
+[slot.rootfs.0]\n\
+device=/dev/rootfs-0\n\
+type=ext4\n\
+bootname=0\n\
+\n\
+[slot.rootfs.1]\n\
+device=/dev/rootfs-1\n\
+type=ext4\n\
+bootname=1\n";
+
+	gchar *pathname = write_tmp_file(fixture->tmpdir, "efibootguard.conf", cfg_file, NULL);
+	g_assert_nonnull(pathname);
+
+	g_clear_pointer(&r_context_conf()->configpath, g_free);
+	r_context_conf()->configpath = pathname;
+	r_context();
+
+	rootfs0 = find_config_slot_by_name(r_context()->config, "rootfs.0");
+	g_assert_nonnull(rootfs0);
+	rootfs1 = find_config_slot_by_name(r_context()->config, "rootfs.1");
+	g_assert_nonnull(rootfs1);
+
+	/* mock EFI Boot Guard configuration:
+	 * Slot 0: USTATE=OK, REVISION=1
+	 * Slot 1: USTATE=OK, REVISION=0
+	 */
+	test_efibootguard_initialize_state(fixture,
+			R_EFIBOOTGUARD_USTATE_OK, 1,
+			R_EFIBOOTGUARD_USTATE_OK, 0);
+
+	/* check both slots are considered good (USTATE != FAILED) */
+	g_assert_true(r_boot_get_state(rootfs0, &good, &error));
+	g_assert_no_error(error);
+	g_assert_true(good);
+	g_assert_true(r_boot_get_state(rootfs1, &good, &error));
+	g_assert_no_error(error);
+	g_assert_true(good);
+
+	/* check rootfs.0 is primary (highest revision, not failed) */
+	primary = r_boot_get_primary(&error);
+	g_assert_no_error(error);
+	g_assert_nonnull(primary);
+	g_assert_true(primary == rootfs0);
+
+	/* mark rootfs.0 bad: USTATE should become FAILED; revision=0 */
+	g_assert_true(r_boot_set_state(rootfs0, FALSE, &error));
+	g_assert_no_error(error);
+	g_assert_cmpint(test_efibootguard_get_var("slot.0", "USTATE"), ==, R_EFIBOOTGUARD_USTATE_FAILED);
+	g_assert_cmpint(test_efibootguard_get_var("slot.0", "REVISION"), ==, 0);
+
+	/* rootfs.0 should now be bad, rootfs.1 still good */
+	g_assert_true(r_boot_get_state(rootfs0, &good, &error));
+	g_assert_no_error(error);
+	g_assert_false(good);
+	g_assert_true(r_boot_get_state(rootfs1, &good, &error));
+	g_assert_no_error(error);
+	g_assert_true(good);
+
+	/* rootfs.1 is now the only non-failed slot, so it becomes primary */
+	primary = r_boot_get_primary(&error);
+	g_assert_no_error(error);
+	g_assert_nonnull(primary);
+	g_assert_true(primary == rootfs1);
+
+	/* mark rootfs.0 good again: USTATE should become OK; revision=0 */
+	g_assert_true(r_boot_set_state(rootfs0, TRUE, &error));
+	g_assert_no_error(error);
+	g_assert_cmpint(test_efibootguard_get_var("slot.0", "USTATE"), ==, R_EFIBOOTGUARD_USTATE_OK);
+	g_assert_cmpint(test_efibootguard_get_var("slot.0", "REVISION"), ==, 0);
+
+	/* rootfs.1 still has the highest revision, so it is primary */
+	primary = r_boot_get_primary(&error);
+	g_assert_no_error(error);
+	g_assert_nonnull(primary);
+	g_assert_true(primary == rootfs1);
+
+	/* mark rootfs.1 as primary: should get REVISION=1 (max+1), USTATE=INSTALLED */
+	g_assert_true(r_boot_set_primary(rootfs1, &error));
+	g_assert_no_error(error);
+	g_assert_cmpint(test_efibootguard_get_var("slot.1", "USTATE"), ==, R_EFIBOOTGUARD_USTATE_INSTALLED);
+	g_assert_cmpint(test_efibootguard_get_var("slot.1", "REVISION"), ==, 1);
+
+	/* rootfs.1 now has the highest revision and is not failed */
+	primary = r_boot_get_primary(&error);
+	g_assert_no_error(error);
+	g_assert_nonnull(primary);
+	g_assert_true(primary == rootfs1);
+
+	/* mark both slots failed: get_primary should return an error */
+	test_efibootguard_initialize_state(fixture, 3, 1, 3, 0);
+	primary = r_boot_get_primary(&error);
+	g_assert_null(primary);
+	g_assert_error(error, R_BOOTCHOOSER_ERROR, R_BOOTCHOOSER_ERROR_PARSE_FAILED);
+	g_clear_error(&error);
+}
+
 /* Write content to state storage for custom-backend RAUC mock
  * tools. Content should be similar to:
  * "\
@@ -1234,6 +1382,10 @@ int main(int argc, char *argv[])
 
 	g_test_add("/bootchooser/efi", BootchooserFixture, NULL,
 			bootchooser_fixture_set_up, bootchooser_efi,
+			bootchooser_fixture_tear_down);
+
+	g_test_add("/bootchooser/efibootguard", BootchooserFixture, NULL,
+			bootchooser_fixture_set_up, bootchooser_efibootguard,
 			bootchooser_fixture_tear_down);
 
 	g_test_add("/bootchooser/custom", BootchooserFixture, NULL,


### PR DESCRIPTION
Add bootchooser support for efibootguard.

Draft for now, for some early feedback.

Fixes #1443