### PR TITLE
src/mount: provide more helpful error message when squashfs is missing

### DIFF
--- a/src/mount.c
+++ b/src/mount.c
@@ -24,11 +24,17 @@ gboolean r_mount_bundle(const gchar *source, const gchar *mountpoint, GError **e
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	if (mount(source, mountpoint, "squashfs", flags, NULL)) {
+		const gchar *errmsg;
 		int err = errno;
+		if (err == ENODEV) {
+			errmsg = "squashfs support not enabled in kernel";
+		} else {
+			errmsg = g_strerror(err);
+		}
 		g_set_error(error,
 				G_FILE_ERROR,
 				g_file_error_from_errno(err),
-				"failed to mount bundle: %s", g_strerror(err));
+				"%s", errmsg);
 		return FALSE;
 	}
 


### PR DESCRIPTION
According to the `mount()` syscall manpage, `ENODEV` means "filesystemtype not configured in the kernel."

Since we know our file system, we can directly inform the user about the missing 'squashfs' support in kernel.

While at it, also follow the rule of not adding information a caller would know anyway and remove the "failed to mount bundle: " prefix.

So instead of:

> Failed mounting bundle: failed to mount bundle: No such device

we get

> Failed mounting bundle: squashfs support not enabled in kernel

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
