### PR TITLE
src: simplify and fix NFS (external) boot detection

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -69,8 +69,10 @@ static gchar* get_cmdline_bootname(void)
 	else if (!g_file_get_contents("/proc/cmdline", &contents, NULL, NULL))
 		return NULL;
 
-	if (strstr(contents, "rauc.external") != NULL)
+	if (strstr(contents, "rauc.external") != NULL) {
+		g_message("Detected explicit external boot, ignoring missing active slot");
 		return g_strdup("_external_");
+	}
 
 	bootname = regex_match("rauc\\.slot=(\\S+)", contents);
 	if (bootname)
@@ -87,6 +89,11 @@ static gchar* get_cmdline_bootname(void)
 	}
 
 	bootname = regex_match("root=(\\S+)", contents);
+	if (g_strcmp0(bootname, "/dev/nfs") == 0) {
+		g_message("Detected nfs boot, ignoring missing active slot");
+		g_free(bootname);
+		return g_strdup("_external_");
+	}
 	if (!bootname)
 		bootname = regex_match("systemd\\.verity_root_data=(\\S+)", contents);
 

--- a/src/install.c
+++ b/src/install.c
@@ -203,19 +203,7 @@ gboolean determine_slot_states(GError **error)
 	}
 
 	if (!booted) {
-		gboolean extboot = FALSE;
-
-		if (g_strcmp0(r_context()->bootslot, "/dev/nfs") == 0) {
-			g_message("Detected nfs boot, ignoring missing active slot");
-			extboot = TRUE;
-		}
-
 		if (g_strcmp0(r_context()->bootslot, "_external_") == 0) {
-			g_message("Detected explicit external boot, ignoring missing active slot");
-			extboot = TRUE;
-		}
-
-		if (extboot) {
 			/* mark all as inactive */
 			g_debug("Marking all slots as 'inactive'");
 			for (GList *l = slotlist; l != NULL; l = l->next) {

--- a/test/context.c
+++ b/test/context.c
@@ -49,7 +49,7 @@ static void test_bootslot_nfs_boot(void)
 	r_context_conf()->mock.proc_cmdline = "quiet root=/dev/nfs";
 	g_clear_pointer(&r_context_conf()->bootslot, g_free);
 
-	g_assert_cmpstr(r_context()->bootslot, ==, "/dev/nfs");
+	g_assert_cmpstr(r_context()->bootslot, ==, "_external_");
 
 	r_context_clean();
 }


### PR DESCRIPTION
Since 2928ac06 ("src/main: fix and add support for boot detection with rauc.external"), we consider `"_external_"` in `r_context()->bootslot` as an indicator for an external boot.
While this works well for explicit 'rauc.external' boots, it does not for boots with 'root=/dev/nfs' in the commandline since `r_context()->bootslot` is '/dev/nfs' in this case.

Unify these cases by returning `"_external_"` from `get_cmdline_bootname()` both for the 'rauc.external' as well as the 'root=/dev/nfs' case.

To not loose the info printout for external or nfs, move these to get_cmdline_bootname(), too.

From here on it is now actually safe to use `"_external_"` as an indicator for all kinds of external boots.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
