### PR TITLE
meson: fix test dependencies on rauc binary

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -192,7 +192,7 @@ librauc = static_library('rauc',
   dependencies : rauc_deps + [versiondep],
   )
 
-executable('rauc',
+rauc_binary = executable('rauc',
   'src/main.c',
   dbus_sources,
   include_directories : incdir,

--- a/test/meson.build
+++ b/test/meson.build
@@ -54,6 +54,7 @@ foreach test_name : tests
   test(
     test_name,
     exe,
+    depends : rauc_binary,
     is_parallel : false,
     timeout : 240,
     protocol: 'tap',
@@ -92,6 +93,7 @@ if pytest.found()
       pytest,
       args: ['--basetemp', '/tmp/pytest-custom-root', '-vv', test_name + '.py'],
       env: ['MESON_BUILD_DIR=' + rauc_build_root],
+      depends : rauc_binary,
       is_parallel : false,
       timeout : 120,
       workdir : meson.current_source_dir(),


### PR DESCRIPTION
The tests lack a dependency on building the rauc binary. As a result, the tests will fail when running them directly from a fresh build directory:

    meson setup build
    meson test -C build

Fix this by defining the missing dependency for both the C-based and pytest-based tests.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
