### PR TITLE
Optional syslog support

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1410,6 +1410,7 @@ Command Line Tool
     --keyring=PEMFILE                   keyring file
     --mount=PATH                        mount prefix
     -d, --debug                         enable debug output
+    -s, --syslog=[facility]             enable syslog output, optional facility, default: daemon
     --version                           display version
     -h, --help                          display help and exit
 

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,8 @@
 #include <locale.h>
 #include <stdio.h>
 #include <string.h>
+#define SYSLOG_NAMES
+#include <syslog.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
@@ -2684,6 +2686,67 @@ static gboolean collect_config_values(const gchar *option_name, const gchar *val
 	return TRUE;
 }
 
+static int log_level(GLogLevelFlags level)
+{
+	if (level & G_LOG_FLAG_FATAL)
+		return LOG_EMERG;
+	if (level & G_LOG_FLAG_RECURSION)
+		return LOG_ALERT;
+	if (level & G_LOG_LEVEL_CRITICAL)
+		return LOG_CRIT;
+	if (level & G_LOG_LEVEL_ERROR)
+		return LOG_ERR;
+	if (level & G_LOG_LEVEL_WARNING)
+		return LOG_WARNING;
+	if (level & G_LOG_LEVEL_MESSAGE)
+		return LOG_NOTICE;
+	if (level & G_LOG_LEVEL_INFO)
+		return LOG_INFO;
+	if (level & G_LOG_LEVEL_DEBUG)
+		return LOG_DEBUG;
+
+	return LOG_INFO;       /* Fallback to INFO for unknown levels */
+}
+
+static void syslog_handler(const gchar *domain, GLogLevelFlags level, const gchar *message, gpointer arg)
+{
+	int prio = log_level(level);
+
+	if (g_strcmp0(domain, G_LOG_DOMAIN))
+		syslog(prio, "%s: %s", domain, message);
+	else
+		syslog(prio, "%s", message);
+}
+
+static gboolean syslog_option_cb(const gchar *option_name, const gchar *value,
+		gpointer data, GError **error)
+{
+	int facility = LOG_DAEMON;
+
+	if (value) {
+		gboolean found = FALSE;
+
+		for (const CODE *f = facilitynames; f->c_name != NULL; f++) {
+			if (g_ascii_strcasecmp(value, f->c_name) == 0) {
+				facility = f->c_val;
+				found = TRUE;
+				break;
+			}
+		}
+
+		if (!found) {
+			g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+					"Invalid syslog facility: %s", value);
+			return FALSE;
+		}
+	}
+
+	openlog(G_LOG_DOMAIN, LOG_PID | LOG_NOWAIT, facility);
+	g_log_set_default_handler(syslog_handler, NULL);
+
+	return TRUE;
+}
+
 static void cmdline_handler(int argc, char **argv)
 {
 	gboolean help = FALSE, debug = FALSE, version = FALSE;
@@ -2700,6 +2763,7 @@ static void cmdline_handler(int argc, char **argv)
 		{"intermediate", '\0', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_FILENAME_ARRAY, &intermediate, "intermediate CA file or PKCS#11 URL", "PEMFILE|PKCS11-URL"},
 		{"mount", '\0', 0, G_OPTION_ARG_FILENAME, &mount, "mount prefix", "PATH"},
 		{"debug", 'd', 0, G_OPTION_ARG_NONE, &debug, "enable debug output", NULL},
+		{"syslog", 's', G_OPTION_FLAG_OPTIONAL_ARG, G_OPTION_ARG_CALLBACK,  syslog_option_cb, "enable syslog output, optional facility, default: daemon", "[facility]"},
 		{"version", '\0', 0, G_OPTION_ARG_NONE, &version, "display version", NULL},
 		{"help", 'h', 0, G_OPTION_ARG_NONE, &help, "display help and exit", NULL},
 		{0}

--- a/test/meson.build
+++ b/test/meson.build
@@ -92,6 +92,7 @@ if pytest.found()
     'replace_signature',
     'resign',
     'service',
+    'syslog',
     'sign',
     'status',
     'verify',

--- a/test/test_syslog.py
+++ b/test/test_syslog.py
@@ -1,0 +1,88 @@
+import os
+import re
+import socket
+import subprocess
+import threading
+import time
+from pathlib import Path
+import pytest
+
+
+def _run_syslog_test(tmp_path, syslog_arg, expect_success=True):
+    """Helper function to run syslog test with given syslog argument"""
+    log_path = "/dev/log"
+    messages = []
+
+    def listener(sock):
+        while True:
+            try:
+                data = sock.recv(1024)
+                if data:
+                    messages.append(data.decode("utf-8", errors="ignore"))
+                else:
+                    break
+            except OSError:
+                break
+
+    if Path(log_path).exists():
+        pytest.skip("/dev/log already exists, is a syslog daemon running?")
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    try:
+        sock.bind(log_path)
+    except (PermissionError, OSError):
+        pytest.skip("Cannot bind to /dev/log, likely in cross env.")
+
+    threading.Thread(target=listener, args=(sock,), daemon=True).start()
+
+    try:
+        env = os.environ.copy()
+        env["RAUC_PYTEST_TMP"] = str(tmp_path)
+
+        cmd = [
+            "rauc",
+            "service",
+            f"--conf={tmp_path / 'system.conf'}",
+            f"--mount={tmp_path}/mnt",
+            "--override-boot-slot=A",
+            syslog_arg,
+        ]
+
+        proc = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        time.sleep(2)
+        proc.terminate()
+        exit_code = proc.wait(timeout=5)
+
+        if expect_success:
+            assert len(messages) > 0, "No syslog messages logged to /dev/log"
+
+            pat = r"<\d+>.*\s+rauc\[\d+\]:"
+            rauc_messages = [msg for msg in messages if re.search(pat, msg)]
+            assert len(rauc_messages) > 0, "No valid syslog messages from rauc found"
+
+            pat = r"<\d+>.*rauc\[\d+\]:.*service start"
+            assert any(re.search(pat, msg) for msg in rauc_messages), "No 'service start' syslog message found"
+        else:
+            assert exit_code != 0, "Expected rauc service to fail with invalid syslog facility"
+
+    finally:
+        sock.close()
+        if Path(log_path).exists():
+            os.unlink(log_path)
+
+
+@pytest.mark.parametrize("syslog_arg", ["--syslog", "--syslog=local0"])
+def test_syslog(rauc_dbus_service_with_system, tmp_path, syslog_arg):
+    """Check syslog messages from rauc with different syslog options"""
+    _run_syslog_test(tmp_path, syslog_arg, expect_success=True)
+
+
+def test_syslog_invalid(rauc_dbus_service_with_system, tmp_path):
+    """Check that invalid syslog facility causes rauc service to fail"""
+    _run_syslog_test(tmp_path, "--syslog=undefined", expect_success=False)


### PR DESCRIPTION
This pull request adds an optional syslog backend alternative to the default stdout/stderr logging.  It is primarily intended for systems using RAUC without systemd, e.g., an embedded system built around BusyBox init.

It is of course possible to use RAUC as-is on non-systemd systems, however with this patch users avoid ANSI escape sequences (color) in their logs and can perform severity based filtering for remote logging of critical events.

We use an earlier version of this patch in the [Infix NOS](https://github.com/kernelkit/infix/).  This updated version adds configurable facility support and also ensures to replace the default logger.
