### PR TITLE
update compiler warning configuration 

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,7 +60,6 @@ c_warn_flags = '''
   -Wstrict-prototypes
   -Wredundant-decls
   -Wno-unused-parameter
-  -Wno-missing-field-initializers
   -Wdeclaration-after-statement
   -Wformat=2
   -Wold-style-definition
@@ -83,7 +82,6 @@ c_warn_flags = '''
   -Wswitch-enum
   -Wswitch-default
   -Wno-error=unused-parameter
-  -Wno-error=missing-field-initializers
 '''.split()
 # To allow building against OpenSSL 3.0, we still need to allow deprecated
 # declarations

--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,6 @@ c_warn_flags = '''
   -Wcast-align
   -Wcast-align=strict
   -Wdate-time
-  -Wdeclaration-after-statement
   -Wformat=2
   -Wformat-nonliteral
   -Wformat-security

--- a/meson.build
+++ b/meson.build
@@ -51,36 +51,36 @@ conf.set10('ENABLE_CREATE', get_option('create'))
 conf.set10('ENABLE_JSON', jsonglibdep.found())
 
 c_warn_flags = '''
-  -Wundef
-  -Wnested-externs
-  -Wwrite-strings
-  -Wpointer-arith
-  -Wmissing-declarations
-  -Wmissing-prototypes
-  -Wstrict-prototypes
-  -Wredundant-decls
-  -Wno-unused-parameter
+  -Warray-bounds
+  -Wcast-align
   -Wdeclaration-after-statement
   -Wformat=2
-  -Wold-style-definition
-  -Wcast-align
   -Wformat-nonliteral
   -Wformat-security
+  -Wimplicit-function-declaration
+  -Winit-self
+  -Winline
+  -Wmissing-declarations
+  -Wmissing-format-attribute
+  -Wmissing-include-dirs
+  -Wmissing-noreturn
+  -Wmissing-prototypes
+  -Wnested-externs
+  -Wold-style-definition
+  -Wpacked
+  -Wpointer-arith
+  -Wredundant-decls
+  -Wreturn-type
+  -Wshadow
   -Wsign-compare
   -Wstrict-aliasing
-  -Wshadow
-  -Winline
-  -Wpacked
-  -Wmissing-format-attribute
-  -Wmissing-noreturn
-  -Winit-self
-  -Wmissing-include-dirs
-  -Wunused-but-set-variable
-  -Warray-bounds
-  -Wimplicit-function-declaration
-  -Wreturn-type
-  -Wswitch-enum
+  -Wstrict-prototypes
   -Wswitch-default
+  -Wswitch-enum
+  -Wundef
+  -Wunused-but-set-variable
+  -Wwrite-strings
+  -Wno-unused-parameter
   -Wno-error=unused-parameter
 '''.split()
 # To allow building against OpenSSL 3.0, we still need to allow deprecated

--- a/meson.build
+++ b/meson.build
@@ -51,15 +51,23 @@ conf.set10('ENABLE_CREATE', get_option('create'))
 conf.set10('ENABLE_JSON', jsonglibdep.found())
 
 c_warn_flags = '''
+  -Walloca
   -Warray-bounds
   -Wcast-align
+  -Wcast-align=strict
+  -Wdate-time
   -Wdeclaration-after-statement
   -Wformat=2
   -Wformat-nonliteral
   -Wformat-security
+  -Wformat-truncation=2
   -Wimplicit-function-declaration
   -Winit-self
   -Winline
+  -Wint-conversion
+  -Winvalid-utf8
+  -Wjump-misses-init
+  -Wlogical-op
   -Wmissing-declarations
   -Wmissing-format-attribute
   -Wmissing-include-dirs
@@ -74,11 +82,14 @@ c_warn_flags = '''
   -Wshadow
   -Wsign-compare
   -Wstrict-aliasing
+  -Wstrict-overflow
   -Wstrict-prototypes
   -Wswitch-default
   -Wswitch-enum
+  -Wtrampolines
   -Wundef
   -Wunused-but-set-variable
+  -Wuse-after-free=3
   -Wwrite-strings
   -Wno-unused-parameter
   -Wno-error=unused-parameter


### PR DESCRIPTION
Add some more useful warnings and allow declarations after statements. This makes is easier to declare (temporary) variables where they are
initialized. Together with g_auto*, this makes code easier to read.