### PR TITLE
test boot-emmc slots in QEMU

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/rauc/rauc/rauc-ci:latest
+      image: ghcr.io/jluebbe/qemu/rauc-ci-qemu:latest
       # allow mounting and devtmpfs in the container
       options: --user=root --privileged -v /dev:/dev
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.qemu_bash_history
 /.qemu_gdb_history
 /qemu-test-ok
+/qemu-test-emmc.img
 app.info
 /bzImage
 .ccls-cache

--- a/qemu-test
+++ b/qemu-test
@@ -51,6 +51,10 @@ if [ ! -d $BUILD_DIR ]; then
 fi
 ninja -C $BUILD_DIR
 
+if [ -z "$QEMU_BIN" ]; then
+  QEMU_BIN="qemu-system-x86_64"
+fi
+
 QEMU_ARGS=""
 BOOTNAME="system0"
 for x in "$@"; do
@@ -72,7 +76,7 @@ if test -f /usr/share/qemu/qboot.rom; then
   QEMU_ARGS="$QEMU_ARGS -bios /usr/share/qemu/qboot.rom"
 fi
 
-qemu-system-x86_64 \
+$QEMU_BIN \
   $QEMU_ARGS \
   -machine q35 \
   -m 1G \

--- a/qemu-test
+++ b/qemu-test
@@ -76,6 +76,14 @@ if test -f /usr/share/qemu/qboot.rom; then
   QEMU_ARGS="$QEMU_ARGS -bios /usr/share/qemu/qboot.rom"
 fi
 
+if "$QEMU_BIN" -device help | grep -q 'name "emmc"'; then
+  echo "found emmc support, enabling"
+  truncate -s 64M qemu-test-emmc.img
+  QEMU_ARGS="$QEMU_ARGS -drive if=none,id=emmc-drive,file=qemu-test-emmc.img,format=raw"
+  QEMU_ARGS="$QEMU_ARGS -device sdhci-pci"
+  QEMU_ARGS="$QEMU_ARGS -device emmc,id=emmc0,drive=emmc-drive,boot-partition-size=1048576"
+fi
+
 $QEMU_BIN \
   $QEMU_ARGS \
   -machine q35 \

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -159,6 +159,10 @@ if [ -c /dev/mtd3 ] && type ubiattach; then
   export RAUC_TEST_MTD_UBIVOL=/dev/ubi0_0
 fi
 
+if [ -b /dev/mmcblk0 ] && type mmc; then
+  export RAUC_TEST_EMMC=/dev/mmcblk0
+fi
+
 if type casync; then
   export RAUC_TEST_CASYNC=1
 fi

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -150,6 +150,9 @@ def have_service():
     return string_in_config_h("ENABLE_SERVICE 1")
 
 
+needs_emmc = pytest.mark.skipif("RAUC_TEST_EMMC" not in os.environ, reason="Missing eMMC")
+
+
 def softhsm2_load_key_pair(cert, privkey, label, id_, softhsm2_mod):
     proc = subprocess.run(
         f"openssl x509 -in {cert} -inform pem -outform der "

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -496,3 +496,29 @@ def bundle(tmp_path):
     bundle = Bundle(tmp_path)
 
     yield bundle
+
+
+class System:
+    def __init__(self, tmp_path):
+        self.tmp_path = tmp_path
+        self.output = tmp_path / "system.conf"
+        self.data_dir = tmp_path / "data_dir"
+
+        self.config = ConfigParser()
+        self.config["system"] = {
+            "compatible": "Test Config",
+            "bootloader": "noop",
+        }
+
+        self.prefix = f"rauc -c {self.output}"
+
+    def write_config(self):
+        with open(self.output, "w") as f:
+            self.config.write(f, space_around_delimiters=False)
+
+
+@pytest.fixture
+def system(tmp_path):
+    system = System(tmp_path)
+
+    yield system


### PR DESCRIPTION
This required some fixes to QEMU's eMMC emulation and needs [one patch that is still pending](https://lore.kernel.org/qemu-devel/20241015135649.4189256-1-jlu@pengutronix.de), also available at https://github.com/jluebbe/qemu/commit/6d41ee1ac963fbdcea46d00764d835fabf23852a.

To make further tests easier, I've also added a (minimal) fixture to build a `system.conf`.