### PR TITLE
Check the slot status in case of reinstalling of failed slot

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -1111,7 +1111,7 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
 	}
 
 	/* if explicitly enabled, skip update of up-to-date slots */
-	if (!plan->target_slot->install_same && g_strcmp0(plan->image->checksum.digest, slot_state->checksum.digest) == 0) {
+	if (!plan->target_slot->install_same && g_strcmp0(slot_state->status, "ok") == 0 && g_strcmp0(plan->image->checksum.digest, slot_state->checksum.digest) == 0) {
 		install_args_update(args, "Skipping update for correct image '%s'", plan->image->filename);
 		g_message("Skipping update for correct image '%s'", plan->image->filename);
 		r_context_end_step("check_slot", TRUE);


### PR DESCRIPTION
<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->
This PR aims to fix slot selection by checking slot status with the checksum incase of reinstalling bad slot with the same image
<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
Fixes: #1554