### PR TITLE
docs/integration: change old override syntax in example

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -1555,13 +1555,13 @@ Add the `meta-rauc` layer to your setup:
 
 Add the RAUC tool to your image recipe (or package group)::
 
-  IMAGE_INSTALL_append = "rauc"
+  IMAGE_INSTALL:append = " rauc"
 
 Append the RAUC recipe from your BSP layer (referred to as `meta-your-bsp` in the
 following) by creating a ``meta-your-bsp/recipes-core/rauc/rauc_%.bbappend``
 with the following content::
 
-  FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+  FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 Write a ``system.conf`` for your board and place it in the folder you mentioned
 in the recipe (`meta-your-bsp/recipes-core/rauc/files`). This file must provide


### PR DESCRIPTION
The FILESEXTRAPATHS_prepend syntax is no longer valid since honister[1], switch to the new one.

Also change it for IMAGE_INSTALL, and add the missing space after the quote.

[1]: https://docs.yoctoproject.org/migration-guides/migration-3.4.html#override-syntax-changes

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
