### PR TITLE
check if encryption recipient cert file containes at least one certificate

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -316,7 +316,8 @@ static STACK_OF(X509) *load_certs_from_file(const gchar *certfile, GError **erro
 		if (cert_x509 == NULL) {
 			err = ERR_peek_last_error();
 
-			if (ERR_GET_REASON(err) == PEM_R_NO_START_LINE) {
+			if (ERR_GET_REASON(err) == PEM_R_NO_START_LINE &&
+			    sk_X509_num(certs) != 0) {
 				/* simply reached end of file */
 				ERR_clear_error();
 				break;

--- a/test/test_encrypt.py
+++ b/test/test_encrypt.py
@@ -61,6 +61,20 @@ def test_encrypt_broken_multi_cert_pem(tmp_path):
     assert not os.path.exists(f"{tmp_path}/encrypted.raucb")
 
 
+def test_encrypt_missing_cert_in_file(tmp_path):
+    out, err, exitcode = run(
+        "rauc encrypt "
+        "--to openssl-enc/keys/rsa-4096/private-key-001.pem "
+        "--keyring openssl-ca/dev-ca.pem "
+        f"good-crypt-bundle-unencrypted.raucb {tmp_path}/encrypted.raucb"
+    )
+
+    assert exitcode == 1
+    assert "Expecting: CERTIFICATE" in err
+
+    assert not os.path.exists(f"{tmp_path}/encrypted.raucb")
+
+
 def test_encrypt_verity_bundle(tmp_path):
     out, err, exitcode = run(
         "rauc encrypt "


### PR DESCRIPTION
When rauc is used to encrypt a bundle, and a certificate file is provided which does not contain any certificate, then the encryption process was not stopped. Check the number of certificates when reaching end of certificate file. If this is zero, display an error and abort.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
