### PR TITLE
move existing slot data directory to "unknown"

### DIFF
--- a/include/slot.h
+++ b/include/slot.h
@@ -90,6 +90,8 @@ void r_slot_clear_status(RaucSlotStatus *slotstatus);
  */
 void r_slot_free_status(RaucSlotStatus *slotstatus);
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucSlotStatus, r_slot_free_status);
+
 /**
  * Finds a slot given its device path.
  *

--- a/include/slot.h
+++ b/include/slot.h
@@ -166,6 +166,22 @@ RaucSlot* r_slot_get_parent_root(RaucSlot *slot)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Moves a data directory to a name with a different digest.
+ *
+ * This is useful when we want to update a slot, as we move it to the "unknown"
+ * digest while we are writing to it. Existing data for the new digest is
+ * removed. If no data exists for the old digest, nothing is moved.
+ *
+ * @param slot slot for which the data directory should be moved
+ * @param old_digest the old digest or NULL
+ * @param new_digest the new digest or NULL
+ *
+ * @return TRUE if successful, otherwise FALSE
+ */
+gboolean r_slot_move_checksum_data_directory(const RaucSlot *slot, const gchar *old_digest, const gchar *new_digest, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
  * Returns the data subdirectory corresponding to the current or given
  * hash/checksum.
  *

--- a/test/status_file.c
+++ b/test/status_file.c
@@ -33,7 +33,8 @@ static void status_file_test_read_slot_status(void)
 {
 	GError *ierror = NULL;
 	gboolean res;
-	RaucSlotStatus *ss = g_new0(RaucSlotStatus, 1);
+	g_autoptr(RaucSlotStatus) ss = g_new0(RaucSlotStatus, 1);
+
 	res = r_slot_status_read("test/rootfs.raucs", ss, &ierror);
 	g_assert_no_error(ierror);
 	g_assert_true(res);
@@ -42,14 +43,12 @@ static void status_file_test_read_slot_status(void)
 	g_assert_cmpint(ss->checksum.type, ==, G_CHECKSUM_SHA256);
 	g_assert_cmpstr(ss->checksum.digest, ==,
 			"e437ab217356ee47cd338be0ffe33a3cb6dc1ce679475ea59ff8a8f7f6242b27");
-
-	r_slot_free_status(ss);
 }
 
 
 static void status_file_test_write_slot_status(void)
 {
-	RaucSlotStatus *ss = g_new0(RaucSlotStatus, 1);
+	g_autoptr(RaucSlotStatus) ss = g_new0(RaucSlotStatus, 1);
 
 	ss->status = g_strdup("ok");
 	ss->checksum.type = G_CHECKSUM_SHA256;
@@ -67,8 +66,6 @@ static void status_file_test_write_slot_status(void)
 	g_assert_cmpint(ss->checksum.type, ==, G_CHECKSUM_SHA256);
 	g_assert_cmpstr(ss->checksum.digest, ==,
 			"dc626520dcd53a22f727af3ee42c770e56c97a64fe3adb063799d8ab032fe551");
-
-	r_slot_free_status(ss);
 }
 
 static void status_file_test_global_slot_status(StatusFileFixture *fixture,

--- a/test/status_file.c
+++ b/test/status_file.c
@@ -4,7 +4,9 @@
 #include "common.h"
 #include "context.h"
 #include "config.h"
+#include "slot.h"
 #include "status_file.h"
+#include "utils.h"
 
 typedef struct {
 	gchar *tmpdir;
@@ -17,6 +19,16 @@ static void status_file_fixture_set_up_global(StatusFileFixture *fixture,
 	g_assert_nonnull(fixture->tmpdir);
 
 	replace_strdup(&r_context_conf()->configpath, "test/test-global.conf");
+	r_context();
+}
+
+static void status_file_fixture_set_up_datadir(StatusFileFixture *fixture,
+		gconstpointer user_data)
+{
+	fixture->tmpdir = g_dir_make_tmp("rauc-conf_file-XXXXXX", NULL);
+	g_assert_nonnull(fixture->tmpdir);
+
+	replace_strdup(&r_context_conf()->configpath, "test/test-datadir.conf");
 	r_context();
 }
 
@@ -357,6 +369,134 @@ boot-id=e02a2afe-cf45-4d50-a3f3-c223ca0f480a\n\
 	g_assert_true(g_strv_contains((const gchar * const *)groups, "slot.rootfs.0"));
 }
 
+#define DIGEST_INITIAL "9a0218f0dbfed28d5b35e441668952100128d7bdec667f3f0e1f7cbbff6d11e7"
+#define DIGEST_OTHER "20ea715f2807da0cccda2a4874898a55b38bdf0473fc2fdcab0d28fdbc96b770"
+#define DIGEST_UPDATED "839127aa5fcd9e5f988934e2d727fb14feb5cec9435dd2548bf1a778ba44549a"
+
+static void status_file_test_datadir(StatusFileFixture *fixture, gconstpointer user_data)
+{
+	GHashTable *slots = r_context()->config->slots;
+	GError *ierror = NULL;
+	gboolean res;
+
+	g_assert_nonnull(r_context()->config->statusfile_path);
+
+	g_assert_nonnull(slots);
+	RaucSlot *slot = g_hash_table_lookup(slots, "rootfs.0");
+	g_assert_nonnull(slot);
+
+	/* Create status */
+	if (slot->status)
+		r_slot_free_status(slot->status);
+	slot->status = g_new0(RaucSlotStatus, 1);
+	slot->status->status = g_strdup("ok");
+	slot->status->checksum.type = G_CHECKSUM_SHA256;
+	slot->status->checksum.digest = g_strdup(DIGEST_INITIAL);
+	slot->status->checksum.size = 512;
+
+	g_autofree gchar *initial_checksum_dir = r_slot_get_checksum_data_directory(slot, NULL, &ierror);
+	g_assert_nonnull(initial_checksum_dir);
+	g_assert_no_error(ierror);
+
+	g_autofree gchar *initial_file = write_tmp_file(initial_checksum_dir, "testfile", "content", &ierror);
+	g_assert_nonnull(initial_file);
+	g_assert_no_error(ierror);
+	g_assert_true(g_file_test(initial_file, G_FILE_TEST_IS_REGULAR));
+
+	GStatBuf initial_stat = {0};
+	g_assert_cmpint(g_lstat(initial_file, &initial_stat), ==, 0);
+
+	RaucChecksum other_checksum = {
+		.type = G_CHECKSUM_SHA256,
+		.digest = g_strdup(DIGEST_OTHER),
+	};
+	g_autofree gchar *other_checksum_dir = r_slot_get_checksum_data_directory(slot, &other_checksum, &ierror);
+	g_assert_nonnull(other_checksum_dir);
+	g_assert_no_error(ierror);
+	g_clear_pointer(&other_checksum.digest, g_free);
+
+	g_autofree gchar *other_file = write_tmp_file(other_checksum_dir, "testfile", "other-content", &ierror);
+	g_assert_nonnull(other_file);
+	g_assert_no_error(ierror);
+	g_assert_true(g_file_test(other_file, G_FILE_TEST_IS_REGULAR));
+
+	res = r_slot_status_save(slot, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_true(g_file_test(initial_file, G_FILE_TEST_IS_REGULAR));
+	g_assert_false(g_file_test(other_file, G_FILE_TEST_IS_REGULAR));
+
+	/* Simulate starting an installation */
+	g_assert_nonnull(slot->status);
+	r_replace_strdup(&slot->status->status, "pending");
+	g_clear_pointer(&slot->status->checksum.digest, g_free);
+	slot->status->checksum.size = 0;
+
+	res = r_slot_move_checksum_data_directory(slot, DIGEST_INITIAL, NULL, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+
+	g_autofree gchar *unknown_checksum_dir = r_slot_get_checksum_data_directory(slot, NULL, &ierror);
+	g_assert_nonnull(unknown_checksum_dir);
+	g_assert_no_error(ierror);
+
+	g_autofree gchar *unknown_file = g_build_filename(unknown_checksum_dir, "testfile", NULL);
+	GStatBuf unknown_stat = {0};
+	g_assert_cmpint(g_lstat(unknown_file, &unknown_stat), ==, 0);
+	g_assert_cmpuint(initial_stat.st_ino, ==, unknown_stat.st_ino);
+
+	/* Test that the checksum data directory for the initial digest was actually moved to the "hash-unknown" folder */
+	g_assert_false(g_file_test(initial_file, G_FILE_TEST_IS_REGULAR));
+	g_assert_false(g_file_test(other_file, G_FILE_TEST_IS_REGULAR));
+	g_assert_true(g_file_test(unknown_file, G_FILE_TEST_IS_REGULAR));
+
+	/* Test that triggering the data dir cleanup for an empty digest preserves the "hash-unknown" folder */
+	res = r_slot_status_save(slot, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_false(g_file_test(initial_file, G_FILE_TEST_IS_REGULAR));
+	g_assert_false(g_file_test(other_file, G_FILE_TEST_IS_REGULAR));
+	g_assert_true(g_file_test(unknown_file, G_FILE_TEST_IS_REGULAR));
+
+	/* Simulate completing an installation */
+	g_assert_nonnull(slot->status);
+	r_replace_strdup(&slot->status->status, "ok");
+	r_replace_strdup(&slot->status->checksum.digest, DIGEST_UPDATED);
+	slot->status->checksum.size = 1024;
+
+	g_autofree gchar *updated_checksum_dir = r_slot_get_checksum_data_directory(slot, NULL, &ierror);
+	g_assert_nonnull(updated_checksum_dir);
+	g_assert_no_error(ierror);
+	g_assert_true(g_str_has_suffix(updated_checksum_dir, DIGEST_UPDATED));
+
+	g_autofree gchar *updated_file = write_tmp_file(updated_checksum_dir, "testfile", "updated-content", &ierror);
+	g_assert_nonnull(updated_file);
+	g_assert_no_error(ierror);
+	g_assert_true(g_file_test(updated_file, G_FILE_TEST_IS_REGULAR));
+
+	/* Test that triggering the data dir cleanup for the 'updated' digest preserves the updated digest's folder. */
+	res = r_slot_status_save(slot, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_false(g_file_test(initial_file, G_FILE_TEST_IS_REGULAR));
+	g_assert_false(g_file_test(other_file, G_FILE_TEST_IS_REGULAR));
+	g_assert_false(g_file_test(unknown_file, G_FILE_TEST_IS_REGULAR));
+	g_assert_true(g_file_test(updated_file, G_FILE_TEST_IS_REGULAR));
+
+	/* Clear status */
+	r_slot_free_status(slot->status);
+	slot->status = NULL;
+
+	/* Test that a freed slot status does not preserve the 'updated' digest's folder. */
+	res = r_slot_status_save(slot, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_false(g_file_test(initial_file, G_FILE_TEST_IS_REGULAR));
+	g_assert_false(g_file_test(other_file, G_FILE_TEST_IS_REGULAR));
+	g_assert_false(g_file_test(unknown_file, G_FILE_TEST_IS_REGULAR));
+	g_assert_false(g_file_test(updated_file, G_FILE_TEST_IS_REGULAR));
+}
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -397,6 +537,11 @@ int main(int argc, char *argv[])
 	g_test_add("/status-file/combined/save-slot-status-existing-system-status", StatusFileFixture, NULL,
 			status_file_fixture_set_up_global,
 			status_file_test_save_slot_status_existing_system_status,
+			status_file_fixture_tear_down);
+
+	g_test_add("/datadir/installation", StatusFileFixture, NULL,
+			status_file_fixture_set_up_datadir,
+			status_file_test_datadir,
 			status_file_fixture_tear_down);
 
 	return g_test_run();


### PR DESCRIPTION
This fixes use of the block-hash-index, which wouldn't be found under
the old hash value during installation.

Fixes: #1158
Fixes: #1455