### PR TITLE
src/slot: do not clean data directory for slot status 'pending'

### DIFF
--- a/src/slot.c
+++ b/src/slot.c
@@ -241,6 +241,10 @@ void r_slot_clean_data_directory(const RaucSlot *slot)
 
 	g_assert(g_path_is_absolute(slot->data_directory));
 
+	/* Do not attempt to clean yet when slot status is still 'pending' */
+	if (slot->status && g_strcmp0(slot->status->status, "pending") == 0)
+		return;
+
 	if (slot->status) {
 		hex_digest = slot->status->checksum.digest;
 	} else {


### PR DESCRIPTION
In 67ccd898 ("src/install: ensure invalidating slot status before updating"), a new `"pending"` state for slots was added to allow identifying slots that were left in an undefined state (mainly by rauc crashing during installation).

In `"pending"` state, the slot does not have a checksum.

Since we currently use the slot status saving for calling the directory cleanup, the cleanup will also be called when saving the 'pending' state (with empty slot checksum information).

As a result, the cleanup will also remove current and still valid checksum-based hash directories used for adaptive mode 'block-hash-index' so that these need to be regenerated on each installation. Depending on the platform and storage, this can be quite time-consuming.

For now, fix this by explicitly leaving the data directory untouched in case of a `"pending"` slot.

A later option is to re-evaluate the slot status handling in general and then see if the data directory cleanup should be coupled or called somewhere else.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
