### PR TITLE
src/context: fix leaking GError in getting custom bootslot

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -146,8 +146,8 @@ static gchar* get_custom_bootname(void)
 	g_autoptr(GSubprocess) handle = NULL;
 	g_autoptr(GDataInputStream) datainstream = NULL;
 	g_autoptr(GPtrArray) args_array = NULL;
+	g_autoptr(GError) ierror = NULL;
 	g_autofree gchar *outline = NULL;
-	GError *ierror = NULL;
 	GInputStream *instream;
 	int res;
 


### PR DESCRIPTION
Hello,

I am not very familiar with the glib, but I think I have found a possible leak in reading the code of the function `get_custom_bootname()`.

I guess it is safe to auto free `ierror` since it is used internally only, am I right?

Regards,
Gaël