### PR TITLE
src/emmc: Error-Out for invalid boot partition configuration and use more explicit errors

### DIFF
--- a/include/emmc.h
+++ b/include/emmc.h
@@ -3,6 +3,14 @@
 #include <glib.h>
 #include <linux/types.h>
 
+#define R_EMMC_ERROR r_emmc_error_quark()
+GQuark r_emmc_error_quark(void);
+
+typedef enum {
+	R_EMMC_ERROR_FAILED,
+	R_EMMC_ERROR_IOCTL,
+} REmmcError;
+
 #define EMMC_BOOT_PARTITIONS			2
 #define INACTIVE_BOOT_PARTITION(part_active)	((part_active + 1) % EMMC_BOOT_PARTITIONS)
 

--- a/include/emmc.h
+++ b/include/emmc.h
@@ -9,6 +9,8 @@ GQuark r_emmc_error_quark(void);
 typedef enum {
 	R_EMMC_ERROR_FAILED,
 	R_EMMC_ERROR_IOCTL,
+	R_EMMC_ERROR_BOOTPART_UDA,
+	R_EMMC_ERROR_BOOTPART_INVALID,
 } REmmcError;
 
 #define EMMC_BOOT_PARTITIONS			2
@@ -47,9 +49,7 @@ typedef enum {
  *
  * @param device eMMC /dev path (/dev/mmcblkX)
  * @param bootpart_active will contain the active boot partition
- * (0 for mmcblkXboot0, 1 for mmcblkXboot1, 6 for mmcblkX user partition and
- * -1 for no active boot partition)
- * for user partition)
+ *        (0 for boot0, 1 for boot1, -1 for no active boot partition)
  * @param error return location for a GError, or NULL
  *
  * @return True if succeeded, False if failed

--- a/src/emmc.c
+++ b/src/emmc.c
@@ -46,7 +46,7 @@ gboolean r_emmc_read_bootpart(const gchar *device, gint *bootpart_active, GError
 
 	if (r_emmc_read_extcsd(fd, extcsd)) {
 		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
-				"Could not read from extcsd register %d in %s\n",
+				"Could not read from extcsd register %d in %s",
 				EXT_CSD_PART_CONFIG, device);
 		return FALSE;
 	}
@@ -93,7 +93,7 @@ gboolean r_emmc_write_bootpart(const gchar *device, gint bootpart_active, GError
 
 	if (r_emmc_read_extcsd(fd, extcsd)) {
 		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
-				"Could not read from extcsd register %d in %s\n",
+				"Could not read from extcsd register %d in %s",
 				EXT_CSD_PART_CONFIG, device);
 		return FALSE;
 	}
@@ -113,7 +113,7 @@ gboolean r_emmc_write_bootpart(const gchar *device, gint bootpart_active, GError
 
 	if (r_emmc_write_extcsd(fd, EXT_CSD_PART_CONFIG, value)) {
 		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
-				"Could not write 0x%02x to extcsd register %d in %s\n",
+				"Could not write 0x%02x to extcsd register %d in %s",
 				value, EXT_CSD_PART_CONFIG, device);
 		return FALSE;
 	}

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -2208,21 +2208,17 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 		g_propagate_error(error, ierror);
 		goto out;
 	}
-	switch (part_active) {
-		case -1:
-			part_active_str = g_strdup("<none>");
-			break;
-		case 6:
-			part_active_str = g_strdup(realdev);
-			break;
-		default:
-			part_active_str = g_strdup_printf("%sboot%d", realdev, part_active);
+
+	if (part_active == -1) {
+		g_warning("eMMC device was not enabled for booting, yet. Ignoring.");
+		/* For simplicity: Consider boot1 to be active */
+		part_active = 1;
+	} else {
+		g_message("Found active eMMC boot partition %sboot%d", realdev, part_active);
 	}
-	g_message("Found active eMMC boot partition %s", part_active_str);
 
 	/* create a temporary RaucSlot with the actual (currently inactive) boot
-	 * partition as device; for simplicity reasons: in case the user partition
-	 * is active use mmcblkXboot1, in case no partition is active use mmcblkXboot0
+	 * partition as device.
 	 */
 	part_slot = g_new0(RaucSlot, 1);
 	part_slot->device = g_strdup_printf(

--- a/test/test_write_slot.py
+++ b/test/test_write_slot.py
@@ -61,7 +61,7 @@ def test_write_boot_emmc(system):
     out, err, exitcode = run(f"{system.prefix} write-slot bootloader.0 install-content/rootfs.img")
     assert exitcode == 0
     assert "Slot written successfully" in out
-    assert "Found active eMMC boot partition <none>" in err
+    assert "eMMC device was not enabled for booting, yet. Ignoring." in err
     assert f"Boot partition {device}boot0 is now active" in err
 
     out, err, exitcode = run(f"{system.prefix} write-slot bootloader.0 install-content/rootfs.img")


### PR DESCRIPTION
The only valid `BOOT_PARTITION_ENABLE` bits for boot partition handling are:

    0x0: Device not boot enabled
    0x1: Boot partition 1 enabled for boot
    0x2: Boot partition 2 enabled for boot

All other values either mean boot partitions are not selected or are 'Reserved' values. Make the method `r_emmc_read_bootpart()` fail for these values with an explicit error message.

This can prevent RAUC from performing eMMC boot partition operations on actually invalid configurations.


While at it, this PR also introduces dedicated error codes in `src/emmc.c` and adds some cleanup and simplification of code.