### PR TITLE
src/bootchooser: fix spelling typo in code

### DIFF
--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -32,7 +32,7 @@ gboolean r_boot_is_supported_bootloader(const gchar *bootloader)
 	return g_strv_contains(supported_bootloaders, bootloader);
 }
 
-static GString *bootchooser_order_primay(RaucSlot *slot)
+static GString *bootchooser_order_primary(RaucSlot *slot)
 {
 	GString *order = NULL;
 	g_autoptr(GList) slots = NULL;
@@ -644,7 +644,7 @@ static gboolean grub_set_primary(RaucSlot *slot, GError **error)
 	g_return_val_if_fail(slot, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	order = bootchooser_order_primay(slot);
+	order = bootchooser_order_primary(slot);
 
 	g_ptr_array_add(pairs, g_strdup_printf("%s_OK=%i", slot->bootname, 1));
 	g_ptr_array_add(pairs, g_strdup_printf("%s_TRY=%i", slot->bootname, 0));
@@ -937,7 +937,7 @@ static gboolean uboot_set_primary(RaucSlot *slot, GError **error)
 		g_message("Unable to obtain BOOT_ORDER (%s), using defaults", ierror->message);
 		g_clear_error(&ierror);
 
-		order_current = bootchooser_order_primay(slot);
+		order_current = bootchooser_order_primary(slot);
 	}
 
 	/* Iterate over current boot order */


### PR DESCRIPTION
This fixes a spelling typo by adding the missing 'r' to the word primary in the function name bootchooser_order_primary().