### PR TITLE
src/mount: open /dev/loop* readonly

### DIFF
--- a/src/mount.c
+++ b/src/mount.c
@@ -155,7 +155,7 @@ gboolean r_setup_loop(gint fd, gint *loopfd_out, gchar **loopname_out, goffset s
 
 		loopname = g_strdup_printf("/dev/loop%d", loopidx);
 
-		loopfd = open(loopname, O_RDWR|O_CLOEXEC);
+		loopfd = open(loopname, O_RDONLY|O_CLOEXEC);
 		if (loopfd < 0) {
 			int err = errno;
 			/* is this loop dev gone already? */


### PR DESCRIPTION
We don't intend to write to the RAUC bundle, so open /dev/loop* readonly.

Mounting readwrite only works when the Kernel option CONFIG_BLK_DEV_WRITE_MOUNTED is enabled. Without this option mounting the bundle fails with -EBUSY.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
