### PR TITLE
Fix handling for missing boot ID

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -426,9 +426,11 @@ static gboolean r_context_configure_target(GError **error)
 	g_clear_pointer(&context->machine_id, g_free);
 
 	context->boot_id = get_boot_id();
-	g_debug("Obtained system boot ID: '%s'", context->boot_id);
+	if (context->boot_id)
+		g_debug("Obtained system boot ID: '%s'", context->boot_id);
 	context->machine_id = get_machine_id();
-	g_debug("Obtained system machine ID: '%s'", context->machine_id);
+	if (context->machine_id)
+		g_debug("Obtained system machine ID: '%s'", context->machine_id);
 
 	return TRUE;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2370,7 +2370,9 @@ static gboolean service_start(int argc, char **argv)
 
 	if (r_context()->system_status) {
 		/* Boot ID-based system reboot vs service restart detection */
-		if (g_strcmp0(r_context()->system_status->boot_id, r_context()->boot_id) == 0) {
+		if (!r_context()->boot_id) {
+			g_message("Kernel does not support reading boot_id. Skipping reboot detection.");
+		} else if (g_strcmp0(r_context()->system_status->boot_id, r_context()->boot_id) == 0) {
 			r_event_log_message(R_EVENT_LOG_TYPE_SERVICE, "Service restarted");
 		} else {
 			if (g_strcmp0(r_context()->bootslot, "_external_") == 0) {


### PR DESCRIPTION
This fixes issues that occur when `/proc/sys/kernel/random/boot_id` (or procfs) is not present for some reason.