### PR TITLE
de.pengutronix.rauc.Installer.xml: use CC0-1.0 license

### DIFF
--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "https://specifications.freedesktop.org/dbus/introspect-latest.dtd">
-<!-- License note: This file is considered data and thus no license is needed for any usage. -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
 <node>
   <interface name="de.pengutronix.rauc.Installer">
     <!--


### PR DESCRIPTION
CC0-1.0 license better match intended license, as it was never intended that XML description of the D-Bus interface could not be distributed.

This allows rauc to be packaged in Fedora Linux as the previous "no license" does not allow redistribution of the XML file.

Fixes: #1713