### PR TITLE
system_variant as g_array

### DIFF
--- a/include/config_file.h
+++ b/include/config_file.h
@@ -37,7 +37,7 @@ typedef struct {
 	gchar *system_compatible;
 	gchar *system_min_bundle_version;
 	RConfigSysVariant system_variant_type;
-	gchar *system_variant;
+	GArray *system_variant;
 	gchar *system_bootloader;
 	gchar *system_bb_statename;
 	gchar *system_bb_dtbpath;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -801,6 +801,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	g_key_file_remove_key(key_file, "system", "activate-installed", NULL);
 
 	c->system_variant_type = R_CONFIG_SYS_VARIANT_NONE;
+	c->system_variant = g_array_new(FALSE, FALSE, sizeof(gchar *));
 
 	/* parse 'variant-dtb' key */
 	dtbvariant = g_key_file_get_boolean(key_file, "system", "variant-dtb", &ierror);
@@ -835,7 +836,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		}
 
 		c->system_variant_type = R_CONFIG_SYS_VARIANT_FILE;
-		c->system_variant = g_steal_pointer(&variant_data);
+		g_array_append_val(c->system_variant, variant_data);
 	}
 
 	/* parse 'variant-name' key */
@@ -858,7 +859,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		}
 
 		c->system_variant_type = R_CONFIG_SYS_VARIANT_NAME;
-		c->system_variant = g_steal_pointer(&variant_data);
+		g_array_append_val(c->system_variant, variant_data);
 	}
 
 	/* parse data/status location
@@ -1138,7 +1139,8 @@ void free_config(RaucConfig *config)
 
 	g_free(config->system_compatible);
 	g_free(config->system_min_bundle_version);
-	g_free(config->system_variant);
+	if (config->system_variant)
+		g_array_free(config->system_variant, TRUE);
 	g_free(config->system_bootloader);
 	g_free(config->system_bb_statename);
 	g_free(config->system_bb_dtbpath);

--- a/src/install.c
+++ b/src/install.c
@@ -441,7 +441,8 @@ GPtrArray* r_install_make_plans(const RaucManifest *manifest, GHashTable *target
 			if (lookup_image->variant == NULL) {
 				if (!matching_img)
 					matching_img = lookup_image;
-			} else if (g_strcmp0(lookup_image->variant, r_context()->config->system_variant) == 0) {
+			} else if (g_strcmp0(lookup_image->variant,
+					g_array_index(r_context()->config->system_variant, gchar *, 0)) == 0) {
 				g_debug("Using variant '%s' image '%s' for '%s'", lookup_image->variant, lookup_image->filename, lookup_image->slotclass);
 				matching_img = lookup_image;
 				break;
@@ -817,7 +818,9 @@ static gboolean run_bundle_hook(RaucManifest *manifest, gchar* bundledir, const 
 	launcher = g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_STDERR_PIPE);
 
 	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_COMPATIBLE", r_context()->config->system_compatible, TRUE);
-	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_VARIANT", r_context()->config->system_variant ?: "", TRUE);
+	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_VARIANT",
+			g_array_index(r_context()->config->system_variant, gchar *, 0) ?: "",
+			TRUE);
 
 	g_subprocess_launcher_setenv(launcher, "RAUC_MF_COMPATIBLE", manifest->update_compatible, TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_MF_VERSION", manifest->update_version ?: "", TRUE);
@@ -1336,7 +1339,7 @@ static gchar **assemble_info_headers(RaucInstallArgs *args)
 		if (g_strcmp0(*header, "serial") == 0)
 			g_ptr_array_add(headers, g_strdup_printf("RAUC-Serial: %s", r_context()->system_serial));
 		if (g_strcmp0(*header, "variant") == 0)
-			g_ptr_array_add(headers, g_strdup_printf("RAUC-Variant: %s", r_context()->config->system_variant));
+			g_ptr_array_add(headers, g_strdup_printf("RAUC-Variant: %s", g_array_index(r_context()->config->system_variant, gchar *, 0)));
 		/* Add per-installation information */
 		if (g_strcmp0(*header, "transaction-id") == 0)
 			g_ptr_array_add(headers, g_strdup_printf("RAUC-Transaction-ID: %s", args->transaction));

--- a/src/install.c
+++ b/src/install.c
@@ -441,11 +441,20 @@ GPtrArray* r_install_make_plans(const RaucManifest *manifest, GHashTable *target
 			if (lookup_image->variant == NULL) {
 				if (!matching_img)
 					matching_img = lookup_image;
-			} else if (g_strcmp0(lookup_image->variant,
-					g_array_index(r_context()->config->system_variant, gchar *, 0)) == 0) {
-				g_debug("Using variant '%s' image '%s' for '%s'", lookup_image->variant, lookup_image->filename, lookup_image->slotclass);
-				matching_img = lookup_image;
-				break;
+			} else {
+				for (guint index = 0; index < r_context()->config->system_variant->len; index++) {
+					gchar *compatible = g_array_index(r_context()->config->system_variant, gchar *, index);
+					if (g_strcmp0(lookup_image->variant, compatible) == 0) {
+						g_debug("Using variant '%s' of image '%s' on slot '%s'",
+								lookup_image->variant,
+								lookup_image->filename,
+								lookup_image->slotclass);
+						matching_img = lookup_image;
+						break;
+					}
+				}
+				if (matching_img)
+					break;
 			}
 		}
 

--- a/src/main.c
+++ b/src/main.c
@@ -1924,7 +1924,7 @@ static gboolean status_start(int argc, char **argv)
 		}
 
 		status_print->compatible = g_strdup(r_context()->config->system_compatible);
-		status_print->variant = g_strdup(r_context()->config->system_variant);
+		status_print->variant = g_array_index(r_context()->config->system_variant, gchar *, 0);
 		status_print->bootslot = g_strdup(r_context()->bootslot);
 		status_print->slots = g_hash_table_ref(r_context()->config->slots);
 	} else {

--- a/src/service.c
+++ b/src/service.c
@@ -563,7 +563,7 @@ static void r_on_bus_acquired(GDBusConnection *connection,
 	}
 
 	r_installer_set_compatible(r_installer, r_context()->config->system_compatible);
-	r_installer_set_variant(r_installer, r_context()->config->system_variant);
+	r_installer_set_variant(r_installer, g_array_index(r_context()->config->system_variant, gchar *, 0));
 	r_installer_set_boot_slot(r_installer, r_context()->bootslot);
 
 	return;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1322,7 +1322,7 @@ static gboolean run_slot_hook_extra_env(const gchar *hook_name, const gchar *hoo
 	launcher = g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_NONE);
 
 	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_COMPATIBLE", r_context()->config->system_compatible ?: "", TRUE);
-	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_VARIANT", r_context()->config->system_variant ?: "", TRUE);
+	g_subprocess_launcher_setenv(launcher, "RAUC_SYSTEM_VARIANT", g_array_index(r_context()->config->system_variant, gchar *, 0) ?: "", TRUE);
 
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_NAME", slot->name, TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_SLOT_STATE", r_slot_slotstate_to_str(slot->state), TRUE);


### PR DESCRIPTION
Convert the `system_variant` kept in the context from a single element to an array; so that a bundle can specify a 'broader' compatibility than just the most exact one.

This PR targets the `variant-dtb=true` feature, where rauc now reads in the full list of compatibles (and not just the very first one...) stored in `/sys/firmware/devicetree/base/compatible` [1] and compares the variant set on a slot in the bundle against *each* of the elements in the devices compatibility hierarchy.

A usage scenario/example: 
On a system with secure-boot, where the bootloader has to be signed against one key/cert out of a set of keys/certs, which can be (individually) revoked.
The running bootloader "would know" which keys/certs are still "open" and append them as of-fixup to the devicetree/compatible.
Bundles would have a variant set on *every* slot (e.g. not leaving an unset/default), where the bootloader.variant could reflect the signature as a compatible; which would then ensure that the bundle installation fails if there are no compatible elements in the bundle - ensuring that the device could not get bricked.
```
# example bundle:
[update]
compatible=ACME Coorp
version=4.3.2
description=acme corp embedded device update bundle
build=20240823202207
...
[image.bootloader.acme,dev001-K2]
sha256=f734326e25a2e1f1b516d7013dd1aabe145441fc61ee5e508e6e83f1542b2a8c
size=1597980
filename=barebox-acme-dev001-s.img

# the bootloader would know which keys/certs are revoked, and fixup the compatible accordingly:
$> cat /sys/firmware/devicetree/base/compatible
acme,dev001-revP\0acme,dev001-K1\0acme,dev001-K3\0acme,dev001\0fsl,imx8mm\0

# so in this scenario, the bundle would just refuse to install
# -> not bricking the device
$> rauc install /tmp/acme-bootloader-bundle-dev001-20240823202207.raucb 
installing                                                                                                       
  0% Installing                                                                                                  
  0% Determining slot states                                                                                     
 10% Determining slot states done.                                                                               
 10% Checking bundle                                                                                             
 10% Verifying signature
 20% Verifying signature done.                                                                                   
 20% Checking bundle done.                                                                                       
 20% Checking manifest contents                                                                                  
 30% Checking manifest contents done.
 30% Determining target install group
 40% Determining target install group done.
100% Installing failed.
LastError: Installation error: Failed to find matching variant of image for bootloader
Installing `/tmp/acme-bootloader-bundle-dev001-20240823202207.raucb` failed
```


Note that this implementation is currently only focused on the concept/feature, and would need to be covered by more tests...
But first -> RFC :-)

Also: this "one-dimensionality" could be carried over to the other two: `variant-file` and `variant-name` features - which would make them more useful/powerful

[1] https://www.kernel.org/doc/html/latest/devicetree/usage-model.html#platform-identification