### PR TITLE
src/context: introduce r_boot_get_current_bootname()

### DIFF
--- a/include/bootchooser.h
+++ b/include/bootchooser.h
@@ -2,7 +2,7 @@
 
 #include <glib.h>
 
-#include "config_file.h"
+#include "context.h"
 
 #define R_BOOTCHOOSER_ERROR r_bootchooser_error_quark()
 GQuark r_bootchooser_error_quark(void);
@@ -19,6 +19,16 @@ GQuark r_bootchooser_error_quark(void);
  * @return TRUE if it is supported, otherwise FALSE
  */
 gboolean r_boot_is_supported_bootloader(const gchar *bootloader)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
+ * Get current bootname slot.
+ *
+ * @param config the RaucConfig
+ *
+ * @return bootname, NULL if detection failed
+ */
+gchar *r_boot_get_current_bootname(RaucConfig *config)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**

--- a/include/bootchooser.h
+++ b/include/bootchooser.h
@@ -25,10 +25,11 @@ G_GNUC_WARN_UNUSED_RESULT;
  * Get current bootname slot.
  *
  * @param config the RaucConfig
+ * @param error return location for a GError, or NULL
  *
  * @return bootname, NULL if detection failed
  */
-gchar *r_boot_get_current_bootname(RaucConfig *config)
+gchar *r_boot_get_current_bootname(RaucConfig *config, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1568,7 +1568,7 @@ static gboolean custom_backend_set(const gchar *cmd, const gchar *bootname, cons
 }
 
 /* Get current bootname */
-static gchar *custom_backend_get_bootname(RaucConfig *config, GError **error)
+static gchar *custom_get_current_bootname(RaucConfig *config, GError **error)
 {
 	g_autoptr(GSubprocessLauncher) launcher = NULL;
 	g_autoptr(GSubprocess) handle = NULL;
@@ -1728,7 +1728,7 @@ gchar *r_boot_get_current_bootname(RaucConfig *config, GError **error)
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	if (g_strcmp0(config->system_bootloader, "custom") == 0) {
-		res = custom_backend_get_bootname(config, &ierror);
+		res = custom_get_current_bootname(config, &ierror);
 	}
 
 	if (ierror) {

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1567,6 +1567,7 @@ static gboolean custom_backend_set(const gchar *cmd, const gchar *bootname, cons
 	return TRUE;
 }
 
+/* Get current bootname */
 static gchar *custom_backend_get_bootname(RaucConfig *config)
 {
 	g_autoptr(GSubprocessLauncher) launcher = NULL;
@@ -1662,7 +1663,7 @@ static RaucSlot* custom_get_primary(GError **error)
 	return primary;
 }
 
-/* Get state of current slot */
+/* Get state of given slot */
 static gboolean custom_get_state(RaucSlot *slot, gboolean *good, GError **error)
 {
 	GError *ierror = NULL;
@@ -1701,6 +1702,7 @@ static gboolean custom_set_primary(RaucSlot *slot, GError **error)
 	return custom_backend_set("set-primary", slot->bootname, NULL, error);
 }
 
+/* Get current bootname */
 gchar *r_boot_get_current_bootname(RaucConfig *config)
 {
 	gchar *res = NULL;
@@ -1714,6 +1716,7 @@ gchar *r_boot_get_current_bootname(RaucConfig *config)
 	return res;
 }
 
+/* Get state of given slot */
 gboolean r_boot_get_state(RaucSlot* slot, gboolean *good, GError **error)
 {
 	gboolean res = FALSE;
@@ -1755,6 +1758,7 @@ gboolean r_boot_get_state(RaucSlot* slot, gboolean *good, GError **error)
 	return res;
 }
 
+/* Set slot status values */
 gboolean r_boot_set_state(RaucSlot *slot, gboolean good, GError **error)
 {
 	gboolean res = FALSE;
@@ -1795,6 +1799,7 @@ gboolean r_boot_set_state(RaucSlot *slot, gboolean good, GError **error)
 	return res;
 }
 
+/* Get slot marked as primary one */
 RaucSlot* r_boot_get_primary(GError **error)
 {
 	RaucSlot *slot = NULL;
@@ -1831,6 +1836,7 @@ RaucSlot* r_boot_get_primary(GError **error)
 	return slot;
 }
 
+/* Set slot as primary boot slot */
 gboolean r_boot_set_primary(RaucSlot *slot, GError **error)
 {
 	gboolean res = FALSE;

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -1616,7 +1616,7 @@ static gchar *custom_backend_get_bootname(RaucConfig *config, GError **error)
 				config->custom_bootloader_backend);
 		return NULL;
 	}
-	if (!outline) {
+	if (!outline || *outline == 0) {
 		g_set_error(
 				error,
 				R_BOOTCHOOSER_ERROR,

--- a/src/context.c
+++ b/src/context.c
@@ -3,6 +3,7 @@
 #include <glib/gstdio.h>
 #include <string.h>
 
+#include "bootchooser.h"
 #include "config_file.h"
 #include "context.h"
 #include "event_log.h"
@@ -145,57 +146,6 @@ static gchar* get_cmdline_bootname(void)
 	}
 
 	return bootname;
-}
-
-static gchar* get_custom_bootname(void)
-{
-	g_autoptr(GSubprocessLauncher) launcher = NULL;
-	g_autoptr(GSubprocess) handle = NULL;
-	g_autoptr(GDataInputStream) datainstream = NULL;
-	g_autoptr(GPtrArray) args_array = NULL;
-	g_autoptr(GError) ierror = NULL;
-	g_autofree gchar *outline = NULL;
-	GInputStream *instream;
-	int res;
-
-	args_array = g_ptr_array_new();
-	g_ptr_array_add(args_array, context->config->custom_bootloader_backend);
-	g_ptr_array_add(args_array, (gchar *)("get-current"));
-	g_ptr_array_add(args_array, NULL);
-
-	launcher = g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE);
-	handle = r_subprocess_launcher_spawnv(launcher, args_array, NULL);
-
-	if (handle == NULL) {
-		g_message("Failed to run custom backend '%s'",
-				context->config->custom_bootloader_backend);
-		return NULL;
-	}
-
-	instream = g_subprocess_get_stdout_pipe(handle);
-	datainstream = g_data_input_stream_new(instream);
-
-	outline = g_data_input_stream_read_line(datainstream, NULL, NULL, &ierror);
-
-	if (ierror) {
-		g_message("Failed to read custom backend output: %s", ierror->message);
-		return NULL;
-	}
-
-	res = g_subprocess_wait_check(handle, NULL, NULL);
-	if (!res) {
-		g_message("Failed to get custom backend output");
-		return NULL;
-	}
-
-	if (!outline) {
-		g_message("Failed to get custom backend bootname: no output");
-		return NULL;
-	}
-
-	g_debug("Resolved custom backend bootname to %s", outline);
-
-	return g_steal_pointer(&outline);
 }
 
 /**
@@ -427,8 +377,8 @@ static gboolean r_context_configure_target(GError **error)
 		context->bootslot = get_cmdline_bootname();
 	}
 
-	if (context->bootslot == NULL && (g_strcmp0(context->config->system_bootloader, "custom") == 0)) {
-		context->bootslot = get_custom_bootname();
+	if (context->bootslot == NULL) {
+		context->bootslot = r_boot_get_current_bootname(context->config);
 	}
 
 	g_clear_pointer(&context->boot_id, g_free);

--- a/src/context.c
+++ b/src/context.c
@@ -378,7 +378,11 @@ static gboolean r_context_configure_target(GError **error)
 	}
 
 	if (context->bootslot == NULL) {
-		context->bootslot = r_boot_get_current_bootname(context->config);
+		context->bootslot = r_boot_get_current_bootname(context->config, &ierror);
+		if (ierror) {
+			g_message("Failed to get bootname: %s", ierror->message);
+			g_clear_error(&ierror);
+		}
 	}
 
 	g_clear_pointer(&context->boot_id, g_free);

--- a/test/context.c
+++ b/test/context.c
@@ -121,7 +121,7 @@ static void test_bootslot_custom_bootloader_no_bootslot(void)
 	r_context_conf()->mock.proc_cmdline = "quiet";
 	g_clear_pointer(&r_context_conf()->bootslot, g_free);
 
-	g_assert_cmpstr(r_context()->bootslot, ==, "");
+	g_assert_null(r_context()->bootslot);
 
 	r_context_clean();
 }

--- a/test/context.c
+++ b/test/context.c
@@ -4,8 +4,6 @@
 
 #include <context.h>
 
-#include "common.h"
-
 static void test_bootslot_rauc_slot(void)
 {
 	r_context_conf()->configpath = g_strdup("test/test.conf");

--- a/test/context.c
+++ b/test/context.c
@@ -115,6 +115,19 @@ static void test_bootslot_custom_bootloader(void)
 	r_context_clean();
 }
 
+static void test_bootslot_custom_bootloader_no_bootslot(void)
+{
+	r_context_conf()->configpath = g_strdup("test/test-custom.conf");
+	r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_REQUIRED;
+	g_assert_true(g_setenv("CUSTOM_STATE_PATH", "/dev/null", TRUE));
+	r_context_conf()->mock.proc_cmdline = "quiet";
+	g_clear_pointer(&r_context_conf()->bootslot, g_free);
+
+	g_assert_cmpstr(r_context()->bootslot, ==, "");
+
+	r_context_clean();
+}
+
 /* Tests that the infos provided by the configured system-info handler make it
  * into RAUC's system information.
  */
@@ -182,6 +195,8 @@ int main(int argc, char *argv[])
 	g_test_add_func("/context/bootslot/no-bootslot", test_bootslot_no_bootslot);
 
 	g_test_add_func("/context/bootslot/custom-bootslot", test_bootslot_custom_bootloader);
+
+	g_test_add_func("/context/bootslot/custom-bootslot_no_bootslot", test_bootslot_custom_bootloader_no_bootslot);
 
 	g_test_add_func("/context/system-info", test_context_system_info);
 


### PR DESCRIPTION
This introduces the function r_boot_get_bootname() to retreive the bootname of the current booted slot.
