### PR TITLE
Print bootname during install

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -1092,7 +1092,11 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 
 	install_args_update(args, "Checking slot %s", plan->target_slot->name);
 
-	r_context_begin_step_weighted_formatted("check_slot", 0, 1, "Checking slot %s", plan->target_slot->name);
+	r_context_begin_step_weighted_formatted("check_slot", 0, 1, "Checking slot %s%s%s%s",
+			plan->target_slot->name,
+			plan->target_slot->bootname ? " (" : "",
+			plan->target_slot->bootname ? plan->target_slot->bootname : "",
+			plan->target_slot->bootname ? ")" : "");
 
 	r_slot_status_load(plan->target_slot);
 	slot_state = plan->target_slot->status;

--- a/test/service.c
+++ b/test/service.c
@@ -186,8 +186,8 @@ static void service_test_install(ServiceFixture *fixture, gconstpointer user_dat
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  30, "Determining target install group", 2));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Determining target install group done.", 2));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Updating slots", 2));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Checking slot rootfs.1", 3));
-	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  43, "Checking slot rootfs.1 done.", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  40, "Checking slot rootfs.1 (system1)", 3));
+	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  43, "Checking slot rootfs.1 (system1) done.", 3));
 	for (gint32 i = 43; i <= 69; i++)
 		g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)", i, "Copying image to rootfs.1", 3));
 	g_queue_push_tail(args, (gpointer*)g_variant_new("(isi)",  70, "Copying image to rootfs.1 done.", 3));


### PR DESCRIPTION
This makes the output more user friendly on systems where the bootname is the common way to refer to a slot.

### Example output
```
...
40% Checking slot rootfs.1 (secondary)
46% Checking slot rootfs.1 (secondary) done.
...
```
If no bootname is specified