### PR TITLE
qemu-test: few fixes

### DIFF
--- a/qemu-test
+++ b/qemu-test
@@ -15,7 +15,7 @@
 #   passthrough       Enable passthrough of the host's CPU features
 #   shell             Setup qemu test system and provide an interactive shell
 #   system            Setup qemu dummy system that behaves like a target (without reboot!)
-#   service-backtrace Run service under gdb and show backtrace on error
+#   service-backtrace Run service under gdb and show backtrace on error (requires 'system')
 #   asan              Set environment variables to support address sanitizer
 #   test=<test>       Run specified test (for use with git bisect)
 #

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -43,9 +43,6 @@ for x in $(cat /proc/cmdline); do
     SERVICE_BACKTRACE=1
   fi
 done
-if [ -n "$test" ]; then
-  MESON_TEST="$test"
-fi
 
 hostname qemu-test
 
@@ -227,7 +224,7 @@ if [ -n "$INTERACTIVE_SHELL" ]; then
   sleep 1
 fi
 
-if meson test -C $BUILD_DIR "$MESON_TEST" -v; then
+if meson test -C $BUILD_DIR $test -v; then
   touch qemu-test-ok
   echo "RESULT: PASSED"
 else

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -86,7 +86,9 @@ if [ -n "$GCOV_PREFIX" ]; then
   cat > /tmp/bin/save_gcov_data <<EOF
 #!/bin/sh
 set -ex
-cp -r -T "$GCOV_PREFIX$BUILD_DIR" "$BUILD_DIR" || true
+if [ -d "$GCOV_PREFIX$BUILD_DIR" ]; then
+  cp -r -T "$GCOV_PREFIX$BUILD_DIR" "$BUILD_DIR" || true
+fi
 EOF
   cat > /tmp/bin/clear_gcov_data <<EOF
 #!/bin/sh

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -91,7 +91,7 @@ EOF
   cat > /tmp/bin/clear_gcov_data <<EOF
 #!/bin/sh
 set -ex
-  rm -rf "$GCOV_PREFIX$BUILD_DIR" || true
+rm -rf "$GCOV_PREFIX$BUILD_DIR" || true
 EOF
   chmod +x /tmp/bin/save_gcov_data /tmp/bin/clear_gcov_data
 fi

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -218,6 +218,7 @@ if [ -n "$INTERACTIVE_SHELL" ]; then
   setsid bash -c "$BASH_CMD" </dev/ttyS0 >/dev/ttyS0 2>&1 || echo exit-code=$?
   save_gcov_data
   echo o > /proc/sysrq-trigger
+  sleep 1
 fi
 
 if [ -n "$SERVICE" ]; then

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -26,8 +26,8 @@ cd "$(dirname "$0")"
 
 BUILD_DIR="$(realpath build)/"
 
-# parse cmdline
-for x in $(cat /proc/cmdline); do
+# parse arguments
+for x in "$@"; do
   if [ "$x" = "shell" ]; then
     INTERACTIVE_SHELL=1
     export MESON_BUILD_DIR=$BUILD_DIR

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -210,6 +210,10 @@ echo "use ctrl-a x to exit and ctrl-a c to access the qemu monitor"
 
 echo "system ready"
 
+if [ -n "$SERVICE" ]; then
+  rauc status mark-good
+fi
+
 if [ -n "$INTERACTIVE_SHELL" ]; then
   echo "alias ll='ls -l'" >> /tmp/bashrc
   BASH_CMD="exec bash --rcfile /tmp/bashrc"
@@ -221,10 +225,6 @@ if [ -n "$INTERACTIVE_SHELL" ]; then
   save_gcov_data
   echo o > /proc/sysrq-trigger
   sleep 1
-fi
-
-if [ -n "$SERVICE" ]; then
-  rauc status mark-good
 fi
 
 if meson test -C $BUILD_DIR "$MESON_TEST" -v; then

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -29,10 +29,10 @@ BUILD_DIR="$(realpath build)/"
 # parse cmdline
 for x in $(cat /proc/cmdline); do
   if [ "$x" = "shell" ]; then
-    SHELL=1
+    INTERACTIVE_SHELL=1
     export MESON_BUILD_DIR=$BUILD_DIR
   elif [ "$x" = "system" ]; then
-    SHELL=1
+    INTERACTIVE_SHELL=1
     SERVICE=1
   elif [ "$x" = "asan" ]; then
     export G_SLICE=always-malloc G_DEBUG=gc-friendly
@@ -107,7 +107,7 @@ EOF
 $BUILD_DIR/test/fakerand
 
 # rauc binary in PATH
-if [ -n "$SHELL" ]; then
+if [ -n "$INTERACTIVE_SHELL" ]; then
   cp -a $BUILD_DIR/rauc /tmp/bin/rauc
 fi
 export RAUC_TEST_NBD_SERVER="$BUILD_DIR/rauc"
@@ -208,7 +208,7 @@ echo "use ctrl-a x to exit and ctrl-a c to access the qemu monitor"
 
 echo "system ready"
 
-if [ -n "$SHELL" ]; then
+if [ -n "$INTERACTIVE_SHELL" ]; then
   echo "alias ll='ls -l'" >> /tmp/bashrc
   BASH_CMD="exec bash --rcfile /tmp/bashrc"
   if type resize; then


### PR DESCRIPTION
Hello,

I have tried to use `qemu-test` to run the whole test suite, and I faced some issues with my host (Arch Linux, sh -> bash, meson 1.6.1).

I have made a change that moves the mark-good before the interactive shell is started, and I am not sure about that one. I do not understand why it runs after the shell and before the tests :thinking: I have probably a misunderstanding of how to use that script.

Also, is there a good way to ensure mark-good runs after the rauc service is started?

Regards