### PR TITLE
src/main: fix leaking strings when printing hooks with 'rauc info'

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -882,7 +882,7 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 
 	hooks = g_ptr_array_new();
 	if (manifest->hooks.install_check == TRUE) {
-		g_ptr_array_add(hooks, g_strdup("install-check"));
+		g_ptr_array_add(hooks, (gchar*) "install-check");
 	}
 	g_ptr_array_add(hooks, NULL);
 
@@ -929,13 +929,13 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 
 		hooks = g_ptr_array_new();
 		if (img->hooks.pre_install == TRUE) {
-			g_ptr_array_add(hooks, g_strdup("pre-install"));
+			g_ptr_array_add(hooks, (gchar*) "pre-install");
 		}
 		if (img->hooks.install == TRUE) {
-			g_ptr_array_add(hooks, g_strdup("install"));
+			g_ptr_array_add(hooks, (gchar*) "install");
 		}
 		if (img->hooks.post_install == TRUE) {
-			g_ptr_array_add(hooks, g_strdup("post-install"));
+			g_ptr_array_add(hooks, (gchar*) "post-install");
 		}
 		g_ptr_array_add(hooks, NULL);
 
@@ -972,7 +972,7 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 
 	hooks = g_ptr_array_new();
 	if (manifest->hooks.install_check == TRUE) {
-		g_ptr_array_add(hooks, g_strdup("install-check"));
+		g_ptr_array_add(hooks, (gchar*) "install-check");
 	}
 	g_ptr_array_add(hooks, NULL);
 
@@ -1041,13 +1041,13 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 
 		hooks = g_ptr_array_new();
 		if (img->hooks.pre_install == TRUE) {
-			g_ptr_array_add(hooks, g_strdup("pre-install"));
+			g_ptr_array_add(hooks, (gchar*) "pre-install");
 		}
 		if (img->hooks.install == TRUE) {
-			g_ptr_array_add(hooks, g_strdup("install"));
+			g_ptr_array_add(hooks, (gchar*) "install");
 		}
 		if (img->hooks.post_install == TRUE) {
-			g_ptr_array_add(hooks, g_strdup("post-install"));
+			g_ptr_array_add(hooks, (gchar*) "post-install");
 		}
 		g_ptr_array_add(hooks, NULL);
 


### PR DESCRIPTION
The GPtrArrays are reference-counted correctly, but since they do not have a free func set, the newly allocated gchar's will not be freed.

Fix this by just using string literals instead.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
