### PR TITLE
refactor service startup for pytest-based tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -388,9 +388,9 @@ def _rauc_dbus_service(tmp_path, conf_file, bootslot):
 
 
 def rauc_dbus_service_helper(tmp_path, dbus_session_bus, create_system_files, config, bootname):
-    service, bus = _rauc_dbus_service(tmp_path, config, bootname)
+    service, proxy = _rauc_dbus_service(tmp_path, config, bootname)
 
-    yield bus
+    yield proxy
 
     service.terminate()
     try:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -387,7 +387,7 @@ def _rauc_dbus_service(tmp_path, conf_file, bootslot):
     return service, proxy
 
 
-def rauc_dbus_service_helper(tmp_path, dbus_session_bus, create_system_files, config, bootname):
+def rauc_dbus_service_helper(tmp_path, config, bootname):
     service, proxy = _rauc_dbus_service(tmp_path, config, bootname)
 
     yield proxy
@@ -404,28 +404,28 @@ def rauc_dbus_service_helper(tmp_path, dbus_session_bus, create_system_files, co
 def rauc_dbus_service_with_system(tmp_path, dbus_session_bus, create_system_files, system):
     system.prepare_minimal_config()
     system.write_config()
-    yield from rauc_dbus_service_helper(tmp_path, dbus_session_bus, create_system_files, system.output, "A")
+    yield from rauc_dbus_service_helper(tmp_path, system.output, "A")
 
 
 @pytest.fixture
 def rauc_dbus_service_with_system_crypt(tmp_path, dbus_session_bus, create_system_files, system):
     system.prepare_crypt_config()
     system.write_config()
-    yield from rauc_dbus_service_helper(tmp_path, dbus_session_bus, create_system_files, system.output, "A")
+    yield from rauc_dbus_service_helper(tmp_path, system.output, "A")
 
 
 @pytest.fixture
 def rauc_dbus_service_with_system_external(tmp_path, dbus_session_bus, create_system_files, system):
     system.prepare_minimal_config()
     system.write_config()
-    yield from rauc_dbus_service_helper(tmp_path, dbus_session_bus, create_system_files, system.output, "_external_")
+    yield from rauc_dbus_service_helper(tmp_path, system.output, "_external_")
 
 
 @pytest.fixture
 def rauc_dbus_service_with_system_adaptive(tmp_path, dbus_session_bus, create_system_files, system):
     system.prepare_adaptive_config()
     system.write_config()
-    yield from rauc_dbus_service_helper(tmp_path, dbus_session_bus, create_system_files, system.output, "A")
+    yield from rauc_dbus_service_helper(tmp_path, system.output, "A")
 
 
 class Bundle:


### PR DESCRIPTION
In the future, we want to be able to customize the `system.conf` per test-case.
By moving the necessary startup/shutdown code from a helper and special-purpose fixtures
to generic code in the `System` class, we can change the config via the `system` fixture before
starting the service.