### PR TITLE
Add progress handling during hash index generation for adaptive mode 'block-hash-index'

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -157,6 +157,13 @@ void r_context_end_step(const gchar *name, gboolean success);
 void r_context_set_step_percentage(const gchar *name, gint percentage);
 
 /**
+ * Increases step percentage by one.
+ *
+ * @param name identifying the step. Must be a step with no explicit substeps.
+ */
+void r_context_inc_step_percentage(const gchar *name);
+
+/**
  * Frees the memory allocated by the RaucProgressStep.
  *
  * @param step a RaucProgressStep to free

--- a/include/hash_index.h
+++ b/include/hash_index.h
@@ -149,3 +149,6 @@ void r_hash_index_free(RaucHashIndex *idx);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucHashIndex, r_hash_index_free);
 
 #define R_HASH_INDEX_ZERO_CHUNK "\xad\x7f\xac\xb2\x58\x6f\xc6\xe9\x66\xc0\x4\xd7\xd1\xd1\x6b\x2\x4f\x58\x5\xff\x7c\xb4\x7c\x7a\x85\xda\xbd\x8b\x48\x89\x2c\xa7"
+
+/** Percentage steps reserved for hash index generation */
+#define R_HASH_INDEX_GEN_PROGRESS_SPAN 10

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -167,8 +167,10 @@ if [ -n "$SERVICE" ]; then
   # fake slot devices
   truncate --size=64M /tmp/rootdev
   mkfs.ext4 /tmp/rootdev
-  truncate --size=64M /tmp/appdev
-  mkfs.ext4 /tmp/appdev
+  truncate --size=64M /tmp/appdev0
+  mkfs.ext4 /tmp/appdev0
+  truncate --size=64M /tmp/appdev1
+  mkfs.ext4 /tmp/appdev1
 
   # fake artifact repos
   mkdir /tmp/file-artifacts-single

--- a/qemu-test-rauc-config
+++ b/qemu-test-rauc-config
@@ -22,11 +22,11 @@ device=/tmp/rootdev
 bootname=B
 
 [slot.appfs.0]
-device=/dev/null
+device=/tmp/appdev0
 parent=rootfs.0
 
 [slot.appfs.1]
-device=/tmp/appdev
+device=/tmp/appdev1
 parent=rootfs.1
 
 [artifacts.files-single]

--- a/src/context.c
+++ b/src/context.c
@@ -772,6 +772,12 @@ void r_context_set_step_percentage(const gchar *name, gint custom_percent)
 		r_context_send_progress(FALSE, FALSE);
 }
 
+void r_context_inc_step_percentage(const gchar *name)
+{
+	RaucProgressStep *step = context->progress->data;
+	r_context_set_step_percentage(name, step->last_explicit_percent + 1);
+}
+
 void r_context_free_progress_step(RaucProgressStep *step)
 {
 	if (!step)

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -937,6 +937,10 @@ static gboolean write_image_to_dev(RaucImage *image, RaucSlot *slot, GError **er
 				g_info("%s", ierror->message);
 			} else {
 				g_warning("Continuing after adaptive mode error: %s", ierror->message);
+				/* Note that step progress can already be at a certain percentage at this point
+				 * and will be reset to 0 when normal copying runs instead.
+				 * This isn't propagated but high level progress may stall until step progress
+				 * exceeds the current value again. */
 			}
 			g_clear_error(&ierror);
 			/* Continue with full copy */

--- a/test/hash_index.c
+++ b/test/hash_index.c
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include "context.h"
 #include "hash_index.h"
 #include "stats.h"
 #include "utils.h"
@@ -307,6 +308,9 @@ int main(int argc, char *argv[])
 	setlocale(LC_ALL, "C");
 
 	g_test_init(&argc, &argv, NULL);
+
+	r_context_conf();
+	r_context();
 
 	g_test_add("/hash_index/basic", Fixture, NULL, fixture_set_up, test_basic, fixture_tear_down);
 	g_test_add("/hash_index/ranges", Fixture, NULL, fixture_set_up, test_ranges, fixture_tear_down);

--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -26,7 +26,7 @@ typedef enum {
 	TEST_UPDATE_HANDLER_INSTALL_HOOK                                  = BIT(6),
 	TEST_UPDATE_HANDLER_NO_HOOK_FILE                                  = BIT(7),
 	TEST_UPDATE_HANDLER_HOOK_FAIL                                     = BIT(8),
-	TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX                           = BIT(9),
+	TEST_UPDATE_HANDLER_ADAPTIVE_BLOCK_HASH_IDX                       = BIT(9),
 	TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE                               = BIT(10),
 } TestUpdateHandlerParams;
 
@@ -123,7 +123,7 @@ static void update_handler_fixture_set_up(UpdateHandlerFixture *fixture,
 	}
 
 	if ((test_pair->params & TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE) &&
-	    (test_pair->params & TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX)) {
+	    (test_pair->params & TEST_UPDATE_HANDLER_ADAPTIVE_BLOCK_HASH_IDX)) {
 		g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
 				"Checking image type for slot type: *");
 		g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
@@ -147,7 +147,7 @@ static void update_handler_fixture_tear_down(UpdateHandlerFixture *fixture,
 	if (!(test_pair->params & TEST_UPDATE_HANDLER_NO_TARGET_DEV)) {
 		g_assert(test_remove(fixture->tmpdir, "rootfs-0") == 0);
 	}
-	if (test_pair->params & TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX) {
+	if (test_pair->params & TEST_UPDATE_HANDLER_ADAPTIVE_BLOCK_HASH_IDX) {
 		test_rm_tree(fixture->tmpdir, "rootfs-0-datadir");
 	}
 	g_assert(test_rmdir(fixture->tmpdir, "") == 0);
@@ -413,7 +413,7 @@ static void test_update_handler(UpdateHandlerFixture *fixture,
 			test_do_chmod(tmp_filename);
 		}
 	}
-	if (test_pair->params & TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX) {
+	if (test_pair->params & TEST_UPDATE_HANDLER_ADAPTIVE_BLOCK_HASH_IDX) {
 		image->adaptive = g_strsplit("block-hash-index", " ", 0);
 	}
 
@@ -453,7 +453,7 @@ no_image:
 	targetslot->device = g_strdup(slotpath);
 	targetslot->type = g_strdup(test_pair->slottype);
 	targetslot->state = ST_INACTIVE;
-	if (test_pair->params & TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX) {
+	if (test_pair->params & TEST_UPDATE_HANDLER_ADAPTIVE_BLOCK_HASH_IDX) {
 		targetslot->data_directory = g_build_filename(fixture->tmpdir, "rootfs-0-datadir", NULL);
 	}
 
@@ -504,7 +504,7 @@ no_image:
 	}
 
 	/* check statistics */
-	if (test_pair->params & TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX) {
+	if (test_pair->params & TEST_UPDATE_HANDLER_ADAPTIVE_BLOCK_HASH_IDX) {
 		RaucStats *stats;
 		guint64 count_zero = 0;
 		guint64 sum_zero = 0;
@@ -686,9 +686,9 @@ int main(int argc, char *argv[])
 		{"nor", "img", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
 
 		/* adaptive tests */
-		{"raw", "img", TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX, 0, 0},
-		{"ext4", "img", TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX, 0, 0},
-		{"raw", "ext4", TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX, 0, 0},
+		{"raw", "img", TEST_UPDATE_HANDLER_ADAPTIVE_BLOCK_HASH_IDX, 0, 0},
+		{"ext4", "img", TEST_UPDATE_HANDLER_ADAPTIVE_BLOCK_HASH_IDX, 0, 0},
+		{"raw", "ext4", TEST_UPDATE_HANDLER_ADAPTIVE_BLOCK_HASH_IDX, 0, 0},
 
 		/* casync blob index tests */
 		{"ext4", "img.caibx", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
@@ -699,7 +699,7 @@ int main(int argc, char *argv[])
 
 		/* image too large */
 		{"ext4", "ext4", TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE | TEST_UPDATE_HANDLER_EXPECT_FAIL, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED},
-		{"ext4", "ext4", TEST_UPDATE_HANDLER_INCR_BLOCK_HASH_IDX | TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE | TEST_UPDATE_HANDLER_EXPECT_FAIL, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED},
+		{"ext4", "ext4", TEST_UPDATE_HANDLER_ADAPTIVE_BLOCK_HASH_IDX | TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE | TEST_UPDATE_HANDLER_EXPECT_FAIL, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED},
 
 		{0}
 	};


### PR DESCRIPTION
Depending on the CPU and storage speed, generating the hash index for the adaptive mode 'block-hash-index' might take a notable amount of time.

So far, we don't emit any progress information during these steps, which could give the impression that the installation progress stalls.

With this approach, we reserve 10% of the step progress for both the 'target_slot' and the 'active_slot' generation and increment the progress evenly while generating the hash index.

Also, add some testing adaptations and improvements related to this feature.