### PR TITLE
add test case for PKCS#11 decryption

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -175,8 +175,30 @@ def softhsm2_load_key_pair(cert, privkey, label, id_, softhsm2_mod):
     assert proc.returncode == 0
 
 
+def softhsm2_test_signature(tmp_path, cert, label, ca):
+    test_tmp = tmp_path / "softhsm2_test" / label
+    test_tmp.mkdir(parents=True)
+    (test_tmp / "message.txt").write_text("test message\n")
+
+    subprocess.check_call(
+        "openssl cms -engine pkcs11 -keyform engine -sign "
+        f"-in {test_tmp}/message.txt -out {test_tmp}/message.sig -binary "
+        f"-inkey 'pkcs11:token=rauc;object={label}&pin-value=1111' "
+        f"-signer {cert}",
+        shell=True,
+    )
+    subprocess.check_call(
+        f"openssl cms -verify -in {test_tmp}/message.sig -out {test_tmp}/message.out -binary -CAfile {ca}",
+        shell=True,
+    )
+
+    assert (test_tmp / "message.out").read_text() == "test message\n"
+
+
+
 def prepare_softhsm2(tmp_path, softhsm2_mod):
     ca_dev = Path("openssl-ca/dev")
+    ca_cert = Path("openssl-ca/dev-ca.pem")
 
     softhsm2_conf = tmp_path / "softhsm2.conf"
     softhsm2_dir = tmp_path / "softhsm2.tokens"
@@ -207,6 +229,18 @@ def prepare_softhsm2(tmp_path, softhsm2_mod):
     softhsm2_load_key_pair(
         ca_dev / "autobuilder-2.cert.pem", ca_dev / "private/autobuilder-2.pem", "autobuilder-2", "02", softhsm2_mod
     )
+
+    subprocess.check_call(
+        f"pkcs11-tool --module {softhsm2_mod} -l --pin 1111 --sign --mechanism RSA-PKCS --label autobuilder-1 --input-file /dev/null --output-file=/dev/null ",
+        shell=True,
+    )
+    subprocess.check_call(
+        f"pkcs11-tool --module {softhsm2_mod} -l --pin 1111 --sign --mechanism RSA-PKCS --label autobuilder-2 --input-file /dev/null --output-file=/dev/null ",
+        shell=True,
+    )
+
+    softhsm2_test_signature(tmp_path, ca_dev / "autobuilder-1.cert.pem", "autobuilder-1", ca_cert)
+    softhsm2_test_signature(tmp_path, ca_dev / "autobuilder-2.cert.pem", "autobuilder-2", ca_cert)
 
     out, err, exitcode = run(f"pkcs11-tool --module {softhsm2_mod} -l --pin 1111 --list-objects")
     assert exitcode == 0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -242,8 +242,7 @@ def prepare_softhsm2(tmp_path, softhsm2_mod):
     softhsm2_test_signature(tmp_path, ca_dev / "autobuilder-1.cert.pem", "autobuilder-1", ca_cert)
     softhsm2_test_signature(tmp_path, ca_dev / "autobuilder-2.cert.pem", "autobuilder-2", ca_cert)
 
-    out, err, exitcode = run(f"pkcs11-tool --module {softhsm2_mod} -l --pin 1111 --list-objects")
-    assert exitcode == 0
+    subprocess.check_call(f"pkcs11-tool --module {softhsm2_mod} -l --pin 1111 --list-objects", shell=True)
 
     os.environ["RAUC_PKCS11_PIN"] = "1111"
     # setting the module is needed only if p11-kit doesn't work

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -94,6 +94,18 @@ def test_info_crypt_encrypted_invalid_key():
     assert "Failed to decrypt CMS EnvelopedData" in err
 
 
+def test_info_crypt_encrypted_pkcs11(pkcs11):
+    out, err, exitcode = run(
+        "rauc --keyring openssl-ca/dev-ca.pem "
+        "--key 'pkcs11:token=rauc;object=enc-rsa-000' "
+        "info good-crypt-bundle-encrypted.raucb"
+    )
+
+    assert exitcode == 0
+    assert out.startswith("Compatible:     'Test Config'")
+    assert "Bundle Format:  crypt" in out
+
+
 def test_info_dump_recipients_crypt_encrypted():
     out, err, exitcode = run(
         "rauc --keyring openssl-ca/dev-ca.pem "


### PR DESCRIPTION
While we tested signing using PKCS#11 extensively, we didn't have tests for bundle decryption with PKCS#11 for key access.

This PR first refactors keypair loading, adds checks that OpenSSL works fine with the loaded keys and then adds a test case for decryption with a PKCS#11 key.