### PR TITLE
manifest: add a min-rauc-version

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -719,6 +719,12 @@ This section contains some high-level information about the bundle.
   information provided by the bundle creation environment. This can help to
   determine the date and origin of the built bundle.
 
+``min-rauc-version`` (optional)
+  An optional version limit which causes the manifest to be rejected if the
+  running version is older/lower than the requested minimum.
+  This was introduced with version 1.14 and will cause an error on older
+  versions.
+
 ``[bundle]`` Section
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -48,6 +48,7 @@ typedef struct {
 	gchar *update_version;
 	gchar *update_description;
 	gchar *update_build;
+	gchar *update_min_rauc_version;
 
 	RManifestBundleFormat bundle_format;
 	gchar *bundle_verity_salt;

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ project(
 cc = meson.get_compiler('c')
 
 conf = configuration_data()
+conf.set_quoted('RAUC_MESON_VERSION', meson.project_version())
 conf.set_quoted('PACKAGE_NAME', 'rauc')
 conf.set_quoted('STREAMING_USER', get_option('streaming_user'))
 


### PR DESCRIPTION
This gives us an additional way to ensure that bundles are not installed by an incompatible version. In the future, we could also require an explicit minimum version during bundle creation when using new features to make the requirements explicit to the user.