### PR TITLE
.github/workflows/scan-build: update to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Upload scan-build report
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: scan-build-report
         path: build/meson-logs/scanbuild/*


### PR DESCRIPTION
The actions/upload-artifact@v3 action was deprecated.