### PR TITLE
install: define RAUC_SYSTEM_VARIANT for handlers

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1295,6 +1295,10 @@ variables.
   Path to the chosen system configuration file (e.g. ``/usr/lib/rauc/system.conf``
   if not overridden by a file in ``/etc`` or ``/run``)
 
+``RAUC_SYSTEM_VARIANT``
+  The system's variant as obtained by the variant source
+  (refer :ref:`sec-variants`)
+
 ``RAUC_CURRENT_BOOTNAME``
   Bootname of the slot the system is currently booted from
 

--- a/src/install.c
+++ b/src/install.c
@@ -640,6 +640,7 @@ static gchar **add_system_environment(gchar **envp)
 	g_return_val_if_fail(envp, NULL);
 
 	envp = g_environ_setenv(envp, "RAUC_SYSTEM_CONFIG", r_context()->configpath, TRUE);
+	envp = g_environ_setenv(envp, "RAUC_SYSTEM_VARIANT", r_context()->config->system_variant ?: "", TRUE);
 	envp = g_environ_setenv(envp, "RAUC_CURRENT_BOOTNAME", r_context()->bootslot, TRUE);
 	envp = g_environ_setenv(envp, "RAUC_MOUNT_PREFIX", r_context()->config->mount_prefix, TRUE);
 


### PR DESCRIPTION
We currently only define RAUC_SYSTEM_VARIANT for hooks in the bundle, but not for handlers; unless we have a system-info script that sets RAUC_SYSTEM_VARIANT.

This can be confusing and the variant is a useful info to provide to handlers, so let's make it available.

---

If you add a feature, please answer these questions:
- What do you use the feature for?

I used to have a system-info handler setting `RAUC_SYSTEM_VARIANT`, which I have now replaced by having two configs, each with its own `variant-name` and installed dynamically into `/run/rauc/system.conf`. I was surprised to see `RAUC_SYSTEM_VARIANT` unset in the pre-install handler.

- How does RAUC benefit from the feature?

It makes it easier to write pre-install handlers that do checks depending on the variant.

- How did you verify the feature works?

Wrote a pre-install handler and verified that `RAUC_SYSTEM_VARIANT` contained the correct variant.