### PR TITLE
support locating system.conf in /usr and /run

### DIFF
--- a/data/rauc.service.in
+++ b/data/rauc.service.in
@@ -6,6 +6,6 @@ After=dbus.service
 [Service]
 Type=dbus
 BusName=de.pengutronix.rauc
-ExecStart=@bindir@/rauc --mount=/run/rauc service
-RuntimeDirectory=rauc
+ExecStart=@bindir@/rauc --mount=/run/rauc/mnt service
+RuntimeDirectory=rauc/mnt
 MountFlags=slave

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -62,8 +62,8 @@ updated
   type=ext4
   bootname=B
 
-In this case, we need to place the signing certificate into
-``/etc/rauc/demo.cert.pem``, so that it is used by RAUC for verification.
+In this case, we need to place the signing certificate into the same
+directory as the ``system.conf``, so that it is used by RAUC for verification.
 
 GRUB Configuration
 ~~~~~~~~~~~~~~~~~~

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -140,9 +140,13 @@ The system configuration file is the central configuration in RAUC that
 abstracts the loosely coupled storage setup, partitioning and boot strategy of
 your board to a coherent redundancy setup world view for RAUC.
 
-RAUC expects its central configuration file ``/etc/rauc/system.conf`` to
-describe the system it runs on in a way that all relevant information for
-performing updates and making decisions are given.
+RAUC configuration files are loaded from one of the listed directories in
+order of priority, only the first file found is used:
+``/etc/rauc/``, ``/run/rauc/``, ``/usr/lib/rauc/``.
+
+The ``system.conf`` is expected to describe the system RAUC runs on in a way
+that all relevant information for performing updates and making decisions are
+given.
 
 .. note:: For a full reference of the system.conf file refer to section
   :ref:`sec_ref_slot_config`.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -12,8 +12,13 @@ Reference
 System Configuration File
 -------------------------
 
-A configuration file located in ``/etc/rauc/system.conf`` describes the
-number and type of available slots.
+A configuration file named ``system.conf`` describes the number and type of
+available slots.
+
+This file is loaded from one of the listed directories in
+order of priority, only the first file found is used:
+``/etc/rauc/``, ``/run/rauc/``, ``/usr/lib/rauc/``.
+
 It is used to validate storage locations for update images.
 Each board type requires its special configuration.
 
@@ -1287,7 +1292,8 @@ Interaction between RAUC and custom handler shell scripts is done using shell
 variables.
 
 ``RAUC_SYSTEM_CONFIG``
-  Path to the system configuration file (default path is ``/etc/rauc/system.conf``)
+  Path to the chosen system configuration file (e.g. ``/usr/lib/rauc/system.conf``
+  if not overridden by a file in ``/etc`` or ``/run``)
 
 ``RAUC_CURRENT_BOOTNAME``
   Bootname of the slot the system is currently booted from

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -222,7 +222,7 @@ the default behavior of RAUC.
 
 In general, there exist three major types of customization:
 
-* configuration parameters (in rootfs config file ``/etc/rauc/system.conf``)
+* configuration parameters (in the rootfs' ``rauc/system.conf`` file)
 * handlers (executables in rootfs)
 * hooks (executables in bundle)
 

--- a/rauc.1
+++ b/rauc.1
@@ -394,15 +394,19 @@ PIN to use for accessing PKCS#11 keys (signing only)
 .SH FILES
 
 .TP
-.B /etc/rauc/system.conf
+.B /etc/rauc/system.conf, /run/rauc/system.conf, /usr/lib/rauc/system.conf
 
 The system configuration file is the central configuration in RAUC that
 abstracts the loosely coupled storage setup, partitioning and boot strategy of
 your board to a coherent redundancy setup world view for RAUC.
 
-RAUC expects its central configuration file \fB/etc/rauc/system.conf\fR to
-describe the system it runs on in a way that all relevant information for
-performing updates and making decisions are given.
+RAUC configuration files are loaded from one of the listed directories in
+order of priority, only the first file found is used:
+\fB/etc/rauc/\fR, \fB/run/rauc/\fR, \fB/usr/lib/rauc/\fR.
+
+The \fBsystem.conf\fR is expected to describe the system RAUC runs on in a way
+that all relevant information for performing updates and making decisions are
+given.
 
 Similar to other configuration files used by RAUC,
 the system configuration uses a key-value syntax (similar to those known


### PR DESCRIPTION
Traditionally, programs look up their configuration in /etc and this is
also what RAUC has been doing so far.

The modern pattern is to consult configuration files at a number of
locations. The default distro-provided config goes into /usr/lib,
which may be even read-only.

A runtime override is possible by placing a configuration into /run,
which masks the distro-provided config. The old location in /etc becomes
the highest priority override and is left to the system administrator.

Putting RAUC along with its configuration into /usr is called hermetic
/usr. The search path order implemented here is the recommendation
described in this patch is aligned with the UAPI group's Configuration
Files Specification[1].

The specification goes beyond what is implemented here and describes
also support for drop-in extensions to the configuration files.

This involves more work, because GKeyFile doesn't support merging of
config files, so drop-in support is skipped for now.

[1]: https://uapi-group.org/specifications/specs/configuration_files_specification/

---

Fixes: #1252

- What do you use the feature for?

/usr/lib/rauc/system.conf is the default config and I override it in /run or /etc for select boards.

- How does RAUC benefit from the feature?

The maintainers already indicated in #1252 that they want to support hermetic /usr.

- How did you verify the feature works?

RAUC now prints e.g. `Using system config file /run/rauc/system.conf`. I removed files or broke symlinks and verified that the search path is used in the intended order.

