### PR TITLE
src/service: fix leak of RaucBundleAccessArgs for InspectBundle

### DIFF
--- a/include/bundle.h
+++ b/include/bundle.h
@@ -283,3 +283,5 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucBundle, free_bundle);
  * @param access_args RaucBundleAccessArgs to clear
  */
 void clear_bundle_access_args(RaucBundleAccessArgs *access_args);
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(RaucBundleAccessArgs, clear_bundle_access_args);

--- a/src/service.c
+++ b/src/service.c
@@ -163,7 +163,7 @@ static gboolean r_on_handle_inspect_bundle(RInstaller *interface,
 		GDBusMethodInvocation  *invocation,
 		const gchar *arg_bundle, GVariant *arg_args)
 {
-	RaucBundleAccessArgs access_args = {0};
+	g_auto(RaucBundleAccessArgs) access_args = {0};
 	g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(arg_args);
 	g_autoptr(GVariant) remaining = NULL;
 	GVariantIter iter;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -618,6 +618,7 @@ class System:
         self.service.terminate()
         try:
             self.service.wait(timeout=10)
+            assert self.service.returncode == 0
         except subprocess.TimeoutExpired:
             self.service.kill()
             self.service.wait()


### PR DESCRIPTION
The leak only happens if there actually are access args in the method call dict.