### PR TITLE
docs/examples: fix grub.cfg example

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -77,8 +77,11 @@ out of the box. Instead we use a script to implement it
 
 .. code-block:: sh
 
+  # set default menuentry (Slot A) and timeout (3s)
   default=0
   timeout=3
+
+  any_ok=0
 
   set ORDER="A B"
   set A_OK=0
@@ -103,12 +106,13 @@ out of the box. Instead we use a script to implement it
       fi
       if [ "$OK" -eq 1 -a "$TRY" -eq 0 ]; then
           default=$INDEX
+          any_ok=1
           break
       fi
   done
 
-  # reset booted flags
-  if [ "$default" -eq 0 ]; then
+  # reset booted flags in case both sides have failed to boot
+  if [ "$any_ok" -eq 0 ]; then
       if [ "$A_OK" -eq 1 -a "$A_TRY" -eq 1 ]; then
           A_TRY=0
       fi


### PR DESCRIPTION
Prior to this patch if the A side failed to boot the B side would never have been tried.

This is because default=0 is used as a sentinel value, while in fact it is also the case where the A side is selected

I think this happened when someone took the grub.conf from the repo [0] and tried to remove the rescue menuentry. If the rescue menuentry is present using default=0 as a sentinel value works, as it will never be selected unless both sides are broken.

[0]: https://github.com/rauc/rauc/blob/master/contrib/grub.conf
