### PR TITLE
Add missing "PRIORITY" field to structured logging arrays

### DIFF
--- a/include/event_log.h
+++ b/include/event_log.h
@@ -73,6 +73,15 @@ typedef struct _REventLogger {
 } REventLogger;
 
 /**
+ * Returns log level to use for "PRIORITY" field of structured log array
+ *
+ * @param log_level log level
+ *
+ * @return static string representing the log priority.
+ */
+const gchar* r_event_log_level_to_priority(GLogLevelFlags log_level);
+
+/**
  * Tests type string for being a supported event log type.
  *
  * @param type Type string to test

--- a/src/event_log.c
+++ b/src/event_log.c
@@ -24,6 +24,25 @@ gboolean r_event_log_is_supported_type(const gchar *type)
 	return g_strv_contains(supported_event_types, type);
 }
 
+const gchar * r_event_log_level_to_priority(GLogLevelFlags log_level)
+{
+	if (log_level & G_LOG_LEVEL_ERROR)
+		return "3";
+	else if (log_level & G_LOG_LEVEL_CRITICAL)
+		return "4";
+	else if (log_level & G_LOG_LEVEL_WARNING)
+		return "4";
+	else if (log_level & G_LOG_LEVEL_MESSAGE)
+		return "5";
+	else if (log_level & G_LOG_LEVEL_INFO)
+		return "6";
+	else if (log_level & G_LOG_LEVEL_DEBUG)
+		return "7";
+
+	/* Default to LOG_NOTICE for custom log levels. */
+	return "5";
+}
+
 void r_event_log_message(const gchar *type, const gchar *message, ...)
 {
 	va_list list;

--- a/src/install.c
+++ b/src/install.c
@@ -1124,8 +1124,8 @@ static void log_event_installation_done(RaucInstallArgs *args, RaucManifest *man
 {
 	g_autofree gchar *formatted = NULL;
 	GLogField fields[] = {
-		{"MESSAGE", NULL, -1 },
-		{"MESSAGE_ID", NULL, -1 },
+		{"MESSAGE", NULL, -1},
+		{"MESSAGE_ID", NULL, -1},
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "install", -1},
 		{"BUNDLE_HASH", "", -1},

--- a/src/install.c
+++ b/src/install.c
@@ -1126,6 +1126,7 @@ static void log_event_installation_done(RaucInstallArgs *args, RaucManifest *man
 	GLogField fields[] = {
 		{"MESSAGE", NULL, -1},
 		{"MESSAGE_ID", NULL, -1},
+		{"PRIORITY", r_event_log_level_to_priority(G_LOG_LEVEL_MESSAGE), -1},
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "install", -1},
 		{"BUNDLE_HASH", "", -1},
@@ -1152,9 +1153,9 @@ static void log_event_installation_done(RaucInstallArgs *args, RaucManifest *man
 
 	fields[0].value = formatted;
 	if (manifest) {
-		fields[4].value = manifest->hash ?: "";
-		fields[5].value = manifest->update_description ?: "";
-		fields[6].value = manifest->update_version ?: "";
+		fields[5].value = manifest->hash ?: "";
+		fields[6].value = manifest->update_description ?: "";
+		fields[7].value = manifest->update_version ?: "";
 	}
 
 	g_log_structured_array(G_LOG_LEVEL_MESSAGE, fields, G_N_ELEMENTS(fields));

--- a/src/main.c
+++ b/src/main.c
@@ -2010,6 +2010,7 @@ static void r_event_log_booted(const RaucSlot *booted_slot)
 	GLogField fields[] = {
 		{"MESSAGE", NULL, -1 },
 		{"MESSAGE_ID", MESSAGE_ID_BOOTED, -1 },
+		{"PRIORITY", r_event_log_level_to_priority(G_LOG_LEVEL_MESSAGE), -1},
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "boot", -1},
 		{"SLOT_NAME", NULL, -1},
@@ -2022,13 +2023,13 @@ static void r_event_log_booted(const RaucSlot *booted_slot)
 
 	message = g_strdup_printf("Booted into %s (%s)", booted_slot->name, booted_slot->bootname);
 	fields[0].value = message;
-	fields[4].value = booted_slot->name;
-	fields[5].value = booted_slot->bootname;
-	fields[6].value = r_context()->boot_id;
+	fields[5].value = booted_slot->name;
+	fields[6].value = booted_slot->bootname;
+	fields[7].value = r_context()->boot_id;
 	if (booted_slot->status && booted_slot->status->bundle_hash) {
-		fields[7].value = booted_slot->status->bundle_hash;
+		fields[8].value = booted_slot->status->bundle_hash;
 	} else {
-		fields[7].value = "unknown";
+		fields[8].value = "unknown";
 	}
 	g_log_structured_array(G_LOG_LEVEL_MESSAGE, fields, G_N_ELEMENTS(fields));
 }
@@ -2039,6 +2040,7 @@ static void r_event_log_booted_external(void)
 	GLogField fields[] = {
 		{"MESSAGE", NULL, -1 },
 		{"MESSAGE_ID", MESSAGE_ID_BOOTED_EXTERNAL, -1 },
+		{"PRIORITY", r_event_log_level_to_priority(G_LOG_LEVEL_MESSAGE), -1},
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "boot", -1},
 		{"BOOT_ID", NULL, -1},
@@ -2046,7 +2048,7 @@ static void r_event_log_booted_external(void)
 
 	message = g_strdup_printf("Booted from external source");
 	fields[0].value = message;
-	fields[4].value = r_context()->boot_id;
+	fields[5].value = r_context()->boot_id;
 	g_log_structured_array(G_LOG_LEVEL_MESSAGE, fields, G_N_ELEMENTS(fields));
 }
 

--- a/test/event_log.c
+++ b/test/event_log.c
@@ -275,6 +275,7 @@ static void event_log_test_structured_logging(EventLogFixture *fixture,
 	REventLogger *logger = NULL;
 	GLogField fields[] = {
 		{"MESSAGE", "This is a test (mark) log message", -1},
+		{"PRIORITY", r_event_log_level_to_priority(G_LOG_LEVEL_INFO), -1},
 		{"MESSAGE_ID", "1d1b7a5aa9084c3a9004650c9d2ce850", -1},
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "mark", -1},

--- a/test/event_log.c
+++ b/test/event_log.c
@@ -274,8 +274,8 @@ static void event_log_test_structured_logging(EventLogFixture *fixture,
 {
 	REventLogger *logger = NULL;
 	GLogField fields[] = {
-		{"MESSAGE", "This is a test (mark) log message", -1 },
-		{"MESSAGE_ID", "1d1b7a5aa9084c3a9004650c9d2ce850", -1 },
+		{"MESSAGE", "This is a test (mark) log message", -1},
+		{"MESSAGE_ID", "1d1b7a5aa9084c3a9004650c9d2ce850", -1},
 		{"GLIB_DOMAIN", R_EVENT_LOG_DOMAIN, -1},
 		{"RAUC_EVENT_TYPE", "mark", -1},
 		{"BUNDLE_HASH", "b970468f-89e4-4793-9904-06c922902b25", -1},


### PR DESCRIPTION
In contrast to `g_log_structured()`, `g_log_structured_array()` takes a `log_level` as input argument but uses this for filtering only.

The `"PRIORITY"` field must already be present in the array fields provided.

Note that the messages are shown in systemd with default priority anyway.
A difference can only be observed when using `journalctl` with `-o verbose`.

Fixes: #1470