### PR TITLE
src/bundle: fix hash_index fd close handling

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -396,7 +396,7 @@ static gboolean generate_adaptive_data(RaucManifest *manifest, const gchar *dir,
 				g_autofree gchar *indexname = g_strconcat(image->filename, ".block-hash-index", NULL);
 				g_autofree gchar *indexpath = g_build_filename(dir, indexname, NULL);
 				g_autoptr(RaucHashIndex) index = NULL;
-				int fd = -1;
+				g_auto(filedesc) fd = -1;
 
 				if (image_is_archive(image)) {
 					g_warning("Generating block hash index requires a block device image but %s looks like an archive", image->filename);
@@ -419,7 +419,6 @@ static gboolean generate_adaptive_data(RaucManifest *manifest, const gchar *dir,
 							error,
 							ierror,
 							"Failed to generate hash index for %s: ", image->filename);
-					g_close(fd, NULL);
 					return FALSE;
 				}
 
@@ -428,7 +427,6 @@ static gboolean generate_adaptive_data(RaucManifest *manifest, const gchar *dir,
 							error,
 							ierror,
 							"Failed to write hash index for %s: ", image->filename);
-					g_close(fd, NULL);
 					return FALSE;
 				}
 

--- a/src/hash_index.c
+++ b/src/hash_index.c
@@ -334,13 +334,13 @@ RaucHashIndex *r_hash_index_open_slot(const gchar *label, const RaucSlot *slot, 
 				G_FILE_ERROR,
 				g_file_error_from_errno(err),
 				"Failed to open slot device %s: %s", slot->device, g_strerror(err));
-		goto out;
+		return NULL;
 	}
 
 	dir = r_slot_get_checksum_data_directory(slot, NULL, &ierror);
 	if (!dir) {
 		g_propagate_error(error, ierror);
-		goto out;
+		return NULL;
 	}
 
 	index_filename = g_build_filename(dir, "block-hash-index", NULL);
@@ -349,11 +349,11 @@ RaucHashIndex *r_hash_index_open_slot(const gchar *label, const RaucSlot *slot, 
 	idx = r_hash_index_open(label, data_fd, index_filename, &ierror);
 	if (!idx) {
 		g_propagate_error(error, ierror);
-		goto out;
+		return NULL;
 	}
 
 	g_debug("opened hash index for slot %s as %s", slot->name, label);
-out:
+
 	return g_steal_pointer(&idx);
 }
 
@@ -375,7 +375,7 @@ RaucHashIndex *r_hash_index_open_image(const gchar *label, const RaucImage *imag
 				G_FILE_ERROR,
 				g_file_error_from_errno(err),
 				"Failed to open image file %s: %s", image->filename, g_strerror(err));
-		goto out;
+		return NULL;
 	}
 
 	index_filename = g_strdup_printf("%s.block-hash-index", image->filename);
@@ -383,11 +383,11 @@ RaucHashIndex *r_hash_index_open_image(const gchar *label, const RaucImage *imag
 	idx = r_hash_index_open(label, data_fd, index_filename, &ierror);
 	if (!idx) {
 		g_propagate_error(error, ierror);
-		goto out;
+		return NULL;
 	}
 
 	g_debug("opened hash index for image %s with index %s", image->filename, index_filename);
-out:
+
 	return g_steal_pointer(&idx);
 }
 

--- a/src/hash_index.c
+++ b/src/hash_index.c
@@ -236,7 +236,7 @@ RaucHashIndex *r_hash_index_open(const gchar *label, int data_fd, const gchar *h
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	idx->label = g_strdup(label);
-	idx->data_fd = data_fd;
+	idx->data_fd = dup(data_fd);
 
 	idx->count = get_chunk_count(data_fd, &ierror);
 	if (!idx->count) {
@@ -321,7 +321,7 @@ RaucHashIndex *r_hash_index_open_slot(const gchar *label, const RaucSlot *slot, 
 	g_autoptr(RaucHashIndex) idx = NULL;
 	g_autofree gchar *dir = NULL;
 	g_autofree gchar *index_filename = NULL;
-	int data_fd = -1;
+	g_auto(filedesc) data_fd = -1;
 
 	g_return_val_if_fail(label, NULL);
 	g_return_val_if_fail(slot, NULL);
@@ -351,13 +351,9 @@ RaucHashIndex *r_hash_index_open_slot(const gchar *label, const RaucSlot *slot, 
 		g_propagate_error(error, ierror);
 		goto out;
 	}
-	data_fd = -1; /* belongs to idx now */
 
 	g_debug("opened hash index for slot %s as %s", slot->name, label);
 out:
-	if (data_fd >= 0) {
-		g_close(data_fd, NULL);
-	}
 	return g_steal_pointer(&idx);
 }
 
@@ -366,7 +362,7 @@ RaucHashIndex *r_hash_index_open_image(const gchar *label, const RaucImage *imag
 	GError *ierror = NULL;
 	g_autoptr(RaucHashIndex) idx = NULL;
 	g_autofree gchar *index_filename = NULL;
-	int data_fd = -1;
+	g_auto(filedesc) data_fd = -1;
 
 	g_return_val_if_fail(label, NULL);
 	g_return_val_if_fail(image, NULL);
@@ -389,13 +385,9 @@ RaucHashIndex *r_hash_index_open_image(const gchar *label, const RaucImage *imag
 		g_propagate_error(error, ierror);
 		goto out;
 	}
-	data_fd = -1; /* belongs to idx now */
 
 	g_debug("opened hash index for image %s with index %s", image->filename, index_filename);
 out:
-	if (data_fd >= 0) {
-		g_close(data_fd, NULL);
-	}
 	return g_steal_pointer(&idx);
 }
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -463,16 +463,19 @@ class Bundle:
             "filename": "hook.sh",
         }
 
-    def build(self):
+    def build_nocheck(self):
         with open(self.content / "manifest.raucm", "w") as f:
             self.manifest.write(f, space_around_delimiters=False)
 
-        out, err, exitcode = run(
+        return run(
             "rauc bundle "
             "--cert openssl-ca/dev/autobuilder-1.cert.pem "
             "--key openssl-ca/dev/private/autobuilder-1.pem "
             f"{self.content} {self.output}"
         )
+
+    def build(self):
+        out, err, exitcode = self.build_nocheck()
         assert exitcode == 0
         assert "Creating 'verity' format bundle" in out
         assert self.output.is_file()

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -137,3 +137,16 @@ def test_bundle_crypt(tmp_path):
 
     out, err, exitcode = run(f"rauc -c test.conf info {tmp_path}/out.raucb")
     assert exitcode == 0
+
+
+def test_bundle_adaptive(tmp_path, bundle):
+    bundle.manifest["image.rootfs"] = {
+        "filename": "rootfs.img",
+        "adaptive": "block-hash-index",
+    }
+    bundle.make_random_image("rootfs", 4097, "random rootfs")
+    out, err, exitcode = bundle.build_nocheck()
+    assert exitcode == 1
+    assert "Creating 'verity' format bundle" in out
+    assert "not a multiple of 4096 bytes" in err
+    assert not bundle.output.is_file()


### PR DESCRIPTION
When calling `r_hash_index_open()`, the ownership of the file descriptor provided should be handed over to the hash index and will be later closed in `r_hash_index_free()`.

Thus, the file descriptor provided must not be closed by the calling code anymore.

In `generate_adaptive_data()` however, the provided pointer was closed manually in the later error case, which would lead to a double-call of `g_close()` on the same pointer happened.

This was wrong anyway but results in a critical error in RAUC since glib version 2.75.0 which comes with a pickier `g_close()` handling: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2964

Fix this and add a hint to the function documentation.

Fixes: https://github.com/rauc/meta-rauc/issues/334