### PR TITLE
test: Support Testing Boot Status Changes

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -346,7 +346,7 @@ def create_system_files(env_setup, tmp_path):
     os.symlink(os.path.abspath("openssl-ca"), tmp_path / "openssl-ca")
     os.symlink(os.path.abspath("openssl-enc"), tmp_path / "openssl-enc")
 
-    run(f'grub-editenv {tmp_path}/grubenv.test set ORDER="A B" A_TRY="0" B_TRY="0" A_OK="1" B_OK="1"')
+    run(f'grub-editenv {tmp_path}/grubenv.test set ORDER="A B" A_TRY="0" B_TRY="0" A_OK="1" B_OK="0"')
 
 
 @pytest.fixture

--- a/test/helper.py
+++ b/test/helper.py
@@ -49,3 +49,18 @@ def run(command, *, timeout=30):
 
 def run_tree(path):
     subprocess.check_call(["tree", "--metafirst", "-ax", "-pugs", "--inodes", path])
+
+
+def slot_data_from_json(status_data, slotname):
+    """
+    Helper to return the slot data from 'rauc status' JSON output.
+
+    :param status_data: JSON data obtained from 'rauc status'.
+    :param slotname: The name of the slot to find in the data.
+    :return: Slot data as a dictionary.
+    """
+    for slot in status_data["slots"]:
+        if slotname in slot:
+            return slot[slotname]
+    else:
+        raise ValueError(f"Slot '{slotname}' not found")


### PR DESCRIPTION
So far we had no assertions testing that the boot selection backend actually changes the boot status on installation or manually `mark-*` calls. Here we add basic support for testing this.