### PR TITLE
src/bootloaders/custom: don't auto-free GError r_custom_get_current_bootname()

### DIFF
--- a/src/bootloaders/custom.c
+++ b/src/bootloaders/custom.c
@@ -124,7 +124,7 @@ gchar *r_custom_get_current_bootname(RaucConfig *config, GError **error)
 	g_autoptr(GSubprocess) handle = NULL;
 	g_autoptr(GDataInputStream) datainstream = NULL;
 	g_autoptr(GPtrArray) args_array = NULL;
-	g_autoptr(GError) ierror = NULL;
+	GError *ierror = NULL;
 	g_autofree gchar *outline = NULL;
 	GInputStream *instream;
 	int res;


### PR DESCRIPTION
When using `autoptr()` for the inner error, it will be freed when leaving the function context and the propagated error message will be empty.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
