### PR TITLE
expose manifest meta-data in install-check hook environment

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -808,9 +808,10 @@ The following fields are supported for image sections:
 The ``meta.<label>`` sections are intended to provide a forwards-compatible
 way to add metadata to the manifest which is not interpreted by RAUC in any
 way.
-They are accessible via ``rauc info`` and the :ref:`"InspectBundle" D-Bus API
-<gdbus-method-de-pengutronix-rauc-Installer.InspectBundle>`.
-In future releases, they will be accessible in hooks/handlers, as well.
+They are accessible via ``rauc info``, the :ref:`"InspectBundle" D-Bus API
+<gdbus-method-de-pengutronix-rauc-Installer.InspectBundle>`, pre-/post-install
+:ref:`handlers <sec-handler-interface>` and the ``install-check`` hook.
+In future releases, they will be accessible in other hooks, as well.
 
 ``<key>`` (optional)
   Keys (and values) can be defined freely in this section.
@@ -1224,6 +1225,10 @@ variables.
 
 ``RAUC_MOUNT_PREFIX``
   Provides the path prefix that may be used for RAUC mount points
+
+``RAUC_META_*``
+  Exposes the :ref:`meta-data sections <meta.label-section>` from the bundle's manifest.
+  This uses the same format as ``rauc info --output-format=shell …``.
 
 ``RAUC_SLOTS``
   An iterator list to loop over all existing slots. Each item in the list is

--- a/include/utils.h
+++ b/include/utils.h
@@ -131,6 +131,17 @@ gchar **r_environ_setenv_ptr_array(gchar **envp, const GPtrArray *ptrarray, gboo
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Calls g_subprocess_launcher_setenv for each 'key=value' string in the array.
+ *
+ * This is useful when setting up the environment via a subprocess launcher.
+ *
+ * @param launcher a GSubprocessLauncher
+ * @param ptrarray the GPtrArray to add to the environment
+ * @param overwrite whether to change existing variables
+ */
+void r_subprocess_launcher_setenv_ptr_array(GSubprocessLauncher *launcher, const GPtrArray *ptrarray, gboolean overwrite);
+
+/**
  * Read file content into a GBytes.
  *
  * @param filename Filename to read from

--- a/src/install.c
+++ b/src/install.c
@@ -829,6 +829,10 @@ static gboolean run_bundle_hook(RaucManifest *manifest, gchar* bundledir, const 
 	g_subprocess_launcher_setenv(launcher, "RAUC_MF_BUILD", manifest->update_build ?: "", TRUE);
 	g_subprocess_launcher_setenv(launcher, "RAUC_MOUNT_PREFIX", r_context()->config->mount_prefix, TRUE);
 
+	g_autoptr(GPtrArray) shell_vars = g_ptr_array_new_with_free_func(g_free);
+	r_shell_from_manifest_meta(shell_vars, manifest);
+	r_subprocess_launcher_setenv_ptr_array(launcher, shell_vars, TRUE);
+
 	sproc = g_subprocess_launcher_spawn(
 			launcher, &ierror,
 			hook_name,

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1300,6 +1300,7 @@ static gboolean unpack_archive(RaucImage *image, gchar *dest, GError **error)
  * @param hook_cmd first argument to the hook script
  * @param image image to be installed (optional)
  * @param slot target slot
+ * @param variables extra environment variables, or NULL
  * @param error return location for a GError, or NULL
  *
  * @return TRUE on success, FALSE if an error occurred

--- a/src/utils.c
+++ b/src/utils.c
@@ -138,6 +138,27 @@ gchar **r_environ_setenv_ptr_array(gchar **envp, const GPtrArray *ptrarray, gboo
 	return envp;
 }
 
+void r_subprocess_launcher_setenv_ptr_array(GSubprocessLauncher *launcher, const GPtrArray *ptrarray, gboolean overwrite)
+{
+	g_return_if_fail(launcher != NULL);
+	g_return_if_fail(ptrarray != NULL);
+
+	for (guint i = 0; i < ptrarray->len; i++) {
+		const gchar *element = g_ptr_array_index(ptrarray, i);
+		gchar *eq = strchr(element, '=');
+		g_autofree gchar *k = NULL;
+
+		if (!eq) {
+			g_error("missing '=' in '%s'", element);
+			return;
+		}
+
+		k = g_strndup(element, eq-element);
+
+		g_subprocess_launcher_setenv(launcher, k, eq+1, overwrite);
+	}
+}
+
 GBytes *read_file(const gchar *filename, GError **error)
 {
 	gchar *contents;

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -254,6 +254,9 @@ def test_install_hook_env(rauc_dbus_service_with_system, tmp_path, bundle):
         "hooks": "install",
     }
     bundle.make_random_image("appfs", 4096, "random appfs")
+    bundle.manifest["meta.test"] = {
+        "foo": "bar",
+    }
     bundle.build()
 
     out, err, exitcode = run(f"rauc install {bundle.output}")
@@ -266,6 +269,7 @@ def test_install_hook_env(rauc_dbus_service_with_system, tmp_path, bundle):
         assert "RAUC_MF_VERSION=2011.03-2\n" in check_lines
         assert "RAUC_SYSTEM_COMPATIBLE=Test Config\n" in check_lines
         assert "RAUC_SYSTEM_VARIANT=Default Variant\n" in check_lines
+        assert "RAUC_META_TEST_FOO=bar\n" in check_lines
 
     with open(tmp_path / "slot-pre-install-hook-env") as f:
         pre_lines = f.readlines()


### PR DESCRIPTION
This uses the same variable names (and implementation) as `rauc info`.

Only the install-check hook is updated for now, as the slot hooks
currently don't have access to the manifest. We'd need to pass the
manifest or prepared variables down through all the update handles, but
that's a larger change.

Also add a helper class to build custom bundles in pytest test cases, based
on code from my artifact tests.