### PR TITLE
test/Dockerfile: add python3-dasbus for testing

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get install -q -y --no-install-recommends \
   slirp \
   python3-pytest \
   python3-pydbus \
+  python3-dasbus \
   python3-sphinx \
   python3-sphinx-rtd-theme \
   dbus \


### PR DESCRIPTION
Since pydbus is no longer maintained, we should switch to the successor project dasbus. To avoid breaking the current test suite, keep pydbus for now.