### PR TITLE
Cleanup dangling bundle mount point before install.

### DIFF
--- a/include/mount.h
+++ b/include/mount.h
@@ -114,3 +114,12 @@ G_GNUC_WARN_UNUSED_RESULT;
  * @return True if succeeded, False if failed
  */
 gboolean r_umount_slot(RaucSlot *slot, GError **error);
+
+/**
+ * Check if a path is mount point.
+ *
+ * @param mountpoint path for mount check
+ *
+ * @return True if path is a mount point, False if not
+ */
+gboolean r_is_mount_point(const gchar *mountpoint);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2915,6 +2915,21 @@ static gboolean read_complete_dm_device(gchar *dev, GError **error)
 	return ret;
 }
 
+static gboolean cleanup_dangling_mount(const gchar* mount_point, GError **error)
+{
+	GError *ierror = NULL;
+
+	if (r_is_mount_point(mount_point)) {
+		g_message("Unmount dangling moint point: %s", mount_point);
+		if (!r_umount_bundle(mount_point, &ierror)) {
+			g_warning("Unable to unmount dangling moint point: %s", ierror->message);
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
 /*
  * Sets up dm-verity for reading verity bundles.
  *
@@ -2937,6 +2952,12 @@ static gboolean prepare_verity(RaucBundle *bundle, gchar *loopname, gchar* mount
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	res = check_manifest_external(bundle->manifest, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	res = cleanup_dangling_mount(mount_point, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		return FALSE;
@@ -3004,6 +3025,12 @@ static gboolean prepare_crypt(RaucBundle *bundle, gchar *loopname, gchar* mount_
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	res = check_manifest_external(bundle->manifest, &ierror);
+	if (!res) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	res = cleanup_dangling_mount(mount_point, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
 		return FALSE;


### PR DESCRIPTION
If rauc install process is terminated, the next run will fail with the following error: 
`Failed mounting bundle: Failed to create dm device: Device or resource busy`

The cause is the bundle from previous run is still mounted. This patch address this issue by check bundle mount point and unmount dangling bundle.

Fix #1676 
