### PR TITLE
src/slot: fix mount point detection for symlinks

### DIFF
--- a/src/slot.c
+++ b/src/slot.c
@@ -68,6 +68,19 @@ RaucSlot *r_slot_find_by_device(GHashTable *slots, const gchar *device)
 	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
 		if (g_strcmp0(slot->device, device) == 0) {
 			return slot;
+		} else {
+			/* The device mentioned in the slot definition may be a symlink (e.g. /dev/disk/by-id/...),
+			 * but the mount point is always passed to this function as the real device path.
+			 * So try to resolve the slot's device path and check if this path matches the device.
+			 */
+			char* resolved = realpath(slot->device, NULL);
+			if (resolved) {
+				if (g_strcmp0(resolved, device) == 0) {
+					g_clear_pointer(&resolved, free);
+					return slot;
+				}
+				g_clear_pointer(&resolved, free);
+			}
 		}
 	}
 


### PR DESCRIPTION
In multiple use cases, it is desirable to use a symlink to a device in the `device=/dev/<device>` attribute of a slot in `system.conf` instead of the actual path of the device.
For example, one might want to identify the slots using attributes such as the disk id or path by using udev-provided symlinks such as `/dev/disk/by-id/...` or `/dev/disk/by-path`.
Or, on devices that support booting from multiple media, dynamically create a symlink such as
`/dev/disk/rootfs-0` that points to the appropriate partition on the currently-active boot device.

This currently makes the mount point detection fail because RAUC cannot identify that such a device is actually mounted to a slot. (`rauc status` does not identify such a slot as `mounted: /<mountpoint>`.)

The reason seems to be the way that `update_external_mount_points()` matches mount points with slots:

To get the currently-mounted devices, `g_unix_mounts_get()` is used and returns the real paths of all mounted devices.
Then, `find_config_slot_by_device()` is used and calls `r_slot_find_by_device()` to match active mounts with config entries.

This iterates over all slots and checks whether the `slot->device` is equal to the given `device` name. In the symlink case, this will fail because the path of the `slot->device` is never resolved. This MR adds handling for the symlink case to `r_slot_find_by_device()` by using `realpath` to resolve the slot's device path.

I could imagine two alternative approaches:
 - Always and unconditionally checking the `realpath()` instead of only when the direct comparison fails. This would introduce a small additional cost in the regular case.
 Also, it would make the function not identify a slot as mounted if the `slot->device` does not point to an existing file that is listed as  a mount point nonetheless - which is relevant at least in one of the `bootchooser` unit tests (but most likely not in real-world use-cases because non-existing devices should not be returned by `g_unix_mounts_get()`).
 - Resolving the paths early after loading the config - I am not sure whether this would be desirable, so I went with the minimally-invasive route.