### PR TITLE
improve log messages related to block hash indices

### DIFF
--- a/src/hash_index.c
+++ b/src/hash_index.c
@@ -77,7 +77,7 @@ static GBytes *hash_file(int data_fd, guint32 count, GError **error)
 				g_set_error(error,
 						R_HASH_INDEX_ERROR,
 						R_HASH_INDEX_ERROR_SIZE,
-						"data file ended unexpectedly");
+						"image/partition ended unexpectedly");
 			}
 			return NULL;
 		}
@@ -533,7 +533,7 @@ gboolean r_hash_index_get_chunk(const RaucHashIndex *idx, const guint8 *hash, Ra
 			g_set_error(error,
 					R_HASH_INDEX_ERROR,
 					R_HASH_INDEX_ERROR_SIZE,
-					"data file ended unexpectedly");
+					"image/partition ended unexpectedly");
 		}
 		ret = FALSE;
 		goto out;

--- a/src/hash_index.c
+++ b/src/hash_index.c
@@ -272,7 +272,7 @@ RaucHashIndex *r_hash_index_open(const gchar *label, int data_fd, const gchar *h
 	}
 
 	if (!idx->hashes) {
-		g_info("building new hash index for %s with %"G_GUINT32_FORMAT " chunks", label, idx->count);
+		g_message("Building new hash index for %s with %"G_GUINT32_FORMAT " chunks", label, idx->count);
 		idx->hashes = hash_file(data_fd, idx->count, &ierror);
 		if (!idx->hashes) {
 			g_propagate_error(error, ierror);

--- a/src/hash_index.c
+++ b/src/hash_index.c
@@ -190,20 +190,20 @@ static guint32 get_chunk_count(int data_fd, GError **error)
 		g_set_error(error,
 				R_HASH_INDEX_ERROR,
 				R_HASH_INDEX_ERROR_SIZE,
-				"data file is empty");
+				"image/partition is empty");
 		return 0;
 	} else if ((size / 4096) > (off_t)G_MAXUINT32) {
 		g_set_error(error,
 				R_HASH_INDEX_ERROR,
 				R_HASH_INDEX_ERROR_SIZE,
-				"data file size (%"G_GINT64_FORMAT ") is too large",
+				"image/partition size (%"G_GINT64_FORMAT ") is too large",
 				(gint64)size);
 		return 0;
 	} else if (size % 4096) {
 		g_set_error(error,
 				R_HASH_INDEX_ERROR,
 				R_HASH_INDEX_ERROR_SIZE,
-				"data file size (%"G_GINT64_FORMAT ") is not a multiple of 4096 bytes",
+				"image/partition size (%"G_GINT64_FORMAT ") is not a multiple of 4096 bytes",
 				(gint64)size);
 		return 0;
 	}

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -130,8 +130,8 @@ static void update_handler_fixture_set_up(UpdateHandlerFixture *fixture,
 				"Image detected as type: *");
 		g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_INFO,
 				"Selected adaptive update method *");
-		g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_INFO,
-				"building*");
+		g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
+				"Building new hash index for *");
 		g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
 				"Continuing after adaptive mode error: Slot * is too small for image *");
 	}


### PR DESCRIPTION
As building a hash index can take multiple minutes, we should tell the
user by default. Usually, this should only happen for the initial
installations, as the index is stored after writing the image.

Also reword the chunk count check, which can trigger for partitions as
well as for images, to use 'image/partition' instead of 'data file'.