### PR TITLE
Error handling and usability improvements around (eMMC) bootloader updates

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -545,7 +545,9 @@ hierarchical separator.
 
 ``type=<type>`` (optional, recommended)
   The type describing the slot. Currently supported ``<type>`` values are ``raw``,
-  ``nand``, ``nor``, ``ubivol``, ``ubifs``, ``ext4``, ``vfat``.
+  ``nand``, ``nor``, ``ubivol``, ``ubifs``, ``ext4``, ``vfat`` for normal slots
+  and ``boot-emmc``, ``boot-mbr-switch``, ``boot-gpt-switch``, and ``boot-raw-fallback``
+  for atomically updatable bootloader slots.
   See table :ref:`sec-slot-type` for a more detailed list of these different types.
   Defaults to ``raw`` if none given.
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -604,6 +604,18 @@ hierarchical separator.
   Allows to specify custom mount options that will be passed to the slot's
   ``mount`` call as ``-o`` argument value.
 
+``region-start`` (mandatory for specific types, invalid for others)
+  Defines the start of the disk region used for atomic bootloader updates.
+  Valid for slot types ``boot-mbr-switch``, ``boot-gpt-switch``,
+  ``boot-raw-fallback`` only!
+  See :ref:`sec-mbr-partition` and the following for more details.
+
+``region-size`` (mandatory for specific types, invalid for others)
+  Defines the size of the disk region used for atomic bootloader updates.
+  Valid for slot types ``boot-mbr-switch``, ``boot-gpt-switch``,
+  ``boot-raw-fallback`` only!
+  See :ref:`sec-mbr-partition` and the following for more details.
+
 .. _sec_ref_artifacts:
 
 ``[artifacts.<repo-name>]`` Sections

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -413,6 +413,14 @@ static GHashTable *parse_slots(const char *filename, const char *data_directory,
 						"%s: device must be located in /dev/ for jffs2", groups[i]);
 				return NULL;
 			}
+			if (g_str_equal(slot->type, "boot-emmc") &&
+			    (g_str_has_suffix(slot->device, "boot0") || g_str_has_suffix(slot->device, "boot1"))) {
+				g_set_error(error,
+						R_CONFIG_ERROR,
+						R_CONFIG_ERROR_INVALID_DEVICE,
+						"%s: 'device' must refer to the eMMC base device, not the boot partition", groups[i]);
+				return NULL;
+			}
 
 			value = key_file_consume_string(key_file, groups[i], "extra-mkfs-opts", NULL);
 			if (value != NULL) {

--- a/src/main.c
+++ b/src/main.c
@@ -522,7 +522,7 @@ static gboolean write_slot_start(int argc, char **argv)
 
 	/* call update handler */
 	if (!update_handler(image, slot, NULL, &ierror)) {
-		g_printerr("%s\n", ierror->message);
+		g_printerr("Failed to write slot: %s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
 		return TRUE;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -2172,14 +2172,14 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 				R_UPDATE_ERROR,
 				R_UPDATE_ERROR_FAILED,
 				"Can't resolve eMMC device %s", dest_slot->device);
-		goto out;
+		return FALSE;
 	}
 
 	/* read active boot partition from ext_csd */
 	res = r_emmc_read_bootpart(realdev, &part_active, &ierror);
 	if (!res) {
 		g_propagate_error(error, ierror);
-		goto out;
+		return FALSE;
 	}
 
 	if (part_active == -1) {

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -2243,6 +2243,13 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 		goto out;
 	}
 
+	/* check size */
+	if (!check_image_size(g_unix_output_stream_get_fd(outstream), image, &ierror)) {
+		res = FALSE;
+		g_propagate_error(error, ierror);
+		goto out;
+	}
+
 	/* copy */
 	g_message("Copying image to slot device partition %s",
 			part_slot->device);

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -706,6 +706,30 @@ bootname=the\tslot\n";
 	g_clear_error(&ierror);
 }
 
+static void config_file_boot_emmc_with_bootpart(ConfigFileFixture *fixture, gconstpointer user_data)
+{
+	g_autoptr(RaucConfig) config = NULL;
+	GError *ierror = NULL;
+	g_autofree gchar* pathname = NULL;
+
+	const gchar *contents = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=barebox\n\
+\n\
+[slot.rootfs.0]\n\
+device=/dev/mmcblk0boot0\n\
+type=boot-emmc\n";
+
+	pathname = write_tmp_file(fixture->tmpdir, "boot-emmc-bootpart.conf", contents, NULL);
+	g_assert_nonnull(pathname);
+
+	g_assert_false(load_config(pathname, &config, &ierror));
+	g_assert_error(ierror, R_CONFIG_ERROR, R_CONFIG_ERROR_INVALID_DEVICE);
+	g_assert_cmpstr(ierror->message, ==, "slot.rootfs.0: 'device' must refer to the eMMC base device, not the boot partition");
+	g_clear_error(&ierror);
+}
+
 static void config_file_no_max_bundle_download_size(ConfigFileFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1655,6 +1679,9 @@ int main(int argc, char *argv[])
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/bootname-tab", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_bootname_tab,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/boot-emmc-with-bootpart", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_boot_emmc_with_bootpart,
 			config_file_fixture_tear_down);
 	g_test_add("/config-file/no-max-bundle-download-size", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_no_max_bundle_download_size,


### PR DESCRIPTION
* Adds missing bootloader update option bits to reference.rst
* size check for eMMC bootloader updates
* better error handling or `boot-emmc` device misconfiguration
* more clear error printout for `write-slot`