### PR TITLE
minor docs cleanup

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -796,6 +796,8 @@ your ``system.conf``.
 
 Currently, the only supported adaptive method is ``block-hash-index``.
 
+.. _sec-adaptive-block-hash-index:
+
 Block-based Adaptive Update (``block-hash-index``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -128,8 +128,10 @@ target device / partition on your board.
 In order to allow RAUC to handle your device correctly, we need to give it the
 right view on your system.
 
+.. _sec-basic-slots:
+
 Slots
-~~~~~
+-----
 
 In RAUC, everything that can be updated is a *slot*.
 Thus a slot can either be a full device, a partition, a volume or simply a file.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,6 @@ Contents:
 
 .. toctree::
    :glob:
-   :numbered:
    :maxdepth: 1
 
    updating

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -794,7 +794,11 @@ The following fields are supported for image sections:
 
   Currently implemented adaptive methods:
 
-  * ``block-hash-index``
+  ``block-hash-index``
+    Build an index which stores the SHA256 hash for each 4kiB block of the input
+    image, allowing reuse of unchanged blocks.
+
+    For information on this method, see :ref:`sec-adaptive-block-hash-index`.
 
 .. _meta.label-section:
 


### PR DESCRIPTION
Disable TOC numbering and improve description of `adaptive=block-hash-index`.

The numbering makes the index harder to read and distracts from the
section titles, which are more relevant.

![Screenshot from 2024-08-07 17-54-13](https://github.com/user-attachments/assets/9bc86aee-b5b1-4c6b-b92b-dfb38623b314) ![Screenshot from 2024-08-07 17-54-25](https://github.com/user-attachments/assets/9b557588-4819-49de-bc17-51f6bc6c2ae4)