### PR TITLE
docs/integration: fix rauc bbappend

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -1558,7 +1558,7 @@ Add the RAUC tool to your image recipe (or package group)::
   IMAGE_INSTALL:append = " rauc"
 
 Append the RAUC recipe from your BSP layer (referred to as `meta-your-bsp` in the
-following) by creating a ``meta-your-bsp/recipes-core/rauc/rauc_%.bbappend``
+following) by creating a ``meta-your-bsp/recipes-core/rauc/rauc-conf.bbappend``
 with the following content::
 
   FILESEXTRAPATHS:prepend := "${THISDIR}/files:"


### PR DESCRIPTION
We should append `rauc-conf.bb`, not `rauc_<version>.bb`.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
