### PR TITLE
utils: add function to format a duration as a human readable string

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -449,3 +449,22 @@ gboolean r_semver_parse(const gchar *version_string, guint64 version_core[3], gc
  * @return TRUE if A<=B, FALSE otherwise
  */
 gboolean r_semver_less_equal(const gchar *version_string_a, const gchar *version_string_b, GError **error);
+
+/**
+ * Converts a duration given in seconds into a short human-readable string.
+ * The format is compact and space-separated, for example: "2h 15m 30s".
+ *
+ * Units are:
+ * - Days: "d"
+ * - Hours: "h"
+ * - Minutes: "m"
+ * - Seconds: "s"
+ *
+ * Units with zero values are omitted (except when the entire duration is zero,
+ * in which case "0s" is returned).
+ *
+ * @param total_seconds duration in seconds
+ *
+ * @return newly-allocated string representing the formatted duration
+ */
+gchar *r_format_duration(gint64 total_seconds);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1077,3 +1077,24 @@ gboolean r_semver_less_equal(const gchar *version_string_a, const gchar *version
 	else
 		return (pre_fields_a[i] == NULL) && (pre_fields_b[i] != NULL);
 }
+
+gchar *r_format_duration(gint64 total_seconds)
+{
+	gint64 seconds = total_seconds % 60;
+	gint64 minutes = (total_seconds / 60) % 60;
+	gint64 hours = (total_seconds / 3600) % 24;
+	gint64 days = total_seconds / (3600 * 24);
+
+	GString *result = g_string_new(NULL);
+
+	if (days)
+		g_string_append_printf(result, "%"G_GINT64_FORMAT "d ", days);
+	if (hours)
+		g_string_append_printf(result, "%"G_GINT64_FORMAT "h ", hours);
+	if (minutes)
+		g_string_append_printf(result, "%"G_GINT64_FORMAT "m ", minutes);
+	if (seconds || !total_seconds)
+		g_string_append_printf(result, "%"G_GINT64_FORMAT "s", seconds);
+
+	return g_strchomp(g_string_free(result, FALSE));
+}

--- a/test/utils.c
+++ b/test/utils.c
@@ -481,6 +481,31 @@ static void semver_less_equal_test(void)
 	g_assert_no_error(error);
 }
 
+static void format_duration_test(void)
+{
+	gchar *tmp = NULL;
+
+	tmp = r_format_duration(0);
+	g_assert_cmpstr(tmp, ==, "0s");
+	g_free(tmp);
+
+	tmp = r_format_duration(1);
+	g_assert_cmpstr(tmp, ==, "1s");
+	g_free(tmp);
+
+	tmp = r_format_duration(61);
+	g_assert_cmpstr(tmp, ==, "1m 1s");
+	g_free(tmp);
+
+	tmp = r_format_duration(3601);
+	g_assert_cmpstr(tmp, ==, "1h 1s");
+	g_free(tmp);
+
+	tmp = r_format_duration(86400);
+	g_assert_cmpstr(tmp, ==, "1d");
+	g_free(tmp);
+}
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -498,6 +523,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/utils/environ", environ_test);
 	g_test_add_func("/utils/semver_parse_test", semver_parse_test);
 	g_test_add_func("/utils/semver_less_equal_test", semver_less_equal_test);
+	g_test_add_func("/utils/format_duration", format_duration_test);
 
 	return g_test_run();
 }


### PR DESCRIPTION
This will be useful to print the time until the next poll for the upcoming polling support.