### PR TITLE
src/config_file: assert NULL returns for key file errors

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -260,6 +260,7 @@ static gboolean r_event_log_parse_config_sections(GKeyFile *key_file, RaucConfig
 
 		logger->events = g_key_file_get_string_list(key_file, *group, "events", &entries, &ierror);
 		if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+			g_assert_null(logger->events);
 			logger->events = g_malloc(2 * sizeof(gchar *));
 			logger->events[0] = g_strdup("all");
 			logger->events[1] = NULL;
@@ -996,6 +997,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 
 	c->statusfile_path = key_file_consume_string(key_file, "system", "statusfile", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+		g_assert_null(c->statusfile_path);
 		if (c->data_directory) {
 			c->statusfile_path = g_build_filename(c->data_directory, "central.raucs", NULL);
 		} else {
@@ -1102,7 +1104,7 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 	c->keyring_check_purpose = key_file_consume_string(key_file, "keyring", "check-purpose", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND) ||
 	    g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_GROUP_NOT_FOUND)) {
-		c->keyring_check_purpose = NULL;
+		g_assert_null(c->keyring_check_purpose);
 		g_clear_error(&ierror);
 	} else if (ierror) {
 		g_propagate_error(error, ierror);


### PR DESCRIPTION
The key files methods will return NULL when the key or group was not found. To make this clear and to fix some Coverity false-positives for potential memory leaks, add explicit `g_assert_null()` statements.

Fixes issues like:

    261     		logger->events = g_key_file_get_string_list(key_file, *group, "events", &entries, &ierror);
    262     		if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
    >>>     CID 1587498:  Resource leaks  (RESOURCE_LEAK)
    >>>     Overwriting "logger->events" in "logger->events = g_malloc(16UL)" leaks the storage that "logger->events" points to.
    263     			logger->events = g_malloc(2 * sizeof(gchar *));

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
