### PR TITLE
include/install.h: remove left-over do_install_network() prototype

### DIFF
--- a/include/install.h
+++ b/include/install.h
@@ -90,20 +90,6 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
- * Basic network installation procedure.
- *
- * NOTE: The network mode of RAUC is deprecated and will be replaced by some
- * other mechanism in the near future. Do not rely on it for new designs.
- *
- * @param url URL to manifest to install
- * @param error return location for a GError
- *
- * @return TRUE if installation succeeded, FALSE if any critical error occurred
- */
-gboolean do_install_network(const gchar *url, GError **error)
-G_GNUC_WARN_UNUSED_RESULT;
-
-/**
  * Initialize new RaucInstallArgs structure
  *
  * @return returns newly allocated RaucInstallArgs.


### PR DESCRIPTION
This is a left-over from cc86459f ("src/install: remove network mode") that removed the network mode back in 2019.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
