### PR TITLE
improve rauc info/status/help output by avoiding tabs

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1871,6 +1871,7 @@ static gboolean print_status(RaucStatusPrint *status_print)
 		return FALSE;
 	}
 
+	g_strchomp(text);
 	g_print("%s\n", text);
 
 	return TRUE;

--- a/src/main.c
+++ b/src/main.c
@@ -1348,13 +1348,13 @@ static void r_string_append_slot(GString *text, RaucSlot *slot, RaucStatusPrint 
 			slot->state == ST_BOOTED ? KBLD : "",
 			r_slot_slotstate_to_str(slot->state));
 	if (slot->bootname)
-		g_string_append_printf(text, "\n\tbootname: "KBLU "%s"KNRM, slot->bootname);
+		g_string_append_printf(text, "\n      bootname: "KBLU "%s"KNRM, slot->bootname);
 	if (slot->description)
-		g_string_append_printf(text, "\n\tdescription: %s", slot->description);
+		g_string_append_printf(text, "\n      description: %s", slot->description);
 	if (slot->mount_point)
-		g_string_append_printf(text, "\n\tmounted: %s", slot->mount_point);
+		g_string_append_printf(text, "\n      mounted: %s", slot->mount_point);
 	if (slot->bootname)
-		g_string_append_printf(text, "\n\tboot status: %s", slot->boot_good ? KGRN "good"KNRM : KRED "bad"KNRM);
+		g_string_append_printf(text, "\n      boot status: %s", slot->boot_good ? KGRN "good"KNRM : KRED "bad"KNRM);
 	if (status_detailed && slot_state) {
 		g_string_append_printf(text, "\n      slot status:");
 		g_string_append_printf(text, "\n          bundle:");

--- a/src/main.c
+++ b/src/main.c
@@ -966,10 +966,10 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 	gboolean show_crypt_key = FALSE; /* change to TRUE to display dm-crypt key */
 	gint cnt;
 
-	g_string_append_printf(text, "Compatible: \t'%s'\n", manifest->update_compatible);
-	g_string_append_printf(text, "Version:    \t'%s'\n", manifest->update_version);
-	g_string_append_printf(text, "Description:\t'%s'\n", manifest->update_description);
-	g_string_append_printf(text, "Build:      \t'%s'\n", manifest->update_build);
+	g_string_append_printf(text, "Compatible:     '%s'\n", manifest->update_compatible);
+	g_string_append_printf(text, "Version:        '%s'\n", manifest->update_version);
+	g_string_append_printf(text, "Description:    '%s'\n", manifest->update_description);
+	g_string_append_printf(text, "Build:          '%s'\n", manifest->update_build);
 
 	hooks = g_ptr_array_new();
 	if (manifest->hooks.install_check == TRUE) {
@@ -978,10 +978,10 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 	g_ptr_array_add(hooks, NULL);
 
 	temp_string = g_strjoinv(" ", (gchar**) hooks->pdata);
-	g_string_append_printf(text, "Hooks:      \t'%s'\n", temp_string);
+	g_string_append_printf(text, "Hooks:          '%s'\n", temp_string);
 	g_free(temp_string);
 
-	g_string_append_printf(text, "Bundle Format: \t%s", r_manifest_bundle_format_to_str(manifest->bundle_format));
+	g_string_append_printf(text, "Bundle Format:  %s", r_manifest_bundle_format_to_str(manifest->bundle_format));
 	if (manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT) {
 		if (manifest->was_encrypted)
 			g_string_append_printf(text, KBLD KGRN " [encrypted CMS]"KNRM);
@@ -991,14 +991,14 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 	g_string_append_printf(text, "\n");
 
 	if (manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT) {
-		g_string_append_printf(text, "  Crypt Key: \t'%s'\n", show_crypt_key ? manifest->bundle_crypt_key : "<hidden>");
+		g_string_append_printf(text, "  Crypt Key:    '%s'\n", show_crypt_key ? manifest->bundle_crypt_key : "<hidden>");
 	}
 	if (manifest->bundle_format == R_MANIFEST_FORMAT_VERITY || manifest->bundle_format == R_MANIFEST_FORMAT_CRYPT) {
-		g_string_append_printf(text, "  Verity Salt: \t'%s'\n", manifest->bundle_verity_salt);
-		g_string_append_printf(text, "  Verity Hash: \t'%s'\n", manifest->bundle_verity_hash);
-		g_string_append_printf(text, "  Verity Size: \t%"G_GUINT64_FORMAT "\n", manifest->bundle_verity_size);
+		g_string_append_printf(text, "  Verity Salt:  '%s'\n", manifest->bundle_verity_salt);
+		g_string_append_printf(text, "  Verity Hash:  '%s'\n", manifest->bundle_verity_hash);
+		g_string_append_printf(text, "  Verity Size:  %"G_GUINT64_FORMAT "\n", manifest->bundle_verity_size);
 	}
-	g_string_append_printf(text, "Manifest Hash:\t'%s'\n\n", manifest->hash);
+	g_string_append_printf(text, "Manifest Hash:  '%s'\n\n", manifest->hash);
 
 	g_ptr_array_unref(hooks);
 
@@ -1014,11 +1014,11 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 			GHashTableIter kvs_iter;
 			const gchar *key, *value;
 
-			g_string_append_printf(text, "\t%s:\n", group);
+			g_string_append_printf(text, "  %s:\n", group);
 
 			g_hash_table_iter_init(&kvs_iter, kvs);
 			while (g_hash_table_iter_next(&kvs_iter, (gpointer*)&key, (gpointer*)&value)) {
-				g_string_append_printf(text, "\t\t%s: %s\n", key, value);
+				g_string_append_printf(text, "    %s: %s\n", key, value);
 			}
 		}
 	}
@@ -1030,14 +1030,14 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 		RaucImage *img = l->data;
 		g_string_append_printf(text, "  "KBLD "[%s]"KNRM "\n", img->slotclass);
 		if (img->variant)
-			g_string_append_printf(text, "\tVariant:   %s\n", img->variant);
+			g_string_append_printf(text, "    Variant:   %s\n", img->variant);
 		if (img->filename) {
 			g_autofree gchar* formatted_size = g_format_size_full(img->checksum.size, G_FORMAT_SIZE_LONG_FORMAT);
-			g_string_append_printf(text, "\tFilename:  %s\n", img->filename);
-			g_string_append_printf(text, "\tChecksum:  %s\n", img->checksum.digest);
-			g_string_append_printf(text, "\tSize:      %s\n", formatted_size);
+			g_string_append_printf(text, "    Filename:  %s\n", img->filename);
+			g_string_append_printf(text, "    Checksum:  %s\n", img->checksum.digest);
+			g_string_append_printf(text, "    Size:      %s\n", formatted_size);
 		} else {
-			g_string_append_printf(text, "\t(no image file)\n");
+			g_string_append_printf(text, "    (no image file)\n");
 		}
 
 		hooks = g_ptr_array_new();
@@ -1053,14 +1053,14 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 		g_ptr_array_add(hooks, NULL);
 
 		temp_string = g_strjoinv(" ", (gchar**) hooks->pdata);
-		g_string_append_printf(text, "\tHooks:     %s\n", temp_string);
+		g_string_append_printf(text, "    Hooks:     %s\n", temp_string);
 		g_free(temp_string);
 
 		g_ptr_array_unref(hooks);
 
 		if (img->adaptive) {
 			temp_string = g_strjoinv(" ", (gchar**) img->adaptive);
-			g_string_append_printf(text, "\tAdaptive:  %s\n", temp_string);
+			g_string_append_printf(text, "    Adaptive:  %s\n", temp_string);
 			g_free(temp_string);
 		}
 

--- a/src/main.c
+++ b/src/main.c
@@ -2432,9 +2432,9 @@ static void cmdline_handler(int argc, char **argv)
 		{STATUS, "status", "status",
 		 "Show system status\n\n"
 		 "List of status commands (default slot is the currently booted slot):\n"
-		 "  mark-good [booted | other | <SLOT_NAME>] \tMark the slot as good\n"
-		 "  mark-bad [booted | other | <SLOT_NAME>] \tMark the slot as bad\n"
-		 "  mark-active [booted | other | <SLOT_NAME>] \tMark the slot as active",
+		 "  mark-good [booted | other | <SLOT_NAME>]    Mark the slot as good\n"
+		 "  mark-bad [booted | other | <SLOT_NAME>]     Mark the slot as bad\n"
+		 "  mark-active [booted | other | <SLOT_NAME>]  Mark the slot as active",
 		 status_start, status_group, R_CONTEXT_CONFIG_MODE_REQUIRED, TRUE},
 		{WRITE_SLOT, "write-slot", "write-slot <SLOTNAME> <IMAGE>",
 		 "Write image to slot and bypass all update logic",
@@ -2462,29 +2462,29 @@ static void cmdline_handler(int argc, char **argv)
 			"\n"
 			"List of rauc bundle handling commands:\n"
 #if ENABLE_CREATE == 1
-			"  bundle\t\tCreate a bundle\n"
-			"  resign\t\tResign an already signed bundle\n"
-			"  convert\t\tConvert classic to casync bundle\n"
-			"  encrypt\t\tEncrypt a crypt bundle\n"
-			"  replace-signature\tReplaces the signature of an already signed bundle\n"
-			"  extract-signature\tExtract the bundle signature\n"
+			"  bundle                  Create a bundle\n"
+			"  resign                  Resign an already signed bundle\n"
+			"  convert                 Convert classic to casync bundle\n"
+			"  encrypt                 Encrypt a crypt bundle\n"
+			"  replace-signature       Replaces the signature of an already signed bundle\n"
+			"  extract-signature       Extract the bundle signature\n"
 #endif
-			"  extract\t\tExtract the bundle content\n"
-			"  info\t\t\tShow bundle information\n"
+			"  extract                 Extract the bundle content\n"
+			"  info                    Show bundle information\n"
 			"\n"
 			"List of rauc target commands:\n"
 #if ENABLE_SERVICE == 1
-			"  service\t\tStart RAUC service\n"
+			"  service                 Start RAUC service\n"
 #endif
-			"  install\t\tInstall a bundle\n"
-			"  status\t\tShow status\n"
-			"  mount\t\t\tMount a bundle\n"
-			"  write-slot\t\tWrite image to slot and bypass all update logic\n"
+			"  install                 Install a bundle\n"
+			"  status                  Show status\n"
+			"  mount                   Mount a bundle\n"
+			"  write-slot              Write image to slot and bypass all update logic\n"
 			"\n"
 			"Environment variables:\n"
-			"  RAUC_KEY_PASSPHRASE Passphrase to use for accessing key files (signing only)\n"
-			"  RAUC_PKCS11_MODULE  Library filename for PKCS#11 module (signing only)\n"
-			"  RAUC_PKCS11_PIN     PIN to use for accessing PKCS#11 keys (signing only)");
+			"  RAUC_KEY_PASSPHRASE     Passphrase to use for accessing key files (signing only)\n"
+			"  RAUC_PKCS11_MODULE      Library filename for PKCS#11 module (signing only)\n"
+			"  RAUC_PKCS11_PIN         PIN to use for accessing PKCS#11 keys (signing only)");
 
 	if (!g_option_context_parse(context, &argc, &argv, &error)) {
 		g_printerr("%s\n", error->message);

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -13,23 +13,23 @@ def test_info_plain(tmp_path):
     out, err, exitcode = run(f"rauc --keyring openssl-ca/dev-ca.pem info {tmp_path}/good-bundle.raucb")
 
     assert exitcode == 0
-    assert out.startswith("Compatible: 	'Test Config'")
-    assert "Bundle Format: 	plain" in out
+    assert out.startswith("Compatible:     'Test Config'")
+    assert "Bundle Format:  plain" in out
 
 
 def test_info_verity():
     out, err, exitcode = run("rauc --keyring openssl-ca/dev-ca.pem info good-verity-bundle.raucb")
 
     assert exitcode == 0
-    assert out.startswith("Compatible: 	'Test Config'")
-    assert "Bundle Format: 	verity" in out
+    assert out.startswith("Compatible:     'Test Config'")
+    assert "Bundle Format:  verity" in out
 
 
 def test_info_verity_adaptive_meta():
     out, err, exitcode = run("rauc --keyring openssl-ca/dev-ca.pem info good-adaptive-meta-bundle.raucb")
 
     assert exitcode == 0
-    assert out.startswith("Compatible: 	'Test Config'")
+    assert out.startswith("Compatible:     'Test Config'")
 
 
 @have_streaming
@@ -39,7 +39,7 @@ def test_info_streaming():
     )
 
     assert exitcode == 0
-    assert out.startswith("Compatible: 	'Test Config'")
+    assert out.startswith("Compatible:     'Test Config'")
 
 
 def test_info_casync_plain(tmp_path):
@@ -49,7 +49,7 @@ def test_info_casync_plain(tmp_path):
     out, err, exitcode = run(f"rauc --keyring openssl-ca/dev-ca.pem info {tmp_path}/good-casync-bundle-1.5.1.raucb")
 
     assert exitcode == 0
-    assert out.startswith("Compatible: 	'Test Config'")
+    assert out.startswith("Compatible:     'Test Config'")
     assert "rootfs.img.caibx" in out
     assert "appfs.img.caibx" in out
 
@@ -58,7 +58,7 @@ def test_info_casync_verity():
     out, err, exitcode = run("rauc --keyring openssl-ca/dev-ca.pem info good-casync-bundle-verity.raucb")
 
     assert exitcode == 0
-    assert out.startswith("Compatible: 	'Test Config'")
+    assert out.startswith("Compatible:     'Test Config'")
     assert "rootfs.img.caibx" in out
     assert "appfs.img.caibx" in out
 
@@ -67,8 +67,8 @@ def test_info_crypt_unencrypted():
     out, err, exitcode = run("rauc --keyring openssl-ca/dev-ca.pem info good-crypt-bundle-unencrypted.raucb")
 
     assert exitcode == 0
-    assert out.startswith("Compatible: 	'Test Config'")
-    assert "Bundle Format: 	crypt" in out
+    assert out.startswith("Compatible:     'Test Config'")
+    assert "Bundle Format:  crypt" in out
 
 
 def test_info_crypt_encrypted_valid_key():
@@ -79,8 +79,8 @@ def test_info_crypt_encrypted_valid_key():
     )
 
     assert exitcode == 0
-    assert out.startswith("Compatible: 	'Test Config'")
-    assert "Bundle Format: 	crypt" in out
+    assert out.startswith("Compatible:     'Test Config'")
+    assert "Bundle Format:  crypt" in out
 
 
 def test_info_crypt_encrypted_invalid_key():
@@ -113,8 +113,8 @@ def test_info_with_config(tmp_path):
     out, err, exitcode = run(f"rauc --conf=test.conf info {tmp_path}/good-bundle.raucb")
 
     assert exitcode == 0
-    assert out.startswith("Compatible: 	'Test Config'")
-    assert "Bundle Format: 	plain" in out
+    assert out.startswith("Compatible:     'Test Config'")
+    assert "Bundle Format:  plain" in out
 
 
 def test_info_verification_failure(tmp_path):
@@ -141,8 +141,8 @@ def test_info_valid_file_uri(tmp_path):
     out, err, exitcode = run(f"rauc info --keyring openssl-ca/dev-ca.pem file://{tmp_path}/good-bundle.raucb")
 
     assert exitcode == 0
-    assert out.startswith("Compatible: 	'Test Config'")
-    assert "Bundle Format: 	plain" in out
+    assert out.startswith("Compatible:     'Test Config'")
+    assert "Bundle Format:  plain" in out
 
 
 def test_info_invalid_file_uri():


### PR DESCRIPTION
Using "\t" in the strings makes them hard to align in the source code and
results in tab characters in the output, which tends to disrupt the
alignment when copying the output somewhere else. So, keep it simple by
aligning using spaces in the source as well.