### PR TITLE
meson.build: derive dbuspolicydir from libdbus datadir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -227,9 +227,11 @@ if dbussystemservicedir == ''
   endif
 endif
 
+dbusdatadir = dbusdep.get_variable(pkgconfig: 'datadir', default_value: datadir) / 'dbus-1'
+
 dbuspolicydir = get_option('dbuspolicydir')
 if dbuspolicydir == ''
-  dbuspolicydir = datadir / 'dbus-1' / 'system.d'
+  dbuspolicydir = dbusdatadir / 'system.d'
 endif
 
 dbusinterfacesdir = get_option('dbusinterfacesdir')


### PR DESCRIPTION
All other dbus directory locations are derived from libdbus pkg-config variables.
The dbuspolicydir instead only used the 'datadir' which has a fixed default and might thus not be valid on some distributions.

If the value cannot be obtained from pkg-config, the fallback remains the same as before.

Fixes #1479

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
