### PR TITLE
avoid GDestroyNotify cast for g_clear_pointer

### DIFF
--- a/src/artifacts.c
+++ b/src/artifacts.c
@@ -82,7 +82,7 @@ void r_artifact_repo_free(gpointer value)
 	g_free(repo->path);
 	g_free(repo->type);
 	g_free(repo->data_directory);
-	g_clear_pointer(&repo->artifacts, (GDestroyNotify)g_hash_table_destroy);
+	g_clear_pointer(&repo->artifacts, g_hash_table_destroy);
 	if (repo->possible_references)
 		g_ptr_array_free(repo->possible_references, TRUE);
 	g_free(repo);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1110,7 +1110,7 @@ void r_free_image(gpointer data)
 	g_free(image->filename);
 	g_strfreev(image->adaptive);
 	g_strfreev(image->convert);
-	g_clear_pointer(&image->converted, (GDestroyNotify)g_ptr_array_unref);
+	g_clear_pointer(&image->converted, g_ptr_array_unref);
 	g_free(image);
 }
 
@@ -1130,9 +1130,9 @@ void free_manifest(RaucManifest *manifest)
 	g_free(manifest->handler_args);
 	g_free(manifest->hook_name);
 	g_list_free_full(manifest->images, r_free_image);
-	g_clear_pointer(&manifest->meta, (GDestroyNotify)g_hash_table_destroy);
+	g_clear_pointer(&manifest->meta, g_hash_table_destroy);
 	g_free(manifest->hash);
-	g_clear_pointer(&manifest->warnings, (GDestroyNotify)g_ptr_array_unref);
+	g_clear_pointer(&manifest->warnings, g_ptr_array_unref);
 	g_free(manifest);
 }
 


### PR DESCRIPTION
With the cast, it would cause a warning:
```
../src/artifacts.c: In function ‘r_artifact_repo_free’: ../src/artifacts.c:85:43: warning: function called through a non-compatible type
   85 |         g_clear_pointer(&repo->artifacts, (GDestroyNotify)g_hash_table_destroy);
/usr/include/glib-2.0/glib/gmem.h:136:8: note: in definition of macro ‘g_clear_pointer’
  136 |       (destroy) (_ptr);                                  \
      |        ^~~~~~~
```
See also https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/269.