### PR TITLE
src/bundle: gracefully abort remote bundle install if support is disabled

### DIFF
--- a/include/bundle.h
+++ b/include/bundle.h
@@ -20,6 +20,7 @@ typedef enum {
 	R_BUNDLE_ERROR_FORMAT,
 	R_BUNDLE_ERROR_VERITY,
 	R_BUNDLE_ERROR_CRYPT,
+	R_BUNDLE_ERROR_UNSUPPORTED,
 } RBundleError;
 
 typedef struct {

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2041,7 +2041,10 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleP
 		}
 		g_debug("Downloaded temp bundle to %s", ibundle->path);
 #else
-		g_warning("Mounting remote bundle not supported, recompile with -Dnetwork=true");
+		g_set_error(error, R_BUNDLE_ERROR, R_BUNDLE_ERROR_UNSUPPORTED,
+				"Remote bundle access not supported, recompile with -Dstreaming=true");
+		res = FALSE;
+		goto out;
 #endif
 	} else {
 		ibundle->path = g_strdup(bundlename);


### PR DESCRIPTION
Currently installing a remote bundle without having first enabled networking support at build-time results in a warning followed by a crash:
```
  Mounting remote bundle not supported, recompile with --enable-network
  installing http://192.168.8.15:8080/TODO-prod.raucb: Checking and mounting bundle...
  g_str_has_suffix: assertion 'str != NULL' failed
  rauc.service: Main process exited, code=dumped, status=5/TRAP
  rauc.service: Failed with result 'core-dump'.
```

Fix this by early exiting in this case and propagating the error up.
