### PR TITLE
Extend prevent-late-fallback by lock-counter

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -890,6 +890,31 @@ boot target is required:
           };
   };
 
+.. _integration-barebox-lock-counter:
+Optionally, if ``prevent-late-fallback=lock-counter`` is set,
+another single variable must be added.
+
+.. code-block:: Devicetree
+
+  bootstate {
+
+          [...]
+
+          attempts_locked@14 {
+                  reg = <0x14 0x4>;
+                  type = "uint32";
+          };
+  };
+
+This makes barebox aware of the counter locking state due to the
+the ``remaining_attempts`` counter.
+Boot counter locking is activated when 'rauc status mark-good' is executed
+implicitly during a RAUC update or explicitly through manual commands.
+The current value of the ``attempts_locked`` state variable can be read via the commands
+``barebox-state -d`` and ``rauc status``.
+It is not yet available via the D-Bus interface and thus cannot be displayed
+when calling ``rauc status`` with the service enabled.
+
 .. warning::
   This example shows only a highly condensed excerpt of setting up Barebox
   state for bootchooser.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -256,13 +256,32 @@ Example configuration:
   It has no effect for ``plain`` bundles, as the signature verification already checks the
   whole bundle.
 
-``prevent-late-fallback=<true/false>`` (optional)
-  In some use-cases, fallback to an older version must be prevented after the
+``prevent-late-fallback=<disable/mark-bad/lock-counter>`` (optional)
+  .. note:: The former existing Values *<true/false>* for this option are deprecated.
+     They will be removed in a future release, Please use the new values.
+
+  In order to get the same behaviour set ``prevent-late-fallback=mark-bad``.
+  For some use-cases, fallback to an older version must be prevented after the
   update is completed successfully (``rauc status mark-good`` executed from the
-  new version).
-  If this option is enabled, RAUC will execute the equivalent of ``rauc status
-  mark-bad other`` after marking the currently booted slot as good.
-  This means that the other slot(s) is/are no longer eligible for fallback.
+  new version). This setting is slot independent.
+
+  Supported values are:
+
+  * ``disable`` Default if not set. Do not prevent fallback to older version.
+  * ``mark-bad`` If this option is enabled, RAUC will execute the equivalent of
+    'rauc status mark-bad other' after marking the currently booted slot as good.
+    This means that the other slot(s) is/are no longer eligible for fallback.
+    It behaves exactly like the *deprecated* ``prevent-late-fallback=false``.
+  * ``lock-counter`` This options allows RAUC to maintain awareness of
+    their respective states.
+    The ``slots-locking`` state is stored in a separate variable that must be
+    recognized by the ``bootloader``.
+    Currently, this feature is only supported when ``bootloader``
+    is set to ``barebox``, and the ``&bootstate`` in the devicetree must
+    include a new variable, which is described in the
+    :ref:`integration chapter <integration-barebox-lock-counter>`.
+    In case the variable is not set in the ``bootloader``, a warning is emitted
+    after an update in order to keep the system in an updatable state.
 
 .. _keyring-section:
 

--- a/include/bootchooser.h
+++ b/include/bootchooser.h
@@ -56,6 +56,26 @@ gboolean r_boot_set_state(RaucSlot *slot, gboolean good, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Enable or disable locking of the boot counter.
+ * This variable is not set per slot, but is valid for all slots.
+ *
+ * @param locked TRUE to lock counting, FALSE to unlock it
+ * @param error return location for a GError, or NULL
+ *
+ * @return TRUE if successful, FALSE if failed
+ */
+gboolean r_boot_set_counters_lock(gboolean locked, GError **error);
+
+/**
+ * Check current status of boot counter locking in the bootloader.
+ *
+ * @param locked return location for the related value in the bootloader
+ * @param error return location for a GError, or NULL
+ *
+ * @return TRUE if successful, FALSE if failed
+ */
+gboolean r_boot_get_counters_lock(gboolean *locked, GError **error);
+/**
  * Mark slot as primary boot option of its slot class.
  *
  * @param slot Slot to mark

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -39,6 +39,12 @@ typedef enum {
 	R_CONFIG_SYS_VARIANT_NAME,
 } RConfigSysVariant;
 
+typedef enum {
+	R_CONFIG_FALLBACK_DISABLE = 0,
+	R_CONFIG_FALLBACK_MARK_BAD = 1,
+	R_CONFIG_FALLBACK_LOCK_COUNTER = 2,
+} RConfigLateFallback;
+
 /* System configuration */
 typedef struct {
 	gchar *system_compatible;
@@ -54,7 +60,7 @@ typedef struct {
 	gchar *custom_bootloader_backend;
 	gboolean efi_use_bootnext;
 	/** prevent fallback after successfully booting into primary slot */
-	gboolean prevent_late_fallback;
+	RConfigLateFallback prevent_late_fallback;
 	/* maximum filesize to download in bytes */
 	guint64 max_bundle_download_size;
 	/* maximum signature/CMS size in bytes */

--- a/src/bootchooser.c
+++ b/src/bootchooser.c
@@ -155,6 +155,62 @@ gboolean r_boot_set_state(RaucSlot *slot, gboolean good, GError **error)
 	return res;
 }
 
+gboolean r_boot_set_counters_lock(gboolean locked, GError **error)
+{
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	gboolean res = FALSE;
+	GError *ierror = NULL;
+	if (g_strcmp0(r_context()->config->system_bootloader, "barebox") == 0) {
+		res = r_barebox_set_lock_counter(locked, &ierror);
+	} else {
+		g_set_error(
+				error,
+				R_BOOTCHOOSER_ERROR,
+				R_BOOTCHOOSER_ERROR_NOT_SUPPORTED,
+				"Using boot lock-counter for bootloader '%s' not supported yet", r_context()->config->system_bootloader);
+		return FALSE;
+	}
+
+	if (!res) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"%s backend: ", r_context()->config->system_bootloader);
+	}
+
+	return res;
+}
+
+gboolean r_boot_get_counters_lock(gboolean *locked, GError **error)
+{
+	GError *ierror = NULL;
+	gboolean res = FALSE;
+
+	g_return_val_if_fail(locked != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (g_strcmp0(r_context()->config->system_bootloader, "barebox") == 0) {
+		res = r_barebox_get_lock_counter(locked, &ierror);
+	} else {
+		g_set_error(
+				error,
+				R_BOOTCHOOSER_ERROR,
+				R_BOOTCHOOSER_ERROR_NOT_SUPPORTED,
+				"Counter locking not yet supported for bootloader '%s'", r_context()->config->system_bootloader);
+		return FALSE;
+	}
+
+	if (!res) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"%s backend: ", r_context()->config->system_bootloader);
+	}
+
+	return res;
+}
+
 /* Get slot marked as primary one */
 RaucSlot *r_boot_get_primary(GError **error)
 {

--- a/src/bootloaders/barebox.h
+++ b/src/bootloaders/barebox.h
@@ -10,6 +10,12 @@ G_GNUC_WARN_UNUSED_RESULT;
 gboolean r_barebox_set_state(RaucSlot *slot, gboolean good, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
+gboolean r_barebox_set_lock_counter(gboolean locked, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+gboolean r_barebox_get_lock_counter(gboolean *locked, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
 gboolean r_barebox_set_primary(RaucSlot *slot, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -131,6 +131,29 @@ out:
 	return res;
 }
 
+static gboolean parse_late_fallback_mode(const gchar *mode_str, RConfigLateFallback *mode, GError **error)
+{
+	g_return_val_if_fail(mode != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (g_strcmp0(mode_str, "disable") == 0) {
+		*mode = R_CONFIG_FALLBACK_DISABLE;
+		return TRUE;
+	} else if (g_strcmp0(mode_str, "mark-bad") == 0) {
+		*mode = R_CONFIG_FALLBACK_MARK_BAD;
+		return TRUE;
+	} else if (g_strcmp0(mode_str, "lock-counter") == 0) {
+		*mode = R_CONFIG_FALLBACK_LOCK_COUNTER;
+		return TRUE;
+	}
+	g_set_error(error,
+			G_KEY_FILE_ERROR,
+			G_KEY_FILE_ERROR_INVALID_VALUE,
+			"Invalid prevent-late-fallback value '%s'. Must be one of: disable, mark-bad, lock-counter, true, false",
+			mode_str);
+	return FALSE;
+}
+
 #define RAUC_LOG_EVENT_CONF_PREFIX "log"
 
 static gboolean r_event_log_parse_config_sections(GKeyFile *key_file, RaucConfig *config, GError **error)
@@ -465,13 +488,33 @@ static gboolean parse_system_section(const gchar *filename, GKeyFile *key_file, 
 	if (dtbvariant)
 		c->system_variant_type = R_CONFIG_SYS_VARIANT_DTB;
 
+	/* Boolean value is deprecated. To keep it simple and easy to remove in the future,
+	 * we assign the old boolean value to their respective new enum values.
+	 * Both are internally mapped to integers so:
+	 * FALSE=R_CONFIG_FALLBACK_DISABLE=0
+	 * TRUE=R_CONFIG_FALLBACK_MARK_BAD=1
+	 */
 	c->prevent_late_fallback = g_key_file_get_boolean(key_file, "system", "prevent-late-fallback", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
-		c->prevent_late_fallback = FALSE;
+		c->prevent_late_fallback = R_CONFIG_FALLBACK_DISABLE;
 		g_clear_error(&ierror);
+	} else if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE)) {
+		/* Boolean is deprecated, so it's probably the new string format */
+		g_clear_error(&ierror);
+		g_autofree gchar *mode_str = g_key_file_get_string(key_file, "system", "prevent-late-fallback", &ierror);
+		if (ierror) {
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
+		if (!parse_late_fallback_mode(mode_str, &c->prevent_late_fallback, &ierror)) {
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
 	} else if (ierror) {
 		g_propagate_error(error, ierror);
 		return FALSE;
+	} else {
+		g_info("Using bool for 'prevent-late-fallback' is deprecated. Use one of 'disable', 'mark-bad' or 'lock-counter' instead.");
 	}
 	g_key_file_remove_key(key_file, "system", "prevent-late-fallback", NULL);
 

--- a/src/mark.c
+++ b/src/mark.c
@@ -1,6 +1,8 @@
 #include "bootchooser.h"
+#include "config_file.h"
 #include "event_log.h"
 #include "context.h"
+#include "glib.h"
 #include "install.h"
 #include "mark.h"
 #include "slot.h"
@@ -141,6 +143,22 @@ gboolean r_mark_active(RaucSlot *slot, GError **error)
 	r_slot_status_load(slot);
 	slot_state = slot->status;
 
+	/* Unlock boot counting before marking the slot primary. Reversing the order would create
+	 * an unintended corner case where a power cut could leave the system configured to boot from a new,
+	 * untested slot without the ability to fall back if that slot fails to boot properly, as it would
+	 * still be locked. So it is better to prepare the fallback mechanisms first. */
+	if (r_context()->config->prevent_late_fallback == R_CONFIG_FALLBACK_LOCK_COUNTER) {
+		if (!r_boot_set_counters_lock(FALSE, &ierror)) {
+			if (g_error_matches(ierror, R_BOOTCHOOSER_ERROR, R_BOOTCHOOSER_ERROR_NOT_SUPPORTED)) {
+				g_propagate_error(error, ierror);
+				return FALSE;
+			}
+			/* If we would throw an error here, RAUC would fail and it might not be possible to execute updates anymore. */
+			g_warning("Unable to set lock-counter in bootloader. Check your bootloader setup: %s", ierror->message);
+			g_clear_error(&ierror);
+		}
+	}
+
 	if (!r_boot_set_primary(slot, &ierror)) {
 		g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_BOOTABLE,
 				"failed to activate slot %s: %s", slot->name, ierror->message);
@@ -175,6 +193,22 @@ gboolean r_mark_good(RaucSlot *slot, GError **error)
 				"Failed marking slot %s as good:  %s", slot->name, ierror->message);
 		g_error_free(ierror);
 		return FALSE;
+	}
+
+	/* It is more sensible to mark the slot as good before locking the counter. As in case of a power fail between
+	 * marking and locking, the boot lock counter could be set by a mark-good on a later boot.
+	 * In case of a problem during the next boot we'd have a system with a working fallback to the old slot, so
+	 * the system would still fall back to the other slot if the current one fails, as the bootcounter has not been locked yet. */
+	if (r_context()->config->prevent_late_fallback == R_CONFIG_FALLBACK_LOCK_COUNTER) {
+		if (!r_boot_set_counters_lock(TRUE, &ierror)) {
+			if (g_error_matches(ierror, R_BOOTCHOOSER_ERROR, R_BOOTCHOOSER_ERROR_NOT_SUPPORTED)) {
+				g_propagate_error(error, ierror);
+				return FALSE;
+			}
+			/* If we would throw an error here, RAUC would fail and it might not be possible to execute updates anymore. */
+			g_warning("Unable to set lock-counter in bootloader. Check your bootloader setup: %s", ierror->message);
+			g_clear_error(&ierror);
+		}
 	}
 
 	r_event_log_mark_good(slot);

--- a/src/mark.c
+++ b/src/mark.c
@@ -232,7 +232,7 @@ gboolean mark_run(const gchar *state,
 			return FALSE;
 		}
 
-		if (r_context()->config->prevent_late_fallback
+		if (r_context()->config->prevent_late_fallback == R_CONFIG_FALLBACK_MARK_BAD
 		    && g_strcmp0(slot_identifier, "booted") == 0) {
 			g_autofree gchar *mark_bad_message = NULL;
 

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -681,6 +681,180 @@ mountprefix=/mnt/myrauc/\n\
 activate-installed=typo\n");
 }
 
+static void config_file_typo_in_prevent_late_fallback_key(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	config_file_typo(fixture, "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+prevent-late-fallback=typo\n\
+\n\
+[slot.rescue.0]\n\
+description=Rescue partition\n\
+device=/dev/mtd4\n\
+type=raw\n\
+bootname=factory0\n");
+}
+
+static void config_file_default_value_false_when_not_set_for_prevent_late_fallback_key(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	GError *ierror = NULL;
+	gboolean res;
+	g_autoptr(RaucConfig) config = NULL;
+	g_autofree gchar* pathname = NULL;
+
+	const gchar *cfg_file = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+min-bundle-version=2024.05-downgrade+barrier\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+statusfile=/mnt/persistent-rw-fs/system.raucs\n\
+bundle-formats=verity\n";
+
+	pathname = write_tmp_file(fixture->tmpdir, "full_config.conf", cfg_file, NULL);
+	g_assert_nonnull(pathname);
+
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_nonnull(config);
+	g_assert_true(config->prevent_late_fallback == R_CONFIG_FALLBACK_DISABLE);
+}
+
+static void config_file_test_all_late_fallback_deprecated_options(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	GError *ierror = NULL;
+	gboolean res;
+	g_autoptr(RaucConfig) config = NULL;
+	g_autofree gchar* pathname = NULL;
+
+	const gchar *cfg_file_fallback_true = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+prevent-late-fallback=true\n\
+\n\
+[slot.rescue.0]\n\
+description=Rescue partition\n\
+device=/dev/mtd4\n\
+type=raw\n\
+bootname=factory0\n";
+
+	pathname = write_tmp_file(fixture->tmpdir, "fallback_true_counter_config.conf", cfg_file_fallback_true, NULL);
+	g_assert_nonnull(pathname);
+
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_nonnull(config);
+	g_assert_true(config->prevent_late_fallback);
+	g_clear_pointer(&config, free_config);
+	g_free(pathname);
+
+	const gchar *cfg_file_fallback_false = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+prevent-late-fallback=false\n\
+\n\
+[slot.rescue.0]\n\
+description=Rescue partition\n\
+device=/dev/mtd4\n\
+type=raw\n\
+bootname=factory0\n";
+
+	pathname = write_tmp_file(fixture->tmpdir, "fallback_false_config.conf", cfg_file_fallback_false, NULL);
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_nonnull(config);
+	g_assert_false(config->prevent_late_fallback);
+	g_clear_pointer(&config, free_config);
+}
+
+static void config_file_test_all_late_fallback_enum_options(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	GError *ierror = NULL;
+	gboolean res;
+	g_autoptr(RaucConfig) config = NULL;
+	g_autofree gchar* pathname = NULL;
+
+	const gchar *cfg_file_fallback_lock_counter = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+prevent-late-fallback=lock-counter\n\
+\n\
+[slot.rescue.0]\n\
+description=Rescue partition\n\
+device=/dev/mtd4\n\
+type=raw\n\
+bootname=factory0\n";
+
+	pathname = write_tmp_file(fixture->tmpdir, "fallback_lock_counter_config.conf", cfg_file_fallback_lock_counter, NULL);
+	g_assert_nonnull(pathname);
+
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_nonnull(config);
+	g_assert_true(config->prevent_late_fallback == R_CONFIG_FALLBACK_LOCK_COUNTER);
+	g_clear_pointer(&config, free_config);
+	g_free(pathname);
+
+	const gchar *cfg_file_fallback_mark_bad = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+prevent-late-fallback=mark-bad\n\
+\n\
+[slot.rescue.0]\n\
+description=Rescue partition\n\
+device=/dev/mtd4\n\
+type=raw\n\
+bootname=factory0\n";
+
+	pathname = write_tmp_file(fixture->tmpdir, "fallback_mark_bad_config.conf", cfg_file_fallback_mark_bad, NULL);
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_nonnull(config);
+	g_assert_true(config->prevent_late_fallback == R_CONFIG_FALLBACK_MARK_BAD);
+	g_clear_pointer(&config, free_config);
+	g_free(pathname);
+
+	const gchar *cfg_file_fallback_disable = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+mountprefix=/mnt/myrauc/\n\
+prevent-late-fallback=disable\n\
+\n\
+[slot.rescue.0]\n\
+description=Rescue partition\n\
+device=/dev/mtd4\n\
+type=raw\n\
+bootname=factory0\n";
+
+	pathname = write_tmp_file(fixture->tmpdir, "fallback_disable_config.conf", cfg_file_fallback_disable, NULL);
+	res = load_config(pathname, &config, &ierror);
+	g_assert_no_error(ierror);
+	g_assert_true(res);
+	g_assert_nonnull(config);
+	g_assert_true(config->prevent_late_fallback == R_CONFIG_FALLBACK_DISABLE);
+	g_clear_pointer(&config, free_config);
+}
+
 static void config_file_bootname_tab(ConfigFileFixture *fixture, gconstpointer user_data)
 {
 	g_autoptr(RaucConfig) config = NULL;
@@ -1675,6 +1849,18 @@ int main(int argc, char *argv[])
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/typo-in-boolean-activate-installed-key", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_typo_in_boolean_activate_installed_key,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/typo-in-prevent-late-fallback-key", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_typo_in_prevent_late_fallback_key,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/typo-in-prevent-late-deprecated-options", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_test_all_late_fallback_deprecated_options,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/typo-in-prevent-late-fallback-enum-options", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_test_all_late_fallback_enum_options,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/config-file-default-value-false-when-not-set-for-prevent-late-fallback-key", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_default_value_false_when_not_set_for_prevent_late_fallback_key,
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/bootname-tab", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_bootname_tab,

--- a/test/install-content/custom_handler.sh
+++ b/test/install-content/custom_handler.sh
@@ -27,6 +27,7 @@ bootstate.system0.priority=20 \
 bootstate.system0.remaining_attempts=3 \
 bootstate.system1.priority=10 \
 bootstate.system1.remaining_attempts=3 \
+bootstate.attempts_locked=1 \
 "
 
 # deactivate current slot


### PR DESCRIPTION
This feature allows to lock the the ``remaining_attempts`` counter.
When ``remaining_attempts`` is locked, the bootloader should not decremented and  incremented the variable anymore during each boot.
It is active when a slot is _marked good_ and inactive when a slot is _marked active_.
This way it prevents fallback to an earlier version, whilst inhibiting additional write cycles to the target medium. 
The status can be printed out with `barebox-state` and `rauc status`.
In a prelimary talk with @ejoerns the decision was made to not add this to the _D-Bus_ interface yet. It will be added in a future pull request.
This feature also needs to be supported by the bootloader. 
So far, a patch has been handed in for _barebox_ to support this feature, see [](https://lists.infradead.org/pipermail/barebox/2025-June/051393.html)