### PR TITLE
src/main: fix wrong log field numbers in r_event_log_booted

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2026,9 +2026,9 @@ static void r_event_log_booted(const RaucSlot *booted_slot)
 	fields[5].value = booted_slot->bootname;
 	fields[6].value = r_context()->boot_id;
 	if (booted_slot->status && booted_slot->status->bundle_hash) {
-		fields[5].value = booted_slot->status->bundle_hash;
+		fields[7].value = booted_slot->status->bundle_hash;
 	} else {
-		fields[5].value = "unknown";
+		fields[7].value = "unknown";
 	}
 	g_log_structured_array(G_LOG_LEVEL_MESSAGE, fields, G_N_ELEMENTS(fields));
 }


### PR DESCRIPTION
The bundle hash must be set for `GLogField [7]` (`"BUNDLE_HASH"`), not `[5]` (`"SLOT_BOOTNAME"`).

Note that this left the `"BUNDLE_HASH"` field with a NULL pointer which the default log writer seems to handle but which fails when running in a systemd context where `g_log_writer_journald()` is used, too. There, the call to `strlen()` with a `NULL` pointer causes a segfault in RAUC.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
