### PR TITLE
test: prepare system files with config for no_service tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -280,6 +280,14 @@ def create_system_files(env_setup, tmp_path):
     os.symlink(os.path.abspath("openssl-enc"), tmp_path / "openssl-enc")
 
 
+@pytest.fixture
+def rauc_no_service(create_system_files, tmp_path):
+    tmp_conf_file = tmp_path / "system.conf"
+    shutil.copy("test.conf", tmp_conf_file)
+
+    return f"rauc -c {tmp_conf_file}"
+
+
 def _rauc_dbus_service(tmp_path, conf_file, bootslot):
     tmp_conf_file = tmp_path / "system.conf"
     shutil.copy(conf_file, tmp_conf_file)

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -4,56 +4,56 @@ from helper import run
 
 @no_service
 @have_grub
-def test_status_mark_good_internally():
-    out, err, exitcode = run("rauc -c test.conf" " --override-boot-slot=system0" " status mark-good")
+def test_status_mark_good_internally(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status mark-good")
 
     assert exitcode == 0
 
 
 @no_service
 @have_grub
-def test_status_mark_bad_internally():
-    out, err, exitcode = run("rauc -c test.conf" " --override-boot-slot=system0" " status mark-bad")
+def test_status_mark_bad_internally(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status mark-bad")
 
     assert exitcode == 0
 
 
 @no_service
 @have_grub
-def test_status_mark_active_internally():
-    out, err, exitcode = run("rauc -c test.conf" " --override-boot-slot=system0" " status mark-active")
+def test_status_mark_active_internally(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status mark-active")
 
     assert exitcode == 0
 
 
 @no_service
 @have_grub
-def test_status_mark_good_booted():
-    out, err, exitcode = run("rauc -c test.conf" " --override-boot-slot=system0" " status mark-good booted")
+def test_status_mark_good_booted(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status mark-good booted")
 
     assert exitcode == 0
 
 
 @no_service
 @have_grub
-def test_status_mark_good_other():
-    out, err, exitcode = run("rauc -c test.conf" " --override-boot-slot=system0" " status mark-good other")
+def test_status_mark_good_other(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status mark-good other")
 
     assert exitcode == 0
 
 
 @no_service
 @have_grub
-def test_status_mark_good_any_bootslot():
-    out, err, exitcode = run("rauc -c test.conf" " --override-boot-slot=system0" " status mark-good rescue.0")
+def test_status_mark_good_any_bootslot(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status mark-good rescue.0")
 
     assert exitcode == 0
 
 
 @no_service
 @have_grub
-def test_status_mark_good_non_bootslot():
-    out, err, exitcode = run("rauc -c test.conf" " --override-boot-slot=system0" " status mark-good bootloader.0")
+def test_status_mark_good_non_bootslot(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status mark-good bootloader.0")
 
     assert exitcode == 1
 

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -5,24 +5,24 @@ from helper import run
 
 
 @no_service
-def test_status_no_service():
-    out, err, exitcode = run("rauc -c test.conf --override-boot-slot=system0 status")
+def test_status_no_service(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status")
 
     assert exitcode == 0
     assert "=== System Info ===" in out
 
 
 @no_service
-def test_status_no_service_output_readable():
-    out, err, exitcode = run("rauc -c test.conf --override-boot-slot=system0 status " "--output-format=readable")
+def test_status_no_service_output_readable(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status --output-format=readable")
 
     assert exitcode == 0
     assert "=== System Info ===" in out
 
 
 @no_service
-def test_status_no_service_output_shell():
-    out, err, exitcode = run("rauc -c test.conf --override-boot-slot=system0 status " "--output-format=shell")
+def test_status_no_service_output_shell(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status --output-format=shell")
 
     assert exitcode == 0
     assert "RAUC_SYSTEM_COMPATIBLE='Test Config'" in out
@@ -30,8 +30,8 @@ def test_status_no_service_output_shell():
 
 @no_service
 @have_json
-def test_status_no_service_output_json():
-    out, err, exitcode = run("rauc -c test.conf --override-boot-slot=system0 status " "--output-format=json")
+def test_status_no_service_output_json(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status --output-format=json")
 
     assert exitcode == 0
     assert '"compatible":"Test Config"' in out
@@ -39,8 +39,8 @@ def test_status_no_service_output_json():
 
 @no_service
 @have_json
-def test_status_no_service_output_json_pretty():
-    out, err, exitcode = run("rauc -c test.conf --override-boot-slot=system0 status " "--output-format=json-pretty")
+def test_status_no_service_output_json_pretty(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status --output-format=json-pretty")
 
     assert exitcode == 0
     assert '"compatible" : "Test Config"' in out
@@ -48,8 +48,8 @@ def test_status_no_service_output_json_pretty():
 
 @no_service
 @have_json
-def test_status_no_service_output_nvalid():
-    out, err, exitcode = run("rauc -c test.conf --override-boot-slot=system0 status " "--output-format=invalid")
+def test_status_no_service_output_nvalid(rauc_no_service):
+    out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status --output-format=invalid")
 
     assert exitcode == 1
     assert "Unknown output format: 'invalid'" in err

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -48,7 +48,7 @@ def test_status_no_service_output_json_pretty(rauc_no_service):
 
 @no_service
 @have_json
-def test_status_no_service_output_nvalid(rauc_no_service):
+def test_status_no_service_output_invalid(rauc_no_service):
     out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=system0 status --output-format=invalid")
 
     assert exitcode == 1


### PR DESCRIPTION
To test with artifact repos, these files and directories will need to
exist. The simplest way is to reuse the system setup from the 'with
service' case, but without starting the daemon. Instead, provide a
command prefix to the test cases which sets the config path.