### PR TITLE
fix OpenSSL 3.5 compatibility

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -780,7 +780,9 @@ void r_context_register_progress_callback(progress_callback progress_cb)
 
 RaucContext *r_context_conf(void)
 {
-	if (context == NULL) {
+	static gboolean initialized = FALSE;
+
+	if (!initialized) {
 		GError *ierror = NULL;
 
 		// let us handle broken pipes explicitly
@@ -797,6 +799,10 @@ RaucContext *r_context_conf(void)
 			return NULL;
 		}
 
+		initialized = TRUE;
+	}
+
+	if (context == NULL) {
 		context = g_new0(RaucContext, 1);
 		context->progress = NULL;
 		context->install_info = g_new0(RContextInstallationInfo, 1);

--- a/src/signature.c
+++ b/src/signature.c
@@ -93,14 +93,12 @@ gboolean signature_init(GError **error)
 		return FALSE;
 	}
 
-	id = X509_PURPOSE_get_count() + 1;
-	if (X509_PURPOSE_get_by_id(id) >= 0) {
-		g_set_error_literal(
-				error,
-				R_SIGNATURE_ERROR,
-				R_SIGNATURE_ERROR_CRYPTOINIT_FAILED,
-				"Failed to calculate free OpenSSL X509 purpose id");
-		return FALSE;
+	/* OpenSSL 3.5 warns that there may be gaps, so we need to search.
+	 * When we have 3.5 as the minimum version, we can use
+	 * X509_PURPOSE_get_unused_id instead. */
+	id = X509_PURPOSE_MAX + 1;
+	while (X509_PURPOSE_get_by_id(id) != -1) {
+		id++;
 	}
 
 	/* X509_TRUST_OBJECT_SIGN maps to the Code Signing ID (via OpenSSL's NID_code_sign) */


### PR DESCRIPTION
In the test suite, we sometimes recreate the context, which caused
multiple initialization of the network and signature dependencies. With
OpenSSL 3.5, this leads to purpose ID collisions, as we try to add the
same purpose multiple times.

Avoid this by remembering if the have initialized our dependencies
already.

Also handle possible gaps in the number space for OpenSSL 3.5.

Fixes: 295fa3a ("src/context.c: fully free context in r_context_clean()")