### PR TITLE
src/bundle: add printout if crated signature size exceeds sanity default

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -14,6 +14,7 @@
 #include <unistd.h>
 
 #include "bundle.h"
+#include "config_file.h"
 #include "context.h"
 #include "crypt.h"
 #include "manifest.h"
@@ -856,6 +857,11 @@ static gboolean append_signature_to_bundle(const gchar *bundlename, GBytes *sig,
 	}
 
 	offset = g_seekable_tell(G_SEEKABLE(bundlestream)) - offset;
+	if (offset > DEFAULT_MAX_BUNDLE_SIGNATURE_SIZE) {
+		g_autofree gchar* formatted_sigsize = g_format_size_full(offset, G_FORMAT_SIZE_IEC_UNITS);
+		g_autofree gchar* formatted_defaultsize = g_format_size_full(DEFAULT_MAX_BUNDLE_SIGNATURE_SIZE, G_FORMAT_SIZE_IEC_UNITS);
+		g_message("Resulting signature size of %s exceeds default of %s. Make sure to set 'max-bundle-signature-size' in your target's system.conf to a sufficiently high value.", formatted_sigsize, formatted_defaultsize);
+	}
 	if (!output_stream_write_uint64_all(bundleoutstream, offset, NULL, &ierror)) {
 		g_propagate_prefixed_error(
 				error,


### PR DESCRIPTION
When encrypting bundles for a large number of recipients, the signature size may exceed the default sanity check size of 64 KiB.

Since RAUC will refuse to install such a bundle by default, the user should be informed during bundle creation already and not surprised in the field.

To give guidance, also note the new 'max-bundle-signature-size' system config option. However, this still has to have been set beforehand on devices in the field.

Use IEC units for printout to let 64*1024 bytes appear more reasonable.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
