### PR TITLE
src/bundle: fix assert handling in uint64 read/write functions

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -502,17 +502,16 @@ static gboolean input_stream_read_bytes_all(GInputStream *stream,
 {
 	g_autofree void *buffer = NULL;
 	gsize bytes_read;
-	gboolean res;
 
 	g_assert_cmpint(count, !=, 0);
 
 	buffer = g_malloc0(count);
 
-	res = g_input_stream_read_all(stream, buffer, count, &bytes_read,
-			cancellable, error);
-	if (!res) {
-		return res;
+	if (!g_input_stream_read_all(stream, buffer, count, &bytes_read,
+			cancellable, error)) {
+		return FALSE;
 	}
+
 	g_assert(bytes_read == count);
 	*bytes = g_bytes_new_take(g_steal_pointer(&buffer), count);
 	return TRUE;

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -456,13 +456,14 @@ static gboolean output_stream_write_uint64_all(GOutputStream *stream,
 		GError **error)
 {
 	gsize bytes_written;
-	gboolean res;
 
 	data = GUINT64_TO_BE(data);
-	res = g_output_stream_write_all(stream, &data, sizeof(data), &bytes_written,
-			cancellable, error);
+	if (!g_output_stream_write_all(stream, &data, sizeof(data), &bytes_written,
+			cancellable, error))
+		return FALSE;
+
 	g_assert(bytes_written == sizeof(data));
-	return res;
+	return TRUE;
 }
 
 static gboolean input_stream_read_uint64_all(GInputStream *stream,
@@ -472,13 +473,14 @@ static gboolean input_stream_read_uint64_all(GInputStream *stream,
 {
 	guint64 tmp;
 	gsize bytes_read;
-	gboolean res;
 
-	res = g_input_stream_read_all(stream, &tmp, sizeof(tmp), &bytes_read,
-			cancellable, error);
+	if (!g_input_stream_read_all(stream, &tmp, sizeof(tmp), &bytes_read,
+			cancellable, error))
+		return FALSE;
+
 	g_assert(bytes_read == sizeof(tmp));
 	*data = GUINT64_FROM_BE(tmp);
-	return res;
+	return TRUE;
 }
 
 static gboolean output_stream_write_bytes_all(GOutputStream *stream,


### PR DESCRIPTION
The `output_stream_write_uint64_all()` and `input_stream_read_uint64_all()` methods had `GError` handling in theory, but actually, in most cases this will be pointless.
The reason is that there is a `g_assert()` that will fail before being able to indicate an error as the function return code and lead to hard aborts like:

> Bail out! rauc:ERROR:src/bundle.c:479:input_stream_read_uint64_all: assertion failed: (bytes_read == sizeof(tmp))

Fix this by directly returning `FALSE` in case of an error in the read/write calls and use the `g_assert()` only if no error has been detected before.