### PR TITLE
test/update_handler: fix tests for block hash index

### DIFF
--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -562,10 +562,10 @@ no_image:
 			 * used mkfs configuration. We use minimal values here
 			 * that have proven to be valid on all test systems.
 			 */
-			g_assert_cmpint(sum_zero, >=, IMAGE_SIZE/4096 - 29);
+			g_assert_cmpint(sum_zero, >=, IMAGE_SIZE/4096 - 37);
 			g_assert_cmpint(sum_target_written, >=, 0);
 			g_assert_cmpint(sum_target, ==, 0);
-			g_assert_cmpint(sum_source, <=, 29);
+			g_assert_cmpint(sum_source, <=, 37);
 		}
 
 		/* Number of total lookups must not increase in lookup order */


### PR DESCRIPTION
This fixes tests for block hash index (with mke2fs 1.47.2).

Fixes:

	not ok /update_handler/block_hash_index/ext4_to_raw - rauc:ERROR:../test/update_handler.c:565:test_update_handler: assertion failed (sum_zero >= IMAGE_SIZE/4096 - 29): (2523 >= 2531)
	Bail out!
	----------------------------------- stderr -----------------------------------
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	The file /tmp/rauc-SPKR12/rootfs-0 does not exist and no size was specified.
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	mkfs.vfat: unable to open /tmp/rauc-KZKR12/rootfs-0: No such file or directory
	mke2fs 1.47.2 (1-Jan-2025)
	mke2fs 1.47.2 (1-Jan-2025)
	**
	rauc:ERROR:../test/update_handler.c:565:test_update_handler: assertion failed (sum_zero >= IMAGE_SIZE/4096 - 29): (2523 >= 2531)
	tar: tar: This does not look like a tar archiveThis does not look like a tar archive

	tar: tar: Exiting with failure status due to previous errors
	Exiting with failure status due to previous errors

	(test program exited with status code -6)
	==============================================================================

	Summary of Failures:

	1/1 update_handler ERROR            3.47s   killed by signal 6 SIGABRT

	Ok:                 0
	Expected Fail:      0
	Fail:               1
	Unexpected Pass:    0
	Skipped:            0
	Timeout:            0

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
