### PR TITLE
src/install: ensure converted pointer is valid before dereferencing

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -994,7 +994,7 @@ static gboolean pre_install_checks(gchar* bundledir, GPtrArray *install_plans, G
 		}
 
 		if (!g_file_test(plan->image->filename, G_FILE_TEST_EXISTS)) {
-			if (plan->image->converted->len == 0) {
+			if (!plan->image->converted || plan->image->converted->len == 0) {
 				g_set_error(error, G_FILE_ERROR, G_FILE_ERROR_NOENT,
 						"Source image '%s' not found in bundle", plan->image->filename);
 				return FALSE;


### PR DESCRIPTION
fix segmentation fault caused by checking `converted->len` without ensuring `converted` is valid in `pre_install_check`