### PR TITLE
Fix "mark-{bad,good}  other" only works for A/B setups

### DIFF
--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -175,13 +175,20 @@ of a rootfs and application slot each that will be used together.
    :width: 500
    :align: center
 
-To detect the active slots, RAUC attempts to detect the currently booted slot.
+To detect the *active* slots, RAUC attempts to detect the currently booted slot.
 For this, it relies on explicit mapping information provided via the kernel command
 line, or attempts to find it out using mount information.
 For more details on this, see :ref:`sec-integration-boot-slot-detection`.
 
-All slots of the group containing the active slot will be considered active,
-too.
+All other slots of the same class will be considered *inactive*.
+
+All slots of the group containing the *active* slot will be considered
+*active*, too.
+Likewise, all slots of a group containing an *inactive* slot will be considered
+*inactive*.
+
+The slot selection algorithm selects an *inactive* slot group for the images
+contained in the update bundle.
 
 Slot Status and Skipping Slot Updates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -189,6 +189,13 @@ Likewise, all slots of a group containing an *inactive* slot will be considered
 
 The slot selection algorithm selects an *inactive* slot group for the images
 contained in the update bundle.
+In case multiple equivalent *inactive* slot groups are available, the default
+algorithm will select the one with the *oldest installation time stamp*
+(requires having a data directory or central status file configured.).
+A slot with no timestamp is always considered the oldest.
+
+This allows to have setups with three redundant slots (A/B/C update) or
+to bootstrap an A/B system from an external or factory system.
 
 Slot Status and Skipping Slot Updates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -178,6 +178,7 @@ of a rootfs and application slot each that will be used together.
 To detect the active slots, RAUC attempts to detect the currently booted slot.
 For this, it relies on explicit mapping information provided via the kernel command
 line, or attempts to find it out using mount information.
+For more details on this, see :ref:`sec-integration-boot-slot-detection`.
 
 All slots of the group containing the active slot will be considered active,
 too.

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -522,6 +522,8 @@ currently booted (running).
 In the following, the different options for letting RAUC detect the currently
 booted slot are described.
 
+.. _sec-integration-boot-slot-detection:
+
 Booted Slot Detection
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/mark.h
+++ b/include/mark.h
@@ -44,7 +44,11 @@ gboolean r_mark_bad(RaucSlot *slot, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 gboolean mark_run(const gchar *state,
-		const gchar *slot_identifier,
+		RaucSlot *slot,
 		gchar **slot_name,
 		gchar **message)
+G_GNUC_WARN_UNUSED_RESULT;
+
+GList* get_slots_by_identifier(const gchar *identifier,
+		GError **error)
 G_GNUC_WARN_UNUSED_RESULT;

--- a/include/slot.h
+++ b/include/slot.h
@@ -26,6 +26,8 @@ typedef struct {
 	guint32 activated_count;
 } RaucSlotStatus;
 
+#define RAUC_FORMAT_ISO_8601 "%Y-%m-%dT%H:%M:%SZ"
+
 typedef struct _RaucSlot {
 	/** name of the slot. A glib intern string. */
 	const gchar *name;

--- a/include/slot.h
+++ b/include/slot.h
@@ -20,9 +20,9 @@ typedef struct {
 	gchar *status;
 	RaucChecksum checksum;
 	gchar *installed_txn;
-	gchar *installed_timestamp;
+	GDateTime *installed_timestamp;
 	guint32 installed_count;
-	gchar *activated_timestamp;
+	GDateTime *activated_timestamp;
 	guint32 activated_count;
 } RaucSlotStatus;
 

--- a/include/status_file.h
+++ b/include/status_file.h
@@ -30,6 +30,16 @@ gboolean r_slot_status_write(const gchar *filename, RaucSlotStatus *ss, GError *
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Loads the status of all slots.
+ *
+ * Note: Callable from context setup.
+ *
+ * @param filename Status file to load from
+ * @param slots Hast table of slots to set status for
+ */
+void r_slot_status_load_globally(const gchar *filename, GHashTable *slots);
+
+/**
  * Load slot status.
  *
  * Takes care to fill in slot status information into the designated component

--- a/src/context.c
+++ b/src/context.c
@@ -372,6 +372,8 @@ static gboolean r_context_configure_target(GError **error)
 			g_message("Failed to load system status: %s", ierror->message);
 			g_clear_error(&ierror);
 		}
+
+		r_slot_status_load_globally(context->config->statusfile_path, context->config->slots);
 	}
 
 	/* set up logging */

--- a/src/install.c
+++ b/src/install.c
@@ -1065,11 +1065,7 @@ skip_filename_checks:
 
 static void update_slot_status(RaucSlotStatus *slot_state, const gchar* status, const RaucManifest *manifest, const RImageInstallPlan *plan, const RaucInstallArgs *args)
 {
-	g_autoptr(GDateTime) now = NULL;
-
 	r_slot_clear_status(slot_state);
-
-	now = g_date_time_new_now_utc();
 
 	slot_state->bundle_compatible = g_strdup(manifest->update_compatible);
 	slot_state->bundle_version = g_strdup(manifest->update_version);
@@ -1081,7 +1077,7 @@ static void update_slot_status(RaucSlotStatus *slot_state, const gchar* status, 
 	slot_state->checksum.digest = g_strdup(plan->image->checksum.digest);
 	slot_state->checksum.size = plan->image->checksum.size;
 	slot_state->installed_txn = g_strdup(args->transaction);
-	slot_state->installed_timestamp = g_date_time_format(now, RAUC_FORMAT_ISO_8601);
+	slot_state->installed_timestamp = g_date_time_new_now_utc();
 	slot_state->installed_count++;
 }
 

--- a/src/install.c
+++ b/src/install.c
@@ -1081,7 +1081,7 @@ static void update_slot_status(RaucSlotStatus *slot_state, const gchar* status, 
 	slot_state->checksum.digest = g_strdup(plan->image->checksum.digest);
 	slot_state->checksum.size = plan->image->checksum.size;
 	slot_state->installed_txn = g_strdup(args->transaction);
-	slot_state->installed_timestamp = g_date_time_format(now, "%Y-%m-%dT%H:%M:%SZ");
+	slot_state->installed_timestamp = g_date_time_format(now, RAUC_FORMAT_ISO_8601);
 	slot_state->installed_count++;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -2130,6 +2130,7 @@ static gboolean status_start(int argc, char **argv)
 	const gchar *state = NULL;
 	const gchar *slot_identifier = NULL;
 	GError *ierror = NULL;
+	GList *slots = NULL;
 	gboolean res = FALSE;
 	g_autoptr(RaucStatusPrint) status_print = NULL;
 
@@ -2242,9 +2243,18 @@ static gboolean status_start(int argc, char **argv)
 			return TRUE;
 		}
 	} else {
-		r_exit_status = mark_run(state, slot_identifier, NULL, &message) ? 0 : 1;
-		if (r_exit_status)
-			g_printerr("rauc mark: %s\n", message);
+		slots = get_slots_by_identifier(slot_identifier, &ierror);
+		if (ierror) {
+			res = FALSE;
+			message = g_strdup(ierror->message);
+		}
+
+		for (GList *l = slots; l != NULL; l = l->next) {
+			RaucSlot *slot = l->data;
+			r_exit_status = mark_run(state, slot, NULL, &message) ? 0 : 1;
+			if (r_exit_status)
+				g_printerr("rauc mark: %s\n", message);
+		}
 		return TRUE;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -1435,15 +1435,17 @@ static void r_string_append_slot(GString *text, RaucSlot *slot, RaucStatusPrint 
 		}
 		g_string_append_printf(text, "\n          installed:");
 		if (slot_state->installed_timestamp) {
-			g_string_append_printf(text, "\n              timestamp=%s", slot_state->installed_timestamp);
+			g_autofree gchar *stamp = g_date_time_format(slot_state->installed_timestamp, RAUC_FORMAT_ISO_8601);
+			g_string_append_printf(text, "\n              timestamp=%s", stamp);
 			g_string_append_printf(text, "\n              count=%u", slot_state->installed_count);
 		}
 		if (slot_state->installed_txn) {
 			g_string_append_printf(text, "\n              transaction=%s", slot_state->installed_txn);
 		}
 		if (slot_state->activated_timestamp) {
+			g_autofree gchar *stamp = g_date_time_format(slot_state->activated_timestamp, RAUC_FORMAT_ISO_8601);
 			g_string_append_printf(text, "\n          activated:");
-			g_string_append_printf(text, "\n              timestamp=%s", slot_state->activated_timestamp);
+			g_string_append_printf(text, "\n              timestamp=%s", stamp);
 			g_string_append_printf(text, "\n              count=%u", slot_state->activated_count);
 		}
 		if (slot_state->status)
@@ -1638,6 +1640,8 @@ static gchar* r_status_formatter_shell(RaucStatusPrint *status)
 		else
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_BOOT_STATUS_%d=", slotcnt);
 		if (status_detailed && slot_state) {
+			g_autofree gchar *installed_stamp = NULL;
+			g_autofree gchar *activated_stamp = NULL;
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_BUNDLE_COMPATIBLE_%d=%s", slotcnt, slot_state->bundle_compatible ?: "");
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_BUNDLE_VERSION_%d=%s", slotcnt, slot_state->bundle_version ?: "");
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_BUNDLE_DESCRIPTION_%d=%s", slotcnt, slot_state->bundle_description ?: "");
@@ -1645,9 +1649,13 @@ static gchar* r_status_formatter_shell(RaucStatusPrint *status)
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_BUNDLE_HASH_%d=%s", slotcnt, slot_state->bundle_hash ?: "");
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_CHECKSUM_SHA256_%d=%s", slotcnt, slot_state->checksum.digest ?: "");
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_CHECKSUM_SIZE_%d=%"G_GOFFSET_FORMAT, slotcnt, slot_state->checksum.size);
-			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_INSTALLED_TIMESTAMP_%d=%s", slotcnt, slot_state->installed_timestamp ?: "");
+			if (slot_state->installed_timestamp)
+				installed_stamp = g_date_time_format(slot_state->installed_timestamp, RAUC_FORMAT_ISO_8601);
+			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_INSTALLED_TIMESTAMP_%d=%s", slotcnt, installed_stamp ?: "");
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_INSTALLED_COUNT_%d=%u", slotcnt, slot_state->installed_count);
-			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_ACTIVATED_TIMESTAMP_%d=%s", slotcnt, slot_state->activated_timestamp ?: "");
+			if (slot_state->activated_timestamp)
+				activated_stamp = g_date_time_format(slot_state->activated_timestamp, RAUC_FORMAT_ISO_8601);
+			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_ACTIVATED_TIMESTAMP_%d=%s", slotcnt, activated_stamp ?: "");
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_ACTIVATED_COUNT_%d=%u", slotcnt, slot_state->activated_count);
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_STATUS_STATUS_%d=%s", slotcnt, slot_state->status ?: "");
 		}
@@ -1817,19 +1825,21 @@ static gchar* r_status_formatter_json(RaucStatusPrint *status, gboolean pretty)
 				json_builder_end_object(builder);       /* checksum */
 			}
 			if (slot_state->installed_timestamp) {
+				g_autofree gchar *stamp = g_date_time_format(slot_state->installed_timestamp, RAUC_FORMAT_ISO_8601);
 				json_builder_set_member_name(builder, "installed");
 				json_builder_begin_object(builder);     /* installed */
 				json_builder_set_member_name(builder, "timestamp");
-				json_builder_add_string_value(builder, slot_state->installed_timestamp);
+				json_builder_add_string_value(builder, stamp);
 				json_builder_set_member_name(builder, "count");
 				json_builder_add_int_value(builder, slot_state->installed_count);
 				json_builder_end_object(builder);       /* installed */
 			}
 			if (slot_state->activated_timestamp) {
+				g_autofree gchar *stamp = g_date_time_format(slot_state->activated_timestamp, RAUC_FORMAT_ISO_8601);
 				json_builder_set_member_name(builder, "activated");
 				json_builder_begin_object(builder);     /* activated */
 				json_builder_set_member_name(builder, "timestamp");
-				json_builder_add_string_value(builder, slot_state->activated_timestamp);
+				json_builder_add_string_value(builder, stamp);
 				json_builder_set_member_name(builder, "count");
 				json_builder_add_int_value(builder, slot_state->activated_count);
 				json_builder_end_object(builder);       /* activated */
@@ -1868,6 +1878,8 @@ static RaucSlotStatus* r_variant_get_slot_state(GVariant *vardict)
 {
 	RaucSlotStatus *slot_state = g_new0(RaucSlotStatus, 1);
 	g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(vardict);
+	g_autofree gchar *installed_stamp = NULL;
+	g_autofree gchar *activated_stamp = NULL;
 
 	g_variant_dict_lookup(&dict, "bundle.compatible", "s", &slot_state->bundle_compatible);
 	g_variant_dict_lookup(&dict, "bundle.version", "s", &slot_state->bundle_version);
@@ -1879,9 +1891,13 @@ static RaucSlotStatus* r_variant_get_slot_state(GVariant *vardict)
 		slot_state->checksum.type = G_CHECKSUM_SHA256;
 	g_variant_dict_lookup(&dict, "size", "t", &slot_state->checksum.size);
 	g_variant_dict_lookup(&dict, "installed.transaction", "s", &slot_state->installed_txn);
-	g_variant_dict_lookup(&dict, "installed.timestamp", "s", &slot_state->installed_timestamp);
+	g_variant_dict_lookup(&dict, "installed.timestamp", "s", &installed_stamp);
+	if (installed_stamp)
+		slot_state->installed_timestamp = g_date_time_new_from_iso8601(installed_stamp, NULL);
 	g_variant_dict_lookup(&dict, "installed.count", "u", &slot_state->installed_count);
-	g_variant_dict_lookup(&dict, "activated.timestamp", "s", &slot_state->activated_timestamp);
+	g_variant_dict_lookup(&dict, "activated.timestamp", "s", &activated_stamp);
+	if (activated_stamp)
+		slot_state->activated_timestamp = g_date_time_new_from_iso8601(activated_stamp, NULL);
 	g_variant_dict_lookup(&dict, "activated.count", "u", &slot_state->activated_count);
 
 	return slot_state;

--- a/src/mark.c
+++ b/src/mark.c
@@ -130,7 +130,6 @@ gboolean r_mark_active(RaucSlot *slot, GError **error)
 {
 	RaucSlotStatus *slot_state;
 	GError *ierror = NULL;
-	g_autoptr(GDateTime) now = NULL;
 
 	g_return_val_if_fail(slot, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
@@ -147,9 +146,9 @@ gboolean r_mark_active(RaucSlot *slot, GError **error)
 
 	r_event_log_mark_active(slot);
 
-	g_free(slot_state->activated_timestamp);
-	now = g_date_time_new_now_utc();
-	slot_state->activated_timestamp = g_date_time_format(now, RAUC_FORMAT_ISO_8601);
+	if (slot_state->activated_timestamp)
+		g_date_time_unref(slot_state->activated_timestamp);
+	slot_state->activated_timestamp = g_date_time_new_now_utc();
 	slot_state->activated_count++;
 
 	if (!r_slot_status_save(slot, &ierror)) {

--- a/src/mark.c
+++ b/src/mark.c
@@ -149,7 +149,7 @@ gboolean r_mark_active(RaucSlot *slot, GError **error)
 
 	g_free(slot_state->activated_timestamp);
 	now = g_date_time_new_now_utc();
-	slot_state->activated_timestamp = g_date_time_format(now, "%Y-%m-%dT%H:%M:%SZ");
+	slot_state->activated_timestamp = g_date_time_format(now, RAUC_FORMAT_ISO_8601);
 	slot_state->activated_count++;
 
 	if (!r_slot_status_save(slot, &ierror)) {

--- a/src/service.c
+++ b/src/service.c
@@ -341,12 +341,14 @@ static GVariant* convert_slot_status_to_dict(RaucSlot *slot)
 		g_variant_dict_insert(&dict, "installed.transaction", "s", slot_state->installed_txn);
 
 	if (slot_state->installed_timestamp) {
-		g_variant_dict_insert(&dict, "installed.timestamp", "s", slot_state->installed_timestamp);
+		g_autofree gchar *stamp = g_date_time_format(slot_state->installed_timestamp, RAUC_FORMAT_ISO_8601);
+		g_variant_dict_insert(&dict, "installed.timestamp", "s", stamp);
 		g_variant_dict_insert(&dict, "installed.count", "u", slot_state->installed_count);
 	}
 
 	if (slot_state->activated_timestamp) {
-		g_variant_dict_insert(&dict, "activated.timestamp", "s", slot_state->activated_timestamp);
+		g_autofree gchar *stamp = g_date_time_format(slot_state->activated_timestamp, RAUC_FORMAT_ISO_8601);
+		g_variant_dict_insert(&dict, "activated.timestamp", "s", stamp);
 		g_variant_dict_insert(&dict, "activated.count", "u", slot_state->activated_count);
 	}
 

--- a/src/slot.c
+++ b/src/slot.c
@@ -43,8 +43,8 @@ void r_slot_clear_status(RaucSlotStatus *slotstatus)
 	g_clear_pointer(&slotstatus->checksum.digest, g_free);
 	slotstatus->checksum.size = 0;
 	g_clear_pointer(&slotstatus->installed_txn, g_free);
-	g_clear_pointer(&slotstatus->installed_timestamp, g_free);
-	g_clear_pointer(&slotstatus->activated_timestamp, g_free);
+	g_clear_pointer(&slotstatus->installed_timestamp, g_date_time_unref);
+	g_clear_pointer(&slotstatus->activated_timestamp, g_date_time_unref);
 }
 
 void r_slot_free_status(RaucSlotStatus *slotstatus)

--- a/src/status_file.c
+++ b/src/status_file.c
@@ -208,19 +208,19 @@ static void load_slot_status_locally(RaucSlot *dest_slot)
 	}
 }
 
-static void load_slot_status_globally(void)
+void r_slot_status_load_globally(const gchar *filename, GHashTable *slots)
 {
 	GError *ierror = NULL;
-	GHashTable *slots = r_context()->config->slots;
 	g_autoptr(GKeyFile) key_file = g_key_file_new();
 	g_auto(GStrv) groups = NULL;
 	gchar **group, *slotname;
 	GHashTableIter iter;
 	RaucSlot *slot;
 
-	g_return_if_fail(r_context()->config->statusfile_path);
+	g_return_if_fail(filename);
+	g_return_if_fail(slots);
 
-	g_key_file_load_from_file(key_file, r_context()->config->statusfile_path, G_KEY_FILE_NONE, &ierror);
+	g_key_file_load_from_file(key_file, filename, G_KEY_FILE_NONE, &ierror);
 	if (ierror && !g_error_matches(ierror, G_FILE_ERROR, G_FILE_ERROR_NOENT))
 		g_message("Failed to load global slot status file: %s", ierror->message);
 	g_clear_error(&ierror);
@@ -260,7 +260,7 @@ void r_slot_status_load(RaucSlot *dest_slot)
 		if (g_strcmp0(r_context()->config->statusfile_path, "per-slot") == 0)
 			load_slot_status_locally(dest_slot);
 		else
-			load_slot_status_globally();
+			r_slot_status_load_globally(r_context()->config->statusfile_path, r_context()->config->slots);
 	}
 
 	r_slot_clean_data_directory(dest_slot);

--- a/src/status_file.c
+++ b/src/status_file.c
@@ -12,6 +12,7 @@ static void status_file_get_slot_status(GKeyFile *key_file, const gchar *group, 
 	GError *ierror = NULL;
 	gchar *digest;
 	guint64 count;
+	gchar *timestamp;
 
 	if (!g_key_file_has_group(key_file, group))
 		g_debug("Group %s not found in key file.", group);
@@ -32,8 +33,13 @@ static void status_file_get_slot_status(GKeyFile *key_file, const gchar *group, 
 		slotstatus->checksum.size = g_key_file_get_uint64(key_file, group, "size", NULL);
 	}
 
-	slotstatus->installed_txn = key_file_consume_string(key_file, group, "installed.transaction", NULL);
-	slotstatus->installed_timestamp = key_file_consume_string(key_file, group, "installed.timestamp", NULL);
+	timestamp = key_file_consume_string(key_file, group, "installed.timestamp", NULL);
+	if (timestamp) {
+		slotstatus->installed_timestamp = g_date_time_new_from_iso8601(timestamp, NULL);
+		if (!slotstatus->installed_timestamp)
+			g_warning("Cannot parse slot 'installed' timestamp '%s'", timestamp);
+		g_free(timestamp);
+	}
 	count = g_key_file_get_uint64(key_file, group, "installed.count", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE))
 		g_message("Value of key \"installed.count\" in group [%s] "
@@ -49,7 +55,13 @@ static void status_file_get_slot_status(GKeyFile *key_file, const gchar *group, 
 	}
 	slotstatus->installed_count = count;
 
-	slotstatus->activated_timestamp = key_file_consume_string(key_file, group, "activated.timestamp", NULL);
+	timestamp = key_file_consume_string(key_file, group, "activated.timestamp", NULL);
+	if (timestamp) {
+		slotstatus->activated_timestamp = g_date_time_new_from_iso8601(timestamp, NULL);
+		if (!slotstatus->activated_timestamp)
+			g_warning("Cannot parse slot 'activated' timestamp '%s'", timestamp);
+		g_free(timestamp);
+	}
 	count = g_key_file_get_uint64(key_file, group, "activated.count", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE))
 		g_message("Value of key \"activated.count\" in group [%s] "
@@ -94,7 +106,8 @@ static void status_file_set_slot_status(GKeyFile *key_file, const gchar *group, 
 	status_file_set_string_or_remove_key(key_file, group, "installed.transaction", slotstatus->installed_txn);
 
 	if (slotstatus->installed_timestamp) {
-		g_key_file_set_string(key_file, group, "installed.timestamp", slotstatus->installed_timestamp);
+		g_autofree gchar *stamp = g_date_time_format(slotstatus->installed_timestamp, RAUC_FORMAT_ISO_8601);
+		g_key_file_set_string(key_file, group, "installed.timestamp", stamp);
 	} else {
 		g_key_file_remove_key(key_file, group, "installed.timestamp", NULL);
 	}
@@ -106,7 +119,8 @@ static void status_file_set_slot_status(GKeyFile *key_file, const gchar *group, 
 	}
 
 	if (slotstatus->activated_timestamp) {
-		g_key_file_set_string(key_file, group, "activated.timestamp", slotstatus->activated_timestamp);
+		g_autofree gchar *stamp = g_date_time_format(slotstatus->activated_timestamp, RAUC_FORMAT_ISO_8601);
+		g_key_file_set_string(key_file, group, "activated.timestamp", stamp);
 	} else {
 		g_key_file_remove_key(key_file, group, "activated.timestamp", NULL);
 	}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -524,6 +524,7 @@ class System:
             "bootloader": "grub",
             "grubenv": "grubenv.test",
             "variant-name": "Default Variant",
+            "data-directory": "data-dir",
         }
         self.config["keyring"] = {
             "path": "openssl-ca/dev-ca.pem",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -420,6 +420,31 @@ def rauc_dbus_service_with_system_external(tmp_path, dbus_session_bus, create_sy
 
 
 @pytest.fixture
+def rauc_dbus_service_with_system_abc(tmp_path, dbus_session_bus, create_system_files, system):
+    system.prepare_minimal_config()
+    # add third slot group
+    system.config["slot.rootfs.2"] = {
+        "device": "images/rootfs-2",
+        "type": "raw",
+        "bootname": "C",
+    }
+    system.config["slot.appfs.2"] = {
+        "device": "images/appfs-2",
+        "type": "raw",
+        "parent": "rootfs.2",
+    }
+    system.write_config()
+    # create target devices for third slot group
+    open(tmp_path / "images/rootfs-2", mode="w").close()
+    open(tmp_path / "images/appfs-2", mode="w").close()
+    # prepare grub env for 3 slots
+    run(
+        f'grub-editenv {tmp_path}/grubenv.test set ORDER="A B C" A_TRY="0" B_TRY="0" C_TRY="0" A_OK="1" B_OK="1" C_OK="1"'
+    )
+    yield from rauc_dbus_service_helper(tmp_path, dbus_session_bus, create_system_files, system.output, "A")
+
+
+@pytest.fixture
 def rauc_dbus_service_with_system_adaptive(tmp_path, dbus_session_bus, create_system_files):
     yield from rauc_dbus_service_helper(tmp_path, dbus_session_bus, create_system_files, "adaptive-test.conf", "A")
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -421,16 +421,7 @@ def rauc_dbus_service_with_system_external(tmp_path, dbus_session_bus, create_sy
 
 @pytest.fixture
 def rauc_dbus_service_with_system_adaptive(tmp_path, dbus_session_bus, create_system_files):
-    service, bus = _rauc_dbus_service(tmp_path, "adaptive-test.conf", "A")
-
-    yield bus
-
-    service.terminate()
-    try:
-        service.wait(timeout=10)
-    except subprocess.TimeoutExpired:
-        service.kill()
-        service.wait()
+    yield from rauc_dbus_service_helper(tmp_path, dbus_session_bus, create_system_files, "adaptive-test.conf", "A")
 
 
 class Bundle:

--- a/test/crypt-test.conf
+++ b/test/crypt-test.conf
@@ -5,6 +5,7 @@ compatible=Test Config
 bootloader=grub
 grubenv=grubenv.test
 variant-name=Default Variant
+data-directory=data-dir
 
 [keyring]
 path=openssl-ca/dev-ca.pem

--- a/test/status_file.c
+++ b/test/status_file.c
@@ -340,14 +340,12 @@ boot-id=e02a2afe-cf45-4d50-a3f3-c223ca0f480a\n\
 	pathname = write_tmp_file(fixture->tmpdir, "existing_system_status.raucs", status_file, NULL);
 	g_assert_nonnull(pathname);
 
+	/* context setup will load/init status of all configured slots */
+
 	replace_strdup(&r_context()->config->statusfile_path, pathname);
 
+	/* pick any slot for saving */
 	slot = g_hash_table_lookup(r_context()->config->slots, "rootfs.0");
-
-	slot->status = g_new0(RaucSlotStatus, 1);
-	slot->status->status = g_strdup("ok");
-	slot->status->checksum.type = G_CHECKSUM_SHA256;
-	slot->status->checksum.digest = g_strdup("dc626520dcd53a22f727af3ee42c770e56c97a64fe3adb063799d8ab032fe551");
 
 	/* assert error-free saving*/
 	res = r_slot_status_save(slot, &ierror);
@@ -360,9 +358,9 @@ boot-id=e02a2afe-cf45-4d50-a3f3-c223ca0f480a\n\
 	g_assert_no_error(ierror);
 	g_assert_true(res);
 
-	/* assert loaded key file contains both existing [system] group and added slot status group*/
+	/* assert loaded key file contains both existing [system] group and added slot status groups */
 	groups = g_key_file_get_groups(keyfile, &num_groups);
-	g_assert_cmpint(num_groups, ==, 2);
+	g_assert_cmpint(num_groups, ==, 6);
 	g_assert_true(g_strv_contains((const gchar * const *)groups, "system"));
 	g_assert_true(g_strv_contains((const gchar * const *)groups, "slot.rootfs.0"));
 }

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -160,6 +160,32 @@ def test_install_rauc_external(rauc_dbus_service_with_system_external, tmp_path)
     assert os.path.getsize(tmp_path / "images/rootfs-0") > 0
 
 
+def test_install_abc(rauc_dbus_service_with_system_abc, tmp_path):
+    assert os.path.exists(tmp_path / "images/rootfs-1")
+    assert not os.path.getsize(tmp_path / "images/rootfs-1") > 0
+    assert os.path.exists(tmp_path / "images/rootfs-2")
+    assert not os.path.getsize(tmp_path / "images/rootfs-2") > 0
+
+    # copy to tmp path for safe ownership check
+    shutil.copyfile("good-verity-bundle.raucb", tmp_path / "good-verity-bundle.raucb")
+
+    # First installation should update rootfs-1 (implementation-defined)
+    out, err, exitcode = run(f"rauc install {tmp_path}/good-verity-bundle.raucb")
+
+    assert exitcode == 0
+    assert os.path.getsize(tmp_path / "images/rootfs-0") == 0
+    assert os.path.getsize(tmp_path / "images/rootfs-1") > 0
+    assert os.path.getsize(tmp_path / "images/rootfs-2") == 0
+
+    # Second installation should update rootfs-2 (implementation-defined)
+    out, err, exitcode = run(f"rauc install {tmp_path}/good-verity-bundle.raucb")
+
+    assert exitcode == 0
+    assert os.path.getsize(tmp_path / "images/rootfs-0") == 0
+    assert os.path.getsize(tmp_path / "images/rootfs-1") > 0
+    assert os.path.getsize(tmp_path / "images/rootfs-2") > 0
+
+
 @no_service
 def test_install_no_service(tmp_path, create_system_files, system):
     assert os.path.exists(tmp_path / "images/rootfs-1")

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -151,6 +151,13 @@ def test_install_rauc_external(rauc_dbus_service_with_system_external, tmp_path)
 
     assert exitcode == 0
     assert os.path.getsize(tmp_path / "images/rootfs-1") > 0
+    assert os.path.getsize(tmp_path / "images/rootfs-0") == 0
+
+    out, err, exitcode = run(f"rauc install {tmp_path}/good-bundle.raucb")
+
+    assert exitcode == 0
+    assert os.path.getsize(tmp_path / "images/rootfs-1") > 0
+    assert os.path.getsize(tmp_path / "images/rootfs-0") > 0
 
 
 @no_service

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -1,5 +1,6 @@
 from conftest import have_grub, no_service
 from helper import run
+import json
 
 
 @no_service
@@ -56,6 +57,21 @@ def test_status_mark_good_non_bootslot(rauc_no_service):
     out, err, exitcode = run(f"{rauc_no_service} --override-boot-slot=A status mark-good bootloader.0")
 
     assert exitcode == 1
+
+
+@have_grub
+def test_status_mark_bad_other(rauc_dbus_service_with_system_abc):
+    out, err, exitcode = run("rauc status mark-bad other")
+    assert exitcode == 0
+
+    out, err, exitcode = run("rauc status --output-format=json")
+    assert exitcode == 0
+
+    status = json.loads(out)
+
+    for slotname, property in status["slots"][0].items():
+        if property["state"] != "booted" and property["class"] == "rootfs":
+            assert property["boot_status"] == "bad"
 
 
 @have_grub


### PR DESCRIPTION
Marking multiple slots with "rauc status mark-{bad,good} other" only works for two slots.
As this behavior might not be intentional, this PR implements support for setups with more than two slots. So now when using the command above more than two slots can be marked.

In order to write test cases I rebased my patches onto the following PR [1].
This avoids reinventing the wheel by using the ABC config and fixtures used in their PR.

[1] https://github.com/rauc/rauc/pull/1525