### PR TITLE
Allow fallback to bundle download if streaming install failed.

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -260,6 +260,10 @@ Example configuration:
   mark-bad other' after marking the currently booted slot as good.
   This means that the other slot(s) is/are no longer eligible for fallback.
 
+``bundle-fallback-download`` (optional)
+  If set to ``true``, allow fallback to bundle download if streaming install initialization
+  is failed, for example server failed to response ranged request.
+
 .. _keyring-section:
 
 ``[keyring]`` Section
@@ -1369,8 +1373,8 @@ Command Line Tool
     RAUC_PKCS11_MODULE  Library filename for PKCS#11 module (signing only)
     RAUC_PKCS11_PIN     PIN to use for accessing PKCS#11 keys (signing only)
 
-.. note:: 
-  Using -C / --confopt can not only override settings of the config file but also 
+.. note::
+  Using -C / --confopt can not only override settings of the config file but also
   set new values that haven't been present before.
 
 .. _sec-handler-interface:

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -77,6 +77,8 @@ typedef struct {
 	guint bundle_formats_mask;
 	/* enable complete read before mount */
 	gboolean perform_pre_check;
+	/* Fallback to download if streaming failed */
+	gboolean bundle_fallback_download;
 
 	gchar *autoinstall_path;
 	gchar *preinstall_handler;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1011,6 +1011,17 @@ gboolean load_config(const gchar *filename, RaucConfig **config, GError **error)
 		c->system_variant = g_steal_pointer(&variant_data);
 	}
 
+	/* parse 'bundle-fallback-download' key */
+	c->bundle_fallback_download = g_key_file_get_boolean(key_file, "system", "bundle-fallback-download", &ierror);
+	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+		c->bundle_fallback_download = FALSE;
+		g_clear_error(&ierror);
+	} else if (ierror) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+	g_key_file_remove_key(key_file, "system", "bundle-fallback-download", NULL);
+
 	/* parse data/status location
 	 *
 	 * We have multiple levels of backwards compatibility:

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -682,6 +682,17 @@ mountprefix=/mnt/myrauc/\n\
 activate-installed=typo\n");
 }
 
+static void config_file_typo_in_boolean_bundle_fallback_download_key(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	config_file_typo(fixture, "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+bundle-fallback-download=typo\n");
+}
+
 static void config_file_bootname_tab(ConfigFileFixture *fixture, gconstpointer user_data)
 {
 	g_autoptr(RaucConfig) config = NULL;
@@ -844,6 +855,57 @@ activate-installed=false\n";
 	g_assert_nonnull(config);
 	g_assert_false(config->activate_installed);
 }
+
+static void config_file_bundle_fallback_download_set_to_true(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	g_autoptr(RaucConfig) config = NULL;
+	GError *ierror = NULL;
+	gboolean res;
+	g_autofree gchar* pathname = NULL;
+
+	const gchar *cfg_file = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+bundle-fallback-download=true\n";
+
+	pathname = write_tmp_file(fixture->tmpdir, "invalid_bootloader.conf", cfg_file, NULL);
+	g_assert_nonnull(pathname);
+
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_nonnull(config);
+	g_assert_true(config->bundle_fallback_download);
+}
+
+static void config_file_bundle_fallback_download_set_to_false(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	g_autoptr(RaucConfig) config = NULL;
+	GError *ierror = NULL;
+	gboolean res;
+	g_autofree gchar* pathname = NULL;
+
+	const gchar *cfg_file = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+bundle-fallback-download=false\n";
+
+	pathname = write_tmp_file(fixture->tmpdir, "invalid_bootloader.conf", cfg_file, NULL);
+	g_assert_nonnull(pathname);
+
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_nonnull(config);
+	g_assert_false(config->bundle_fallback_download);
+}
+
 
 static void config_file_system_variant(ConfigFileFixture *fixture,
 		gconstpointer user_data)
@@ -1649,6 +1711,9 @@ int main(int argc, char *argv[])
 	g_test_add("/config-file/typo-in-boolean-activate-installed-key", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_typo_in_boolean_activate_installed_key,
 			config_file_fixture_tear_down);
+	g_test_add("/config-file/typo-in-boolean-bundle-fallback-download-key", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_typo_in_boolean_bundle_fallback_download_key,
+			config_file_fixture_tear_down);
 	g_test_add("/config-file/bootname-tab", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_bootname_tab,
 			config_file_fixture_tear_down);
@@ -1672,6 +1737,12 @@ int main(int argc, char *argv[])
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/activate-installed-key-set-to-false", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_activate_installed_set_to_false,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/bundle-fallback-download-key-set-to-true", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_bundle_fallback_download_set_to_true,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/bundle-fallback-download-key-set-to-false", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_bundle_fallback_download_set_to_false,
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/system-variant", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_system_variant,


### PR DESCRIPTION
Add an option `bundle-fallback-download`, if set to `true`, allows a streaming install fallback to bundle download if nbd setup failed, which could be caused by server range request handling issue.

