### PR TITLE
test/stats: remove compatibility defines for glib < 2.58

### DIFF
--- a/test/stats.c
+++ b/test/stats.c
@@ -3,23 +3,6 @@
 
 #include "stats.h"
 
-/* APPROX_VALUE exists in glib >= 2.58 */
-#ifndef G_APPROX_VALUE
-#define G_APPROX_VALUE(a, b, epsilon) \
-	(((a) > (b) ? (a) - (b) : (b) - (a)) < (epsilon))
-#endif
-
-/* g_assert_cmpfloat_with_epsilon exists in glib >= 2.58 */
-#ifndef g_assert_cmpfloat_with_epsilon
-#define g_assert_cmpfloat_with_epsilon(n1, n2, epsilon) \
-	G_STMT_START { \
-		double __n1 = (n1), __n2 = (n2), __epsilon = (epsilon); \
-		if (G_APPROX_VALUE(__n1, __n2, __epsilon)); else \
-		g_assertion_message_cmpnum(G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, \
-		#n1 " == " #n2 " (+/- " #epsilon ")", __n1, "==", __n2, 'f'); \
-	} G_STMT_END
-#endif
-
 static void test_basic(void)
 {
 	g_autoptr(RaucStats) stats = NULL;


### PR DESCRIPTION
Our minimum glib version is 2.64, thus these are not required anymore.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
