### PR TITLE
Add option to prevent fallback

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -244,6 +244,9 @@ Example configuration:
   It has no effect for ``plain`` bundles, as the signature verification already checks the
   whole bundle.
 
+``prevent-fallback=<true/false>`` (optional)
+  Prevent booting into another slot than the one that is currently marked as good.
+
 .. _keyring-section:
 
 ``[keyring]`` Section

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -244,8 +244,13 @@ Example configuration:
   It has no effect for ``plain`` bundles, as the signature verification already checks the
   whole bundle.
 
-``prevent-fallback=<true/false>`` (optional)
-  Prevent booting into another slot than the one that is currently marked as good.
+``prevent-late-fallback=<true/false>`` (optional)
+  In some use-cases, fallback to an older version must be prevented after the
+  update is completed successfully ('rauc status mark-good' executed from the
+  new version).
+  If this option is enabled, RAUC will execute the equivalent of 'rauc status
+  mark-bad other' after marking the currently booted slot as good.
+  This means that the other slot(s) is/are no longer eligible for fallback.
 
 .. _keyring-section:
 

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -49,6 +49,8 @@ typedef struct {
 	gchar *grubenv_path;
 	gchar *custom_bootloader_backend;
 	gboolean efi_use_bootnext;
+	/** prevent fallback after successfully booting into primary slot*/
+	gboolean prevent_fallback;
 	/* maximum filesize to download in bytes */
 	guint64 max_bundle_download_size;
 	/* path prefix where rauc may create mount directories */

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -49,8 +49,8 @@ typedef struct {
 	gchar *grubenv_path;
 	gchar *custom_bootloader_backend;
 	gboolean efi_use_bootnext;
-	/** prevent fallback after successfully booting into primary slot*/
-	gboolean prevent_fallback;
+	/** prevent fallback after successfully booting into primary slot */
+	gboolean prevent_late_fallback;
 	/* maximum filesize to download in bytes */
 	guint64 max_bundle_download_size;
 	/* path prefix where rauc may create mount directories */

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -928,6 +928,16 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	if (dtbvariant)
 		c->system_variant_type = R_CONFIG_SYS_VARIANT_DTB;
 
+	c->prevent_fallback = g_key_file_get_boolean(key_file, "system", "prevent-fallback", &ierror);
+	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+		c->prevent_fallback = FALSE;
+		g_clear_error(&ierror);
+	} else if (ierror) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+	g_key_file_remove_key(key_file, "system", "prevent-fallback", NULL);
+
 	/* parse 'variant-file' key */
 	variant_data = key_file_consume_string(key_file, "system", "variant-file", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -928,15 +928,15 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	if (dtbvariant)
 		c->system_variant_type = R_CONFIG_SYS_VARIANT_DTB;
 
-	c->prevent_fallback = g_key_file_get_boolean(key_file, "system", "prevent-fallback", &ierror);
+	c->prevent_late_fallback = g_key_file_get_boolean(key_file, "system", "prevent-late-fallback", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
-		c->prevent_fallback = FALSE;
+		c->prevent_late_fallback = FALSE;
 		g_clear_error(&ierror);
 	} else if (ierror) {
 		g_propagate_error(error, ierror);
 		return FALSE;
 	}
-	g_key_file_remove_key(key_file, "system", "prevent-fallback", NULL);
+	g_key_file_remove_key(key_file, "system", "prevent-late-fallback", NULL);
 
 	/* parse 'variant-file' key */
 	variant_data = key_file_consume_string(key_file, "system", "variant-file", &ierror);

--- a/src/mark.c
+++ b/src/mark.c
@@ -230,7 +230,7 @@ gboolean mark_run(const gchar *state,
 			return FALSE;
 		}
 
-		if (r_context()->config->prevent_fallback
+		if (r_context()->config->prevent_late_fallback
 		    && g_strcmp0(slot_identifier, "booted") == 0) {
 			g_autofree gchar *mark_bad_message = NULL;
 

--- a/src/mark.c
+++ b/src/mark.c
@@ -229,6 +229,16 @@ gboolean mark_run(const gchar *state,
 			*message = g_strdup(ierror->message);
 			return FALSE;
 		}
+
+		if (r_context()->config->prevent_fallback
+		    && g_strcmp0(slot_identifier, "booted") == 0) {
+			g_autofree gchar *mark_bad_message = NULL;
+
+			if (!mark_run("bad", "other", NULL, &mark_bad_message)) {
+				*message = g_strdup(mark_bad_message);
+				return FALSE;
+			}
+		}
 	} else if (g_strcmp0(state, "bad") == 0) {
 		for (GList *l = slots; l != NULL; l = l->next) {
 			RaucSlot *slot = l->data;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -392,26 +392,8 @@ def rauc_dbus_service_with_system_adaptive(tmp_path, dbus_session_bus, create_sy
 
 @pytest.fixture
 def rauc_dbus_service_with_system_abc(tmp_path, dbus_session_bus, create_system_files, system):
-    system.prepare_minimal_config()
-    # add third slot group
-    system.config["slot.rootfs.2"] = {
-        "device": "images/rootfs-2",
-        "type": "raw",
-        "bootname": "C",
-    }
-    system.config["slot.appfs.2"] = {
-        "device": "images/appfs-2",
-        "type": "raw",
-        "parent": "rootfs.2",
-    }
+    system.prepare_abc_config()
     system.write_config()
-    # create target devices for third slot group
-    open(tmp_path / "images/rootfs-2", mode="w").close()
-    open(tmp_path / "images/appfs-2", mode="w").close()
-    # prepare grub env for 3 slots
-    run(
-        f'grub-editenv {tmp_path}/grubenv.test set ORDER="A B C" A_TRY="0" B_TRY="0" C_TRY="0" A_OK="1" B_OK="1" C_OK="1"'
-    )
     with system.running_service("A"):
         yield system.proxy
 
@@ -559,6 +541,27 @@ class System:
             "pre-install": "bin/preinstall.sh",
             "post-install": "bin/postinstall.sh",
         }
+
+    def prepare_abc_config(self):
+        self.prepare_minimal_config()
+        # add third slot group
+        self.config["slot.rootfs.2"] = {
+            "device": "images/rootfs-2",
+            "type": "raw",
+            "bootname": "C",
+        }
+        self.config["slot.appfs.2"] = {
+            "device": "images/appfs-2",
+            "type": "raw",
+            "parent": "rootfs.2",
+        }
+        # create target devices for third slot group
+        open(self.tmp_path / "images/rootfs-2", mode="w").close()
+        open(self.tmp_path / "images/appfs-2", mode="w").close()
+        # prepare grub env for 3 slots
+        run(
+            f'grub-editenv {self.tmp_path}/grubenv.test set ORDER="A B C" A_TRY="0" B_TRY="0" C_TRY="0" A_OK="1" B_OK="1" C_OK="1"'
+        )
 
     def write_config(self):
         with open(self.output, "w") as f:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -390,6 +390,32 @@ def rauc_dbus_service_with_system_adaptive(tmp_path, dbus_session_bus, create_sy
         yield system.proxy
 
 
+@pytest.fixture
+def rauc_dbus_service_with_system_abc(tmp_path, dbus_session_bus, create_system_files, system):
+    system.prepare_minimal_config()
+    # add third slot group
+    system.config["slot.rootfs.2"] = {
+        "device": "images/rootfs-2",
+        "type": "raw",
+        "bootname": "C",
+    }
+    system.config["slot.appfs.2"] = {
+        "device": "images/appfs-2",
+        "type": "raw",
+        "parent": "rootfs.2",
+    }
+    system.write_config()
+    # create target devices for third slot group
+    open(tmp_path / "images/rootfs-2", mode="w").close()
+    open(tmp_path / "images/appfs-2", mode="w").close()
+    # prepare grub env for 3 slots
+    run(
+        f'grub-editenv {tmp_path}/grubenv.test set ORDER="A B C" A_TRY="0" B_TRY="0" C_TRY="0" A_OK="1" B_OK="1" C_OK="1"'
+    )
+    with system.running_service("A"):
+        yield system.proxy
+
+
 class Bundle:
     def __init__(self, tmp_path, name=None):
         if name is None:

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -62,6 +62,28 @@ def test_status_mark_good_non_bootslot(rauc_no_service):
 
 
 @have_grub
+def test_status_mark_bad_other(rauc_dbus_service_with_system_abc):
+    out, err, exitcode = run("rauc status --output-format=json")
+    assert exitcode == 0
+    status = json.loads(out)
+
+    for slotname, property in status["slots"][0].items():
+        if property["state"] != "booted" and property["class"] == "rootfs":
+            assert property["boot_status"] == "good"
+
+    out, err, exitcode = run("rauc status mark-bad other")
+    assert exitcode == 0
+
+    out, err, exitcode = run("rauc status --output-format=json")
+    assert exitcode == 0
+    status = json.loads(out)
+
+    for slotname, property in status["slots"][0].items():
+        if property["state"] != "booted" and property["class"] == "rootfs":
+            assert property["boot_status"] == "bad"
+
+
+@have_grub
 def test_status_mark_good_dbus(rauc_dbus_service_with_system):
     out, err, exitcode = run("rauc status --output-format=json-pretty")
     assert exitcode == 0

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -73,7 +73,7 @@ def test_status_mark_good_dbus(rauc_dbus_service_with_system):
     out, err, exitcode = run("rauc status mark-good")
 
     assert exitcode == 0
-    assert "marked slot rootfs.0 as good" in out
+    assert "marked slot(s) rootfs.0 as good" in out
 
     out, err, exitcode = run("rauc status --output-format=json-pretty")
     assert exitcode == 0
@@ -97,7 +97,7 @@ def test_status_mark_bad_dbus(rauc_dbus_service_with_system):
     out, err, exitcode = run("rauc status mark-bad")
 
     assert exitcode == 0
-    assert "marked slot rootfs.0 as bad" in out
+    assert "marked slot(s) rootfs.0 as bad" in out
 
     # check post-condition
     out, err, exitcode = run("rauc status --output-format=json-pretty")
@@ -123,7 +123,7 @@ def test_status_mark_active_dbus(rauc_dbus_service_with_system):
     out, err, exitcode = run("rauc status mark-active other")
 
     assert exitcode == 0
-    assert "activated slot rootfs.1" in out
+    assert "rootfs.1 as active" in out
 
     # check post-condition
     out, err, exitcode = run("rauc status --output-format=json-pretty")


### PR DESCRIPTION
This PR aims to implement an option that automatically marks all _other_ slots as bad when the booted one is marked as good. This can be used to ensure not booting into the previous used slot after installing a new rootfs. The option is called "prevent-fallback" and can be set in the _system_ section.

For example:

``` ini
[system]
compatible=My BSP
bootloader=barebox
bundle-formats=-plain
data-directory=/data/rauc
prevent-late-fallback=true
....
```

The main logic for this patch is mostly based on the underlying "mark-bad other" command.
In order to make the prevent-fallback option to work for more than two slots, I have reworked the _get_slot_by_identifier_ function to be able to return more than one slot.

For the test case I decided to only test the "mark-bad other" command as the prevent-fallback option simply calls this command. I used the ABC pytest fixture from [38f7a2f8eac](https://github.com/rauc/rauc/commit/38cb2e4b4aed8ad1a5c5f1af0884938f7a2f8eac) for my test.

There is one minor issue with this PR, which is the message handling in the _mark_run_ function. When the fallback option is enabled, we call the _mark_run_ method recursively which results in overriding the variables _message_ and _slot_name_. This results in information loss as only the last call  sets the variables properly. One possible solution to fix this is by concatenating the messages and slot_names in some way?
