### PR TITLE
src/manifest: throw parser error for invalid slot hook combination

### DIFF
--- a/include/manifest.h
+++ b/include/manifest.h
@@ -132,6 +132,20 @@ gboolean check_manifest_external(const RaucManifest *manifest, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Check a new manifest for consistency during bundle creation.
+ *
+ * This is used for checks that could otherwise break compatibility of new RAUC
+ * versions with old bundles.
+ *
+ * @param manifest Pointer to the manifest to check
+ * @param error return location for a GError, or NULL
+ *
+ * @return TRUE on success, FALSE if an error occurred
+ */
+gboolean check_manifest_create(const RaucManifest *mf, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
  * Stores the manifest to memory.
  *
  * @param mem location to store manifest

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1000,6 +1000,12 @@ gboolean create_bundle(const gchar *bundlename, const gchar *contentdir, GError 
 		g_print("%s\n", (gchar *)g_ptr_array_index(manifest->warnings, i));
 	}
 
+	res = check_manifest_create(manifest, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
 	res = sync_manifest_with_contentdir(manifest, workdir, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -616,6 +616,23 @@ out:
 	return res;
 }
 
+gboolean check_manifest_create(const RaucManifest *mf, GError **error)
+{
+	for (GList *l = mf->images; l != NULL; l = l->next) {
+		RaucImage *image = l->data;
+
+		g_assert(image);
+
+		if (image->hooks.install && (image->hooks.pre_install || image->hooks.post_install)) {
+			g_set_error_literal(error, R_MANIFEST_ERROR, R_MANIFEST_CHECK_ERROR,
+					"An 'install' hook must not be combined with 'pre-install' or 'post-install' hooks");
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
 static GKeyFile *prepare_manifest(const RaucManifest *mf)
 {
 	g_autoptr(GKeyFile) key_file = NULL;


### PR DESCRIPTION
When using an `install` hook, the `pre-install` and `post-install` hooks will not be called. To avoid confusion, prevent generating bundles having both 'install' and 'pre-install' (or 'post-install') hook set for the same slot.

Fixes https://github.com/rauc/meta-rauc/issues/321