### PR TITLE
src/dm: replace data size assertion by explicit gerror

### DIFF
--- a/src/dm.c
+++ b/src/dm.c
@@ -99,8 +99,19 @@ gboolean r_dm_setup(RaucDM *dm, GError **error)
 	g_return_val_if_fail(dm->uuid != NULL, FALSE);
 	g_return_val_if_fail(dm->lower_dev != NULL, FALSE);
 	g_return_val_if_fail(dm->upper_dev == NULL, FALSE);
-	g_return_val_if_fail(dm->data_size > 0 && dm->data_size % 4096 == 0, FALSE);
+	g_return_val_if_fail(dm->data_size > 0, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (dm->data_size % 4096 != 0) {
+		g_set_error(error,
+				G_FILE_ERROR,
+				G_FILE_ERROR_FAILED,
+				"Payload size (%"G_GUINT64_FORMAT ") is not a multiple of 4KiB. "
+				"See https://rauc.readthedocs.io/en/latest/faq.html#what-causes-a-payload-size-that-is-not-a-multiple-of-4kib",
+				dm->data_size);
+		res = FALSE;
+		goto out;
+	}
 
 	dmfd = open("/dev/mapper/control", O_RDWR|O_CLOEXEC);
 	if (dmfd < 0) {


### PR DESCRIPTION
When using a modified raucb bundle with payload that is not a multiple of 4096, the following assertion happens:

"rauc-CRITICAL **: r_dm_setup: assertion 'dm->data_size > 0 && dm->data_size % 4096 == 0' failed"

Repalce the assertion with a proper gerror failure.

Fixes: #1684
Reported-by: Tobias Graemer <tobias.graemer@mt.com>
Signed-off-by: Janek Filus <janek.filus@mt.com>