### PR TITLE
fix scan-build report

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -35,4 +35,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: scan-build-report
-        path: /tmp/scan-build-*
+        path: build/meson-logs/scanbuild/*

--- a/scan-build
+++ b/scan-build
@@ -2,5 +2,5 @@
 
 set -ex
 
-meson setup build
-SCANBUILD=$(pwd)/scan-build-wrapper.sh ninja -C build scan-build
+meson setup build-clang-scan
+SCANBUILD=$(pwd)/scan-build-wrapper.sh ninja -C build-clang-scan scan-build

--- a/scan-build
+++ b/scan-build
@@ -2,5 +2,5 @@
 
 set -ex
 
-meson setup build-clang-scan
+meson setup --wipe build-clang-scan
 SCANBUILD=$(pwd)/scan-build-wrapper.sh ninja -C build-clang-scan scan-build


### PR DESCRIPTION
It seems the report path has changed at some point, so fix it.

A working upload can be seen at https://github.com/jluebbe/rauc/actions/runs/11365746904/job/31614597488#step:8:23.