### PR TITLE
Fix occasional broken pipe error on RAUC install

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -218,7 +218,7 @@ static gboolean splice_with_progress(GUnixInputStream *image_stream,
 			last_percent = percent;
 			r_context_set_step_percentage("copy_image", percent);
 		}
-	} while (out_size);
+	} while (out_size && (sum_size < stat.st_size));
 
 	return TRUE;
 }


### PR DESCRIPTION
- RAUC is splicing data from the input file (a .tar inside the bundle) to stdin of a `tar` process it spawns to untar it.  This is done in chunks in a while() loop, where the loop is exited if splice() ever returns 0 (presumably because the input FD hit EOF).

  Under high CPU load, I've seen the last chunk of data reach the `tar` process and for it to complete the untarring and exit successfully before the loop in the installer process goes around one last time to call splice() and get the 0 return value.  If this happens, when it finally does call splice() one more time, the destination (`tar`) is gone, so splice() reports a broken pipe and the process aborts, even though `tar` completed successfully.

- The fix is to add a check to the while() loop to break if all of the data has been spliced, even if the last splice() call returned a non-zero value.
<details>
<summary>Example error message</summary>

```
<snip>
59% Copying image to bootfs.1
60% Copying image to bootfs.1 failed.
99% Updating slots failed.
100% Installing failed.
LastError: Installation error: Failed updating slot bootfs.1: failed to splice data to tar: Broken pipe
Installing `/tmp/update.raucb` failed
```
</details>

<details>
<summary>Failure Trace (under high CPU load)</summary>

```
<snip>
[pid  4438<installer>] splice(9</run/rauc/bundle/bootfs.tar>, NULL, 10<pipe:[18318]>, NULL, 1048576, 0) = 65536
[pid  4438<installer>] splice(9</run/rauc/bundle/bootfs.tar>, NULL, 10<pipe:[18318]>, NULL, 1048576, 0) = 65536
[pid  4438<installer>] splice(9</run/rauc/bundle/bootfs.tar>, NULL, 10<pipe:[18318]>, NULL, 1048576, 0 <unfinished ...>
[pid  4460<tar>] +++ exited with 0 +++
[pid  4438<installer>] <... splice resumed>) = 34816
[pid  4438<installer>] splice(9</run/rauc/bundle/bootfs.tar>, NULL, 10<pipe:[18318]>, NULL, 1048576, 0) = -1 EPIPE (Broken pipe)
[pid  4438<installer>] --- SIGPIPE {si_signo=SIGPIPE, si_code=SI_USER, si_pid=4428<rauc>, si_uid=0} ---
```
</details>

<details>
<summary>Success Trace (under low CPU load)</summary>

```
<snip>
[pid  5286<installer>] splice(10</run/rauc/bundle/bootfs.tar>, NULL, 9<pipe:[20185]>, NULL, 1048576, 0) = 20480
[pid  5286<installer>] splice(10</run/rauc/bundle/bootfs.tar>, NULL, 9<pipe:[20185]>, NULL, 1048576, 0) = 8192
[pid  5286<installer>] splice(10</run/rauc/bundle/bootfs.tar>, NULL, 9<pipe:[20185]>, NULL, 1048576, 0) = 12288
[pid  5286<installer>] splice(10</run/rauc/bundle/bootfs.tar>, NULL, 9<pipe:[20185]>, NULL, 1048576, 0) = 6144
[pid  5286<installer>] splice(10</run/rauc/bundle/bootfs.tar>, NULL, 9<pipe:[20185]>, NULL, 1048576, 0) = 0
[pid  5311<tar>] +++ exited with 0 +++
rauc-Message: 19:19:49.651: Unmounting ext4 slot /dev/mmcblk0p2
```
</details>

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
