### PR TITLE
src/main: handle empty bootname in r_event_log_booted()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1999,10 +1999,10 @@ static void r_event_log_booted(const RaucSlot *booted_slot)
 
 	g_return_if_fail(booted_slot);
 
-	message = g_strdup_printf("Booted into %s (%s)", booted_slot->name, booted_slot->bootname);
+	message = g_strdup_printf("Booted into %s (%s)", booted_slot->name, booted_slot->bootname ?: "");
 	fields[0].value = message;
 	fields[5].value = booted_slot->name;
-	fields[6].value = booted_slot->bootname;
+	fields[6].value = booted_slot->bootname ?: "";
 	fields[7].value = r_context()->boot_id;
 	if (booted_slot->status && booted_slot->status->bundle_hash) {
 		fields[8].value = booted_slot->status->bundle_hash;


### PR DESCRIPTION
The slot booted does not necessarily need to be a slot with a 'bootname' set since RAUC supports identifying slots via root= command line argument, too.

For these cases `fields[6].value` would have been set to `NULL` which made the journal log handler crash.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
