### PR TITLE
Memory handling fixes for casync archive conversion

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -204,7 +204,7 @@ static gboolean casync_make_arch(const gchar *idxpath, const gchar *contentpath,
 	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(5, g_free);
 	g_autoptr(GPtrArray) iargs = g_ptr_array_new_full(15, g_free);
-	const gchar *tmpdir = NULL;
+	g_autofree gchar *tmpdir = NULL;
 
 	g_return_val_if_fail(idxpath != NULL, FALSE);
 	g_return_val_if_fail(contentpath != NULL, FALSE);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -259,7 +259,7 @@ static gboolean casync_make_arch(const gchar *idxpath, const gchar *contentpath,
 	g_ptr_array_add(args, g_strdup("fakeroot"));
 	g_ptr_array_add(args, g_strdup("sh"));
 	g_ptr_array_add(args, g_strdup("-c"));
-	g_ptr_array_add(args, g_strjoinv(" ", (gchar**) g_ptr_array_free(iargs, FALSE)));
+	g_ptr_array_add(args, g_strjoinv(" ", (gchar**) iargs->pdata));
 	g_ptr_array_add(args, NULL);
 
 	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_STDOUT_SILENCE, &ierror);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -202,7 +202,7 @@ static gboolean casync_make_arch(const gchar *idxpath, const gchar *contentpath,
 {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
-	g_autoptr(GPtrArray) args = g_ptr_array_new_full(15, g_free);
+	g_autoptr(GPtrArray) args = g_ptr_array_new_full(5, g_free);
 	g_autoptr(GPtrArray) iargs = g_ptr_array_new_full(15, g_free);
 	const gchar *tmpdir = NULL;
 


### PR DESCRIPTION
Fixes memory leakages, over-allocations, and a sort of double-free crash for 'rauc convert' calls with archives as input images.

Fixes: #1461 