### PR TITLE
src/context: priorize bootchooser to select bootslot (for custom bootloader backend)

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -374,15 +374,15 @@ static gboolean r_context_configure_target(GError **error)
 		g_warning("Ignoring surrounding whitespace in system variant: %s", context->config->system_variant);
 
 	if (context->bootslot == NULL) {
-		context->bootslot = get_cmdline_bootname();
-	}
-
-	if (context->bootslot == NULL) {
 		context->bootslot = r_boot_get_current_bootname(context->config, &ierror);
 		if (ierror) {
 			g_message("Failed to get bootname: %s", ierror->message);
 			g_clear_error(&ierror);
 		}
+	}
+
+	if (context->bootslot == NULL) {
+		context->bootslot = get_cmdline_bootname();
 	}
 
 	g_clear_pointer(&context->boot_id, g_free);


### PR DESCRIPTION
The commit 9af0613c7527ebadc855c1a49a4d10757150194a introduced the new bootchooser API r_boot_get_current_bootname() to allow the backend to determine the current bootslot.

Since then, the bootchooser is able determine the bootslot if it cannot be guessed from the kernel cmdline; it is used by the custom backend only at that moment.

This gives the priority to the bootchooser over the kernel cmdline.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
