### PR TITLE
meson: add support for building without OpenSSL engine support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -172,6 +172,10 @@ if composefsdep.found()
   sources_rauc += files('src/artifacts_composefs.c')
 endif
 
+# To allow building against OpenSSL 3.0 and 4.0 without engine support
+# as they are deprecated in favor of providers API
+conf.set10('ENABLE_OPENSSL_PKCS11_ENGINE', get_option('pkcs11_engine'))
+
 gnome = import('gnome')
 dbus_ifaces = files('src/de.pengutronix.rauc.Installer.xml')
 dbus_sources = gnome.gdbus_codegen(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -34,6 +34,11 @@ option(
   type : 'feature',
   value : 'disabled',
   description : 'Enable/Disable composefs artifact installation support')
+option(
+  'pkcs11_engine',
+  type : 'boolean',
+  value : 'true',
+  description : 'Enable/Disable OpenSSL PKCS11 engine support')
 
 # other options
 option(

--- a/src/signature.c
+++ b/src/signature.c
@@ -5,7 +5,9 @@
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/crypto.h>
+#if ENABLE_OPENSSL_PKCS11_ENGINE
 #include <openssl/engine.h>
+#endif
 #include <openssl/x509.h>
 #include <string.h>
 
@@ -117,6 +119,7 @@ gboolean signature_init(GError **error)
 	return TRUE;
 }
 
+#if ENABLE_OPENSSL_PKCS11_ENGINE
 static ENGINE *get_pkcs11_engine(GError **error)
 {
 	static ENGINE *e = NULL;
@@ -181,6 +184,7 @@ free:
 out:
 	return e;
 }
+#endif
 
 static EVP_PKEY *load_key_file(const gchar *keyfile, GError **error)
 {
@@ -221,6 +225,7 @@ out:
 static EVP_PKEY *load_key_pkcs11(const gchar *url, GError **error)
 {
 	EVP_PKEY *res = NULL;
+#if ENABLE_OPENSSL_PKCS11_ENGINE
 	GError *ierror = NULL;
 	ENGINE *e;
 
@@ -242,6 +247,14 @@ static EVP_PKEY *load_key_pkcs11(const gchar *url, GError **error)
 				"failed to load PKCS11 private key for '%s': %s", url, get_openssl_err_string());
 		goto out;
 	}
+#else
+	g_set_error(
+			error,
+			R_SIGNATURE_ERROR,
+			R_SIGNATURE_ERROR_LOAD_FAILED,
+			"failed to load PKCS11 private key for '%s': OpenSSL engine support disabled", url);
+#endif
+
 out:
 	return res;
 }
@@ -345,6 +358,7 @@ out:
 static X509 *load_cert_pkcs11(const gchar *url, GError **error)
 {
 	X509 *res = NULL;
+#if ENABLE_OPENSSL_PKCS11_ENGINE
 	GError *ierror = NULL;
 	ENGINE *e;
 
@@ -374,6 +388,13 @@ static X509 *load_cert_pkcs11(const gchar *url, GError **error)
 		goto out;
 	}
 	res = parms.cert;
+#else
+	g_set_error(
+			error,
+			R_SIGNATURE_ERROR,
+			R_SIGNATURE_ERROR_PARSE_ERROR,
+			"failed to load PKCS11 certificate for '%s': OpenSSL engine support disabled", url);
+#endif
 
 out:
 	return res;


### PR DESCRIPTION
Adding -DDISABLE_OPENSSL_ENGINE will disable engine support and remove openssl-devel-engine dependency on Fedora.
OpenSSL engine support will also be removed in 4.0 in favour of providers API.
I have tested an earlier version of the patch in Fedora Copr RPM build.
https://copr.fedorainfracloud.org/coprs/bax/rauc/build/8859137/

Fixes: #1688
