### PR TITLE
Fix some issues found by Coverity

### DIFF
--- a/src/artifacts.c
+++ b/src/artifacts.c
@@ -328,6 +328,7 @@ static gboolean artifact_repo_prune_subdir(RArtifactRepo *repo, const gchar *par
 	g_autofree gchar *path = g_build_filename(repo->path, parent, NULL);
 	g_autoptr(GDir) dir = g_dir_open(path, 0, &ierror);
 	if (dir == NULL) {
+		g_propagate_error(error, ierror);
 		return TRUE;
 	}
 

--- a/src/artifacts.c
+++ b/src/artifacts.c
@@ -513,6 +513,7 @@ gboolean r_artifact_repo_commit(RArtifactRepo *repo, GError **error)
 							artifact->name,
 							artifact->checksum.digest
 							);
+					break;
 				} else {
 					g_debug("disabled");
 				}

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -989,8 +989,12 @@ static gboolean decrypt_bundle_payload(RaucBundle *bundle, GError **error)
 out:
 	/* Remove temporary bundle creation directory.
 	 * RAUC will still have access to the decrypted bundle via the opened GFile */
-	if (tmpdir)
-		rm_tree(tmpdir, NULL);
+	if (tmpdir) {
+		g_autoptr(GError) tmperror = NULL;
+		if (!rm_tree(tmpdir, &tmperror)) {
+			g_warning("Failed to remove bundle decryption tmpdir %s: %s", tmpdir, tmperror->message);
+		}
+	}
 
 	return res;
 }
@@ -1516,8 +1520,12 @@ static gboolean convert_to_casync_bundle(RaucBundle *bundle, const gchar *outbun
 	res = TRUE;
 out:
 	/* Remove temporary bundle creation directory */
-	if (tmpdir)
-		rm_tree(tmpdir, NULL);
+	if (tmpdir) {
+		g_autoptr(GError) tmperror = NULL;
+		if (!rm_tree(tmpdir, &tmperror)) {
+			g_warning("Failed to remove conversion tmpdir %s: %s", tmpdir, tmperror->message);
+		}
+	}
 	return res;
 }
 
@@ -2735,8 +2743,12 @@ gboolean load_manifest_from_bundle(RaucBundle *bundle, RaucManifest **manifest, 
 		goto out;
 	}
 out:
-	if (tmpdir)
-		rm_tree(tmpdir, NULL);
+	if (tmpdir) {
+		g_autoptr(GError) tmperror = NULL;
+		if (!rm_tree(tmpdir, &tmperror)) {
+			g_warning("Failed to remove unsquashfs tmpdir %s: %s", tmpdir, tmperror->message);
+		}
+	}
 	return res;
 }
 


### PR DESCRIPTION
* Adds missing `rm_tree()` return value checks
* Fixes GError propagation in `artifact_repo_prune_subdir()`
* Fixes potential leakage in `r_artifact_repo_commit()`