### PR TITLE
src/install.c: Add details to the log messages

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -1427,10 +1427,10 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 
 	if (boot_mark_slot) {
 		/* Mark boot slot non-bootable */
-		g_message("Marking target slot %s as non-bootable...", boot_mark_slot->name);
+		g_message("Marking target slot %s as non-bootable (bad)...", boot_mark_slot->name);
 		if (!r_mark_bad(boot_mark_slot, &ierror)) {
 			g_set_error(error, R_INSTALL_ERROR, R_INSTALL_ERROR_MARK_NONBOOTABLE,
-					"Failed marking slot %s non-bootable: %s", boot_mark_slot->name, ierror->message);
+					"Failed marking slot %s non-bootable (bad): %s", boot_mark_slot->name, ierror->message);
 			g_clear_error(&ierror);
 			return FALSE;
 		}
@@ -1472,10 +1472,10 @@ static gboolean launch_and_wait_default_handler(RaucInstallArgs *args, gchar* bu
 	if (boot_mark_slot) {
 		if (r_context()->config->activate_installed) {
 			/* Mark boot slot bootable */
-			g_message("Marking target slot %s as bootable...", boot_mark_slot->name);
+			g_message("Marking target slot %s as bootable (active/primary)...", boot_mark_slot->name);
 			if (!r_mark_active(boot_mark_slot, &ierror)) {
 				g_propagate_prefixed_error(error, ierror,
-						"Failed marking slot %s bootable: ", boot_mark_slot->name);
+						"Failed marking slot %s bootable (active/primary): ", boot_mark_slot->name);
 				return FALSE;
 			}
 		} else {


### PR DESCRIPTION
Enhance the log messages during RAUC Bundle installation to provide more clarity on the process:

- For non-bootable, indicate that the slot is being marked as bad by calling r_mark_bad. For example:

```
Jun 16 14:58:12 raspberrypi5 rauc[925]: Marking target slot rootfs.1 as non-bootable (bad)...
Jun 16 14:58:12 raspberrypi5 rauc[925]: Marked slot rootfs.1 as bad
```

- For bootable, clarify that r_mark_active is being executed to mark the slot as active and to make it primary. For example:

```
Jun 16 14:58:49 raspberrypi5 rauc[925]: Marking target slot rootfs.1 as bootable (active and primary)...
Jun 16 14:58:49 raspberrypi5 rauc[925]: installing http://XXX.XXX.X.XXX:8000/update-bundle-raspberrypi5.raucb: All slots updated
Jun 16 14:58:49 raspberrypi5 rauc[925]: Marked slot rootfs.1 as active
```

Hopefully, the added details will make the log messages more helpful for debugging. According to me, currently, it is not very clear what "non-bootable" and "bootable" actually signify in the RAUC context.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->

