### PR TITLE
test/Dockerfile: add python3-requests

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -51,6 +51,7 @@ RUN apt-get install -q -y --no-install-recommends \
   mtd-utils \
   mmc-utils \
   python3-aiohttp \
+  python3-requests \
   nginx-light \
   fdisk
 


### PR DESCRIPTION
This is useful for communicating with the HTTP server from pytest to prepare and analyze advanced tests for streaming.