### PR TITLE
Add -C option to overwrite config file parameters

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1248,12 +1248,13 @@ Command Line Tool
     rauc [OPTION?] <COMMAND>
 
   Options:
-    -c, --conf=FILENAME     config file
-    --keyring=PEMFILE       keyring file
-    --mount=PATH            mount prefix
-    -d, --debug             enable debug output
-    --version               display version
-    -h, --help              display help and exit
+    -c, --conf=FILENAME                 config file
+    -C, --confopt=SECTION:KEY=VALUE     config settings that override parameters from the config file
+    --keyring=PEMFILE                   keyring file
+    --mount=PATH                        mount prefix
+    -d, --debug                         enable debug output
+    --version                           display version
+    -h, --help                          display help and exit
 
   Command-specific help:
     rauc <COMMAND> --help
@@ -1277,6 +1278,10 @@ Command Line Tool
     RAUC_KEY_PASSPHRASE Passphrase to use for accessing key files (signing only)
     RAUC_PKCS11_MODULE  Library filename for PKCS#11 module (signing only)
     RAUC_PKCS11_PIN     PIN to use for accessing PKCS#11 keys (signing only)
+
+.. note:: 
+  Using -C / --confopt can not only override settings of the config file but also 
+  set new values that haven't been present before.
 
 .. _sec-handler-interface:
 

--- a/include/context.h
+++ b/include/context.h
@@ -23,6 +23,12 @@ typedef enum {
 } RContextConfigMode;
 
 typedef struct {
+	gchar *section;
+	gchar *name;
+	gchar *value;
+} ConfigFileOverride;
+
+typedef struct {
 	/* a busy context must not be reconfigured */
 	gboolean busy;
 	gboolean pending;
@@ -30,6 +36,7 @@ typedef struct {
 	/* system configuration data */
 	RContextConfigMode configmode;
 	gchar *configpath;
+	GList *configoverride;
 	RaucConfig *config;
 
 	/* system status (not available when using per-slot status file) */

--- a/rauc.1
+++ b/rauc.1
@@ -64,6 +64,11 @@ not all combinations make sense.
 use the given config file instead of the one at the compiled-in default path
 
 .TP
+\fB\-C\fR \fISECTION:KEY=VALUE\fR, \fB\-\-confopt=\fR\fISECTION:KEY=VALUE\fR
+Override parameters from the config file with the specified configuration settings.
+If specified parameter is not present in the config file it will still be set by this option.
+
+.TP
 \fB\-\-keyring=\fR\fIPEMFILE\fR
 use specific keyring file
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -743,6 +743,12 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		return FALSE;
 	}
 
+	/* process overrides */
+	for (GList *l = r_context_conf()->configoverride; l != NULL; l = l->next) {
+		ConfigFileOverride *override = (ConfigFileOverride *)l->data;
+		g_key_file_set_value(key_file, override->section, override->name, override->value);
+	}
+
 	/* parse [system] section */
 	c->system_compatible = key_file_consume_string(key_file, "system", "compatible", &ierror);
 	if (!c->system_compatible) {

--- a/src/context.c
+++ b/src/context.c
@@ -871,6 +871,15 @@ void r_context_clean(void)
 
 		g_clear_pointer(&context->config, free_config);
 
+		for (GList *l = context->configoverride; l != NULL; l = l->next) {
+			ConfigFileOverride *override = (ConfigFileOverride *)l->data;
+			g_clear_pointer(&override->section, g_free);
+			g_clear_pointer(&override->name, g_free);
+			g_clear_pointer(&override->value, g_free);
+			g_clear_pointer(&override, g_free);
+		}
+		g_clear_pointer(&context->configoverride, g_list_free);
+
 		g_clear_pointer(&context->system_status, r_system_status_free);
 
 		g_clear_pointer(&context, g_free);

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -225,3 +225,24 @@ def test_info_format_invalid():
 
     assert exitcode == 1
     assert "Unknown output format: 'invalid'" in err
+
+
+def test_info_configoverride(tmp_path):
+    # copy to tmp path for safe ownership check
+    shutil.copyfile("good-bundle.raucb", tmp_path / "good-bundle.raucb")
+
+    out, err, exitcode = run(f"rauc info -c test.conf -C system:bundle-formats=verity {tmp_path}/good-bundle.raucb")
+    assert exitcode == 1
+    assert "Bundle format 'plain' not allowed" in err
+
+    out, err, exitcode = run("rauc info -C system:bundle-formats")
+    assert exitcode == 1
+    assert "Error in parsing override: Missing '='" in err
+
+    out, err, exitcode = run("rauc info -C systembundle-formats=verity")
+    assert exitcode == 1
+    assert "Error in parsing override: Missing ':'" in err
+
+    out, err, exitcode = run("rauc info -C")
+    assert exitcode == 1
+    assert "Error in parsing override: you must specify it in format SECTION:KEY=VALUE" in err


### PR DESCRIPTION
add -C option to set/overwrite config file parameters (currently only for keyring:check-crl=false and keyring:check-purpose=codesign)

Fixes: #953 

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
