### PR TITLE
src/signature: fix CMS debug output check

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -1133,9 +1133,10 @@ static void debug_cms_ci(CMS_ContentInfo *cms)
 	gchar *out_str = NULL;
 	long size;
 
-	if ((domains == NULL) || (strstr(domains, G_LOG_DOMAIN "-signature") == NULL)) {
+	if (domains == NULL)
 		return;
-	}
+	if (!g_str_equal(domains, "all") && strstr(domains, G_LOG_DOMAIN "-signature") == NULL)
+		return;
 
 	out = BIO_new(BIO_s_mem());
 	CMS_ContentInfo_print_ctx(out, cms, 2, NULL);


### PR DESCRIPTION
As specified in the documentation, setting `G_MESSAGES_DEBUG=all` is supposed to enable log output for all logging domains. However the check to print CMS info introduced by
2cd407600a35eb51995c53bf97fc9cdb0d0fade4
only checks if `G_MESSAGES_DEBUG` contains `-signature`.

The goal is to make this check consistent with the rest of the program and the documentation. This does not affect the `-d` command line option as this uses the `rauc` debug message domain. But when one requests `all`, there should be all messages.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
