### PR TITLE
src/update_handler: ignore mount error before running slot hook

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1424,12 +1424,12 @@ static gboolean mount_and_run_slot_hook(const gchar *hook_name, const gchar *hoo
 	g_assert_nonnull(hook_name);
 	g_assert_nonnull(hook_cmd);
 
-	/* mount slot */
+	/* try mount slot */
 	g_message("Mounting slot %s", slot->device);
 	res = r_mount_slot(slot, &ierror);
 	if (!res) {
-		g_propagate_error(error, ierror);
-		goto out;
+		g_warning("Ignoring mount error before slot hook error: %s", ierror->message);
+		g_clear_error(&ierror);
 	}
 
 	/* run slot install hook */
@@ -1438,6 +1438,10 @@ static gboolean mount_and_run_slot_hook(const gchar *hook_name, const gchar *hoo
 	if (!res) {
 		g_propagate_error(error, ierror);
 	}
+
+	/* slot not mounted */
+	if (slot->mount_point == NULL)
+		return res;
 
 	/* finally umount slot */
 	g_message("Unmounting slot %s", slot->device);
@@ -1453,7 +1457,6 @@ static gboolean mount_and_run_slot_hook(const gchar *hook_name, const gchar *hoo
 		}
 	}
 
-out:
 	return res;
 }
 


### PR DESCRIPTION
The handler mounts the other-slot filesystem, and it returns in error if it fails to mount it.

The filesystem may be in bad health, or may be not yet made, and thus, it causes the handler to fail.

As a consequence, it results in a slot that is unupdatable until the filesystem is remade manually (i.e. externally).

This ignores the mount error before the slot hook is run, and leaves the hook to decide whether or not to fail.

---

Hello,

This PR intends to fix an issue if installing a bundle with a pre-install slot hook, on the device slot A system, with the slot B partitions created, but without the filesystems made yet.

The handler function [img_to_raw_handler()](https://github.com/rauc/rauc/blob/e3956840291874dce6a7734d19eef62c50c5fa66/src/update_handler.c#L2527) runs the [pre_install](https://github.com/rauc/rauc/blob/e3956840291874dce6a7734d19eef62c50c5fa66/src/update_handler.c#L2533-2539) hook and fails because the filesystem is not made yet. I will be ~~made~~ copy right after by the function [write_image_to_dev()](https://github.com/rauc/rauc/blob/e3956840291874dce6a7734d19eef62c50c5fa66/src/update_handler.c#L2542).

(Well, I supposed it comes from that handler, I have not checked it).

With this PR, I am suggesting to ignore mount failure in function [mount_and_run_slot_hook()](https://github.com/rauc/rauc/blob/e3956840291874dce6a7734d19eef62c50c5fa66/src/update_handler.c#L1429-L1433). This fixes the issue I am facing; however, I guess it may have some side-effects and I am not convinced yet.

What are you opinions?

The issue can be reproduced easily:
 - generate a bundle with a pre-hook,
 - corrupt the other filesystem slot (`dd if=/dev/zero of=/dev/other-slot`), and
 - install the bundle (`rauc install bundle.raucb`). 

Regards,
Gaël

---

Here are the failing logs on 1.12:

```
# journalctl -u rauc | cat
Oct 08 15:42:35 buildroot systemd[1]: Starting RAUC Update Service...
Oct 08 15:42:35 buildroot rauc[305]: Using central status file /boot/rauc/central.raucs
Oct 08 15:42:35 buildroot rauc[305]: Failed to load system status: No such file or directory
Oct 08 15:42:35 buildroot rauc[305]: Getting Systeminfo: /usr/lib/raspberrypi-firmware-rauc-bootloader-backend/system-info
Oct 08 15:42:35 buildroot rauc[305]: Booted into rootfs.0 (ROOTFS-A)
Oct 08 15:42:35 buildroot systemd[1]: Started RAUC Update Service.
Oct 08 15:42:36 buildroot rauc[305]: Marked slot rootfs.0 as good
Oct 08 15:42:36 buildroot rauc[305]: rauc mark: marked slot rootfs.0 as good
Jan 10 16:54:53 buildroot rauc[305]: input bundle: /tmp/buildroot.raucb
Jan 10 16:54:53 buildroot rauc[305]: Active slot bootname: /dev/mmcblk0p5
Jan 10 16:54:53 buildroot rauc[305]: installing /tmp/buildroot.raucb: started
Jan 10 16:54:53 buildroot rauc[305]: Installation 0f629fe9 started
Jan 10 16:54:53 buildroot rauc[305]: installing /tmp/buildroot.raucb: Checking and mounting bundle...
Jan 10 16:54:53 buildroot rauc[305]: Reading bundle: /tmp/buildroot.raucb
Jan 10 16:54:53 buildroot rauc[305]: Detected CRL but CRL checking is disabled!
Jan 10 16:54:53 buildroot rauc[305]: Verifying bundle signature... 
Jan 10 16:54:54 buildroot rauc[305]: Verified detached signature by 'O = Test Org, CN = Test Org Release-1'
Jan 10 16:54:54 buildroot rauc[305]: Mounting bundle '/tmp/buildroot.raucb' to '/run/rauc/bundle'
Jan 10 16:54:54 buildroot rauc[305]: Configured loop device '/dev/loop0' for 51494912 bytes
Jan 10 16:54:54 buildroot rauc[305]: Checking image type for slot type: ext4
Jan 10 16:54:54 buildroot rauc[305]: Image detected as type: *.ext4
Jan 10 16:54:54 buildroot rauc[305]: Checking image type for slot type: vfat
Jan 10 16:54:54 buildroot rauc[305]: Image detected as type: *.vfat
Jan 10 16:54:54 buildroot rauc[305]: Marking target slot rootfs.1 as non-bootable...
Jan 10 16:54:54 buildroot rauc[305]: Marked slot rootfs.1 as bad
Jan 10 16:54:54 buildroot rauc[305]: installing /tmp/buildroot.raucb: Updating slots...
Jan 10 16:54:54 buildroot rauc[305]: installing /tmp/buildroot.raucb: Checking slot rootfs.1
Jan 10 16:54:54 buildroot rauc[305]: Updating slot rootfs.1
Jan 10 16:54:54 buildroot rauc[305]: installing /tmp/buildroot.raucb: Updating slot rootfs.1
Jan 10 16:54:54 buildroot rauc[305]: Updating /dev/mmcblk0p6 with /run/rauc/bundle/rootfs.ext4
Jan 10 16:54:54 buildroot rauc[305]: Mounting slot /dev/mmcblk0p6
Jan 10 16:54:54 buildroot rauc[366]: mount: /run/rauc/rootfs.1: wrong fs type, bad option, bad superblock on /dev/mmcblk0p6, missing codepage or helper program, or other error.
Jan 10 16:54:54 buildroot rauc[366]:        dmesg(1) may have more information after failed mount system call.
Jan 10 16:54:54 buildroot rauc[305]: Updating slot rootfs.1 status
Jan 10 16:54:54 buildroot rauc[305]: Installation 0f629fe9 failed: Installation error: Failed updating slot rootfs.1: failed to mount slot: failed to run mount: Child process exited with code 32
Jan 10 16:54:54 buildroot rauc[305]: Installation error: Failed updating slot rootfs.1: failed to mount slot: failed to run mount: Child process exited with code 32
Jan 10 16:54:54 buildroot rauc[305]: installing /tmp/buildroot.raucb: Installation error: Failed updating slot rootfs.1: failed to mount slot: failed to run mount: Child process exited with code 32
Jan 10 16:54:54 buildroot rauc[305]: installing /tmp/buildroot.raucb: finished
Jan 10 16:54:54 buildroot rauc[305]: installing `/tmp/buildroot.raucb` failed: 1
```

Here are the logs on 1.12 + PR:
```
# journalctl -u rauc | cat
Oct 08 15:42:35 buildroot systemd[1]: Starting RAUC Update Service...
Oct 08 15:42:35 buildroot rauc[303]: Using central status file /boot/rauc/central.raucs
Oct 08 15:42:35 buildroot rauc[303]: Failed to load system status: No such file or directory
Oct 08 15:42:35 buildroot rauc[303]: Getting Systeminfo: /usr/lib/raspberrypi-firmware-rauc-bootloader-backend/system-info
Oct 08 15:42:35 buildroot rauc[303]: Booted into rootfs.0 (ROOTFS-A)
Oct 08 15:42:35 buildroot systemd[1]: Started RAUC Update Service.
Oct 08 15:42:36 buildroot rauc[303]: Marked slot rootfs.0 as good
Oct 08 15:42:36 buildroot rauc[303]: rauc mark: marked slot rootfs.0 as good
Jan 10 16:58:04 buildroot rauc[303]: input bundle: /tmp/buildroot.raucb
Jan 10 16:58:04 buildroot rauc[303]: Active slot bootname: /dev/mmcblk0p5
Jan 10 16:58:04 buildroot rauc[303]: installing /tmp/buildroot.raucb: started
Jan 10 16:58:04 buildroot rauc[303]: Installation 8c72cc7c started
Jan 10 16:58:04 buildroot rauc[303]: installing /tmp/buildroot.raucb: Checking and mounting bundle...
Jan 10 16:58:04 buildroot rauc[303]: Reading bundle: /tmp/buildroot.raucb
Jan 10 16:58:04 buildroot rauc[303]: Detected CRL but CRL checking is disabled!
Jan 10 16:58:04 buildroot rauc[303]: Verifying bundle signature... 
Jan 10 16:58:05 buildroot rauc[303]: Verified detached signature by 'O = Test Org, CN = Test Org Release-1'
Jan 10 16:58:05 buildroot rauc[303]: Mounting bundle '/tmp/buildroot.raucb' to '/run/rauc/bundle'
Jan 10 16:58:05 buildroot rauc[303]: Configured loop device '/dev/loop0' for 51494912 bytes
Jan 10 16:58:05 buildroot rauc[303]: Checking image type for slot type: ext4
Jan 10 16:58:05 buildroot rauc[303]: Image detected as type: *.ext4
Jan 10 16:58:05 buildroot rauc[303]: Checking image type for slot type: vfat
Jan 10 16:58:05 buildroot rauc[303]: Image detected as type: *.vfat
Jan 10 16:58:05 buildroot rauc[303]: Marking target slot rootfs.1 as non-bootable...
Jan 10 16:58:05 buildroot rauc[303]: Marked slot rootfs.1 as bad
Jan 10 16:58:05 buildroot rauc[303]: installing /tmp/buildroot.raucb: Updating slots...
Jan 10 16:58:05 buildroot rauc[303]: installing /tmp/buildroot.raucb: Checking slot rootfs.1
Jan 10 16:58:05 buildroot rauc[303]: Updating slot rootfs.1
Jan 10 16:58:05 buildroot rauc[303]: Updating /dev/mmcblk0p6 with /run/rauc/bundle/rootfs.ext4
Jan 10 16:58:05 buildroot rauc[303]: Mounting slot /dev/mmcblk0p6
Jan 10 16:58:05 buildroot rauc[303]: installing /tmp/buildroot.raucb: Updating slot rootfs.1
Jan 10 16:58:05 buildroot rauc[363]: mount: /run/rauc/rootfs.1: wrong fs type, bad option, bad superblock on /dev/mmcblk0p6, missing codepage or helper program, or other error.
Jan 10 16:58:05 buildroot rauc[363]:        dmesg(1) may have more information after failed mount system call.
Jan 10 16:58:05 buildroot rauc[303]: Ignoring mount error before slot hook error: failed to mount slot: failed to run mount: Child process exited with code 32
Jan 10 16:58:05 buildroot rauc[303]: Running slot 'slot-pre-install' hook for rootfs.1
Jan 10 16:58:05 buildroot rauc[303]: Running slot hook 'slot-pre-install' for rootfs.1
Jan 10 16:58:05 buildroot rauc[303]: opening slot device /dev/mmcblk0p6
Jan 10 16:58:05 buildroot rauc[303]: writing data to device /dev/mmcblk0p6
Jan 10 16:58:23 buildroot rauc[303]: Updating slot rootfs.1 status
Jan 10 16:58:23 buildroot rauc[303]: installing /tmp/buildroot.raucb: Updating slot rootfs.1 done
Jan 10 16:58:23 buildroot rauc[303]: installing /tmp/buildroot.raucb: Checking slot firmware.1
Jan 10 16:58:23 buildroot rauc[303]: Updating slot firmware.1
Jan 10 16:58:23 buildroot rauc[303]: Updating /dev/mmcblk0p3 with /run/rauc/bundle/firmwarefs.vfat
Jan 10 16:58:23 buildroot rauc[303]: opening slot device /dev/mmcblk0p3
Jan 10 16:58:23 buildroot rauc[303]: writing data to device /dev/mmcblk0p3
Jan 10 16:58:23 buildroot rauc[303]: installing /tmp/buildroot.raucb: Updating slot firmware.1
Jan 10 16:58:27 buildroot rauc[303]: Mounting slot /dev/mmcblk0p3
Jan 10 16:58:27 buildroot rauc[303]: Running slot 'slot-post-install' hook for firmware.1
Jan 10 16:58:27 buildroot rauc[303]: Running slot hook 'slot-post-install' for firmware.1
Jan 10 16:58:27 buildroot rauc[303]: Unmounting slot /dev/mmcblk0p3
Jan 10 16:58:27 buildroot rauc[303]: Updating slot firmware.1 status
Jan 10 16:58:27 buildroot rauc[303]: installing /tmp/buildroot.raucb: Updating slot firmware.1 done
Jan 10 16:58:27 buildroot rauc[303]: Marking target slot rootfs.1 as bootable...
Jan 10 16:58:27 buildroot rauc[303]: installing /tmp/buildroot.raucb: All slots updated
Jan 10 16:58:27 buildroot rauc[377]: 0x0000001c 0x80000000 0x00038064 0x00000004 0x80000004 0x00000000 0x00000000
Jan 10 16:58:27 buildroot rauc[303]: Marked slot rootfs.1 as active
Jan 10 16:58:27 buildroot rauc[303]: Installation 8c72cc7c succeeded
Jan 10 16:58:27 buildroot rauc[303]: installing /tmp/buildroot.raucb: finished
Jan 10 16:58:27 buildroot rauc[303]: installing `/tmp/buildroot.raucb` succeeded
```

Note: I have tested it with that [custom](https://github.com/Rtone/raspberrypi-firmware-rauc-bootloader-backend/) bootloader backend, and that [pre-install](https://github.com/Rtone/rtone-br2-external/blob/main/board/raspberrypi/raspberrypi-firmware-hook.sh) slot hook. The bundle is generated by that [genimage](https://github.com/Rtone/rtone-br2-external/blob/main/board/raspberrypi/genimage.cfg#L52-L78) config file.