### PR TITLE
src/manifest: ignore the rollout section for now

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -327,6 +327,10 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 		}
 	}
 
+	/* ignore [rollout] section for now, so that we can add hints/overrides
+	 * for rollout/polling behaviour later */
+	g_key_file_remove_group(key_file, "rollout", NULL);
+
 	if (!check_remaining_groups(key_file, &ierror)) {
 		g_propagate_error(error, ierror);
 		return FALSE;

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -239,3 +239,10 @@ def test_bundle_min_rauc_version(bundle):
     assert "Creating 'verity' format bundle" in out
     assert "Minimum RAUC version field in manifest is only supported since 1.14 (not '1.13')" in err
     assert not bundle.output.is_file()
+
+
+def test_rollout_options(bundle):
+    bundle.manifest["rollout"] = {
+        "foo": "bar",
+    }
+    bundle.build()


### PR DESCRIPTION
The main polling configuration is set in the system.conf. In the future, we may want to further delay or restrict polling/installation, e.g. to specific time windows or for phased roll-outs.

By ignoring unknown options in this section until then, it will be easier to use them later as an intermediate update can be avoided.