### PR TITLE
add support for requiring a specific manifest hash during installation

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1653,6 +1653,15 @@ IN a{sv} *args*:
         identifying the (installation) transaction.
         If not given, RAUC will generate a random one.
 
+    :STRING 'require-manifest-hash', VARIANT 's' <HASH>:
+       Check that the manifest hash of the to-be-installed bundle's matches the
+       expected value.
+       This can be used when explicit confirmation is needed before installing a
+       bundle by first reviewing the information returned by ``InspectBundle``
+       and then passing the hash here.
+       If the bundle was replaced by a different (but correctly signed) bundle,
+       this is detected by comparing the manifest hashes.
+
     :STRING 'tls-cert', VARIANT 's' <filename/pkcs11-url>: Use the provided
         certificate for TLS client authentication
 

--- a/include/install.h
+++ b/include/install.h
@@ -29,9 +29,11 @@ typedef struct {
 	GMutex status_mutex;
 	GQueue status_messages;
 	gint status_result;
+
 	/* install options */
 	gboolean ignore_compatible;
 	gboolean ignore_version_limit;
+	gchar *require_manifest_hash;
 	gchar *transaction;
 	RaucBundleAccessArgs access_args;
 } RaucInstallArgs;

--- a/src/main.c
+++ b/src/main.c
@@ -52,6 +52,7 @@ gchar **recipients = NULL;
 gchar *handler_args = NULL;
 gchar *bootslot = NULL;
 gchar *installation_txn = NULL;
+gchar *require_manifest_hash = NULL;
 gboolean utf8_supported = FALSE;
 RaucBundleAccessArgs access_args = {0};
 
@@ -264,6 +265,7 @@ static gboolean install_start(int argc, char **argv)
 	args->ignore_compatible = install_ignore_compatible;
 	args->ignore_version_limit = install_ignore_version_limit;
 	args->transaction = installation_txn;
+	args->require_manifest_hash = require_manifest_hash;
 	if (access_args.tls_cert)
 		args->access_args.tls_cert = g_strdup(access_args.tls_cert);
 	if (access_args.tls_key)
@@ -285,6 +287,8 @@ static gboolean install_start(int argc, char **argv)
 		g_variant_dict_insert(&dict, "ignore-version-limit", "b", args->ignore_version_limit);
 		if (args->transaction)
 			g_variant_dict_insert(&dict, "transaction-id", "s", args->transaction);
+		if (args->require_manifest_hash)
+			g_variant_dict_insert(&dict, "require-manifest-hash", "s", args->require_manifest_hash);
 		if (args->access_args.tls_cert)
 			g_variant_dict_insert(&dict, "tls-cert", "s", args->access_args.tls_cert);
 		if (args->access_args.tls_key)
@@ -2495,6 +2499,7 @@ static GOptionEntry entries_install[] = {
 	{"ignore-compatible", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_compatible, "disable compatible check", NULL},
 	{"ignore-version-limit", '\0', 0, G_OPTION_ARG_NONE, &install_ignore_version_limit, "disable version check", NULL},
 	{"transaction-id", '\0', 0, G_OPTION_ARG_STRING, &installation_txn, "custom transaction id", "UUID"},
+	{"require-manifest-hash", '\0', 0, G_OPTION_ARG_STRING, &require_manifest_hash, "require a specific manifest hash", "HASH"},
 #if ENABLE_SERVICE == 1
 	{"progress", '\0', 0, G_OPTION_ARG_NONE, &install_progressbar, "show progress bar", NULL},
 #else

--- a/src/service.c
+++ b/src/service.c
@@ -111,6 +111,9 @@ static gboolean r_on_handle_install_bundle(
 	if (g_variant_dict_lookup(&dict, "transaction-id", "s", &args->transaction))
 		g_variant_dict_remove(&dict, "transaction-id");
 
+	if (g_variant_dict_lookup(&dict, "require-manifest-hash", "s", &args->require_manifest_hash))
+		g_variant_dict_remove(&dict, "require-manifest-hash");
+
 	convert_dict_to_bundle_access_args(&dict, &args->access_args);
 
 	/* Check for unhandled keys */


### PR DESCRIPTION
Check that the hash of the to be installed bundle's manifest matches the expected value. This can be used to when explicit confirmation is needed before installing a bundle by first reviewing the information returned by InspectBundle and then passing the hash here. If the bundle was replaced by a different (but correctly signed) bundle, this is detected by comparing the manifest hashes.

This is also useful with the upcoming polling support if the user wants to automate the polling only and still trigger the installation explicitly.