### PR TITLE
src/mount: simplify control flow

### DIFF
--- a/src/mount.c
+++ b/src/mount.c
@@ -234,7 +234,6 @@ out:
 gboolean r_umount(const gchar *filename, GError **error)
 {
 	GError *ierror = NULL;
-	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(10, g_free);
 
 	g_return_val_if_fail(filename != NULL, FALSE);
@@ -244,18 +243,15 @@ gboolean r_umount(const gchar *filename, GError **error)
 	g_ptr_array_add(args, g_strdup(filename));
 	g_ptr_array_add(args, NULL);
 
-	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
-	if (!res) {
+	if (!r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror)) {
 		g_propagate_prefixed_error(
 				error,
 				ierror,
 				"failed to run umount: ");
-		goto out;
+		return FALSE;
 	}
 
-	res = TRUE;
-out:
-	return res;
+	return TRUE;
 }
 
 /* Creates a mount subdir in mount path prefix */

--- a/src/mount.c
+++ b/src/mount.c
@@ -340,25 +340,21 @@ out:
 gboolean r_umount_slot(RaucSlot *slot, GError **error)
 {
 	GError *ierror = NULL;
-	gboolean res = FALSE;
 
 	g_return_val_if_fail(slot != NULL, FALSE);
 	g_return_val_if_fail(slot->mount_point != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	res = r_umount(slot->mount_point, &ierror);
-	if (!res) {
-		res = FALSE;
+	if (!r_umount(slot->mount_point, &ierror)) {
 		g_propagate_prefixed_error(
 				error,
 				ierror,
 				"failed to unmount slot: ");
-		goto out;
+		return FALSE;
 	}
 
 	g_rmdir(slot->mount_point);
 	g_clear_pointer(&slot->mount_point, g_free);
 
-out:
-	return res;
+	return TRUE;
 }

--- a/src/mount.c
+++ b/src/mount.c
@@ -63,7 +63,6 @@ gboolean r_umount_bundle(const gchar *mountpoint, GError **error)
 gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar* type, const gchar* extra_options, GError **error)
 {
 	GError *ierror = NULL;
-	gboolean res = FALSE;
 	g_autoptr(GPtrArray) args = g_ptr_array_new_full(10, g_free);
 
 	g_return_val_if_fail(source != NULL, FALSE);
@@ -93,18 +92,15 @@ gboolean r_mount_full(const gchar *source, const gchar *mountpoint, const gchar*
 	g_ptr_array_add(args, g_strdup(mountpoint));
 	g_ptr_array_add(args, NULL);
 
-	res = r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror);
-	if (!res) {
+	if (!r_subprocess_runv(args, G_SUBPROCESS_FLAGS_NONE, &ierror)) {
 		g_propagate_prefixed_error(
 				error,
 				ierror,
 				"failed to run mount: ");
-		goto out;
+		return FALSE;
 	}
 
-	res = TRUE;
-out:
-	return res;
+	return TRUE;
 }
 
 gboolean r_setup_loop(gint fd, gint *loopfd_out, gchar **loopname_out, goffset size, GError **error)


### PR DESCRIPTION
There is no need for a `res` variable and gotos in these simple functions.