### PR TITLE
require glib version 2.64.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,18 +25,18 @@ conf.set('bindir', bindir)
 libexecdir = join_paths(prefixdir, get_option('libexecdir'))
 conf.set('libexecdir', libexecdir)
 
-glibdep = dependency('glib-2.0', version : '>=2.56')
+glibdep = dependency('glib-2.0', version : '>=2.64')
 
 # Sanity checks to not use new glib methods unintentionally.
 # package check, minimum and maximum required version must be updated
 # explicitly when using newer glib APIs
 c_flags = [
-  '-DGLIB_VERSION_MAX_ALLOWED=G_ENCODE_VERSION(2,56)',
-  '-DGLIB_VERSION_MIN_REQUIRED=G_ENCODE_VERSION(2,56)'
+  '-DGLIB_VERSION_MAX_ALLOWED=G_ENCODE_VERSION(2,64)',
+  '-DGLIB_VERSION_MIN_REQUIRED=G_ENCODE_VERSION(2,64)'
 ]
 
-giodep = dependency('gio-2.0', version : '>=2.56')
-giounixdep = dependency('gio-unix-2.0', version : '>=2.56')
+giodep = dependency('gio-2.0', version : '>=2.64')
+giounixdep = dependency('gio-unix-2.0', version : '>=2.64')
 openssldep = dependency('openssl', version : '>=1.1.1')
 jsonglibdep = dependency('json-glib-1.0', required : get_option('json'))
 dbusdep = dependency('dbus-1', required : get_option('service'))


### PR DESCRIPTION
This allows us to use g_ptr_array_copy()/_extend() from 2.62, g_canonicalize_file() from 2.58 and g_warning_once() from 2.64.

Versions newer than 2.64.0 are used by the oldest supported releases of major distributions.
- Debian bullseye: 2.66.8 (EOL: 2026-08-31)
- Ubuntu focal: 2.64.2 (EOL Standard Support: May 2025)
- Yocto kirkstone: 2.72.3 (EOL: April 2026)