### PR TITLE
src/update_handler: fix memory leak on G_IO_ERROR_NO_SPACE in clear_slot()

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -82,11 +82,15 @@ static gboolean clear_slot(RaucSlot *slot, GError **error)
 		 * G_IO_ERROR_NO_SPACE is expected here, because the block
 		 * device is cleared completely
 		 */
-		if (write_count == -1 &&
-		    !g_error_matches(ierror, G_IO_ERROR, G_IO_ERROR_NO_SPACE)) {
-			g_propagate_prefixed_error(error, ierror,
-					"failed clearing block device: ");
-			return FALSE;
+		if (write_count == -1) {
+			if (g_error_matches(ierror, G_IO_ERROR, G_IO_ERROR_NO_SPACE)) {
+				g_clear_error(&ierror);
+				break;
+			} else {
+				g_propagate_prefixed_error(error, ierror,
+						"failed clearing block device: ");
+				return FALSE;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
This PR improves the robustness of clear_slot() by addressing a potential memory leak when G_IO_ERROR_NO_SPACE occurs

## Changes
- Added explicit g_clear_error() when the error is expected and recoverable.

## Question
Using `ioctl(fd, BLKDISCARD)` to discard blocks rather than zero-write may be more efficient for flash-based block devices?

