### PR TITLE
add new 'size-limit' option for type 'boot-emmc'

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -294,3 +294,23 @@ need to split the payload and CMS data and then use `openssl cms -verify` with
 the `-content` option.
 As this is more involved, we recommend using either `rauc extract` or switching
 to verity bundles.
+
+How can I protect manufacturer data at the end of the boot partition when using ``boot-emmc``?
+----------------------------------------------------------------------------------------------
+
+When using RAUC's boot-emmc slot type for bootloader updates, the entire eMMC
+boot partition is cleared before the new image is written.
+If this partition contains manufacturer-specific data (e.g., calibration data
+at the end), that data will be lost unless special precautions are taken.
+
+The recommended solution is to migrate this data to a safe location during the
+first boot of the device. This ensures future bootloader updates can proceed
+safely.
+
+If migration is not feasible (for example, on already deployed devices) RAUC
+provides a ``size-limit`` :ref:`slot option <_slot.slot-class.idx-section>` for
+the ``boot-emmc`` slot.
+This restricts the writable area to avoid overwriting critical data.
+
+.. warning:: The ``size-limit`` option is intended only for backwards
+   compatibility and should not be used in new designs!

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -624,6 +624,19 @@ hierarchical separator.
 
   See :ref:`sec-mbr-partition` and the following for more details.
 
+``size-limit=<value>`` (type-specific, optional)
+  .. warning:: The ``size-limit`` option is intended only for backwards
+     compatibility and should not be used in new designs!
+
+  Valid for slot type ``boot-emmc`` only.
+  Allows defining the maximum size of an eMMC boot partition to write.
+  This is only useful if the eMMC boot partitions contain e.g. manufacturer
+  at the end and, for certain reason, this cannot be migrated to a more
+  appropriate location anymore.
+
+  Accepts integer values in bytes.
+  Supports optional size suffixes: ``K``, ``M``, ``G``, ``T`` (powers of 1024).
+
 .. _sec_ref_artifacts:
 
 ``[artifacts.<repo-name>]`` Sections

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1644,6 +1644,10 @@ The following environment variables will be passed to the hook executable:
   Both halves in the region will be written by RAUC.
   ``boot-raw-fallback`` slot type only.
 
+``RAUC_BOOT_SIZE_LIMIT``
+  This maximum size of the boot partition to use.
+  ``boot-emmc`` slot type only.
+
 .. _sec_ref_dbus-api:
 
 D-Bus API

--- a/include/slot.h
+++ b/include/slot.h
@@ -55,6 +55,8 @@ typedef struct _RaucSlot {
 	guint64 region_start;
 	/** size of both partitions(for boot-mbr-switch, boot-gpt-switch and boot-raw-fallback) */
 	guint64 region_size;
+	/** limit the writable size of the boot partition (for boot-emmc) */
+	guint64 size_limit;
 
 	/** current state of the slot (runtime) */
 	SlotState state;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -538,6 +538,18 @@ static GHashTable *parse_slots(const char *filename, const char *data_directory,
 				}
 			}
 
+			if (g_strcmp0(slot->type, "boot-emmc") == 0) {
+				slot->size_limit = key_file_consume_binary_suffixed_string(key_file, groups[i],
+						"size-limit", &ierror);
+				if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+					slot->size_limit = 0;
+					g_clear_error(&ierror);
+				} else if (ierror) {
+					g_propagate_error(error, ierror);
+					return NULL;
+				}
+			}
+
 			if (!check_remaining_keys(key_file, groups[i], &ierror)) {
 				g_propagate_error(error, ierror);
 				return NULL;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -2259,6 +2259,8 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 
 	g_hash_table_insert(vars, g_strdup("RAUC_BOOT_PARTITION_ACTIVATING"),
 			g_strdup_printf("%d", INACTIVE_BOOT_PARTITION(part_active)));
+	g_hash_table_insert(vars, g_strdup("RAUC_BOOT_SIZE_LIMIT"),
+			g_strdup_printf("%"G_GUINT64_FORMAT, dest_slot->size_limit));
 
 	/* run slot pre install hook if enabled */
 	if (hook_name && image->hooks.pre_install) {

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -32,6 +32,19 @@ GQuark r_update_error_quark(void)
 	return g_quark_from_static_string("r_update_error_quark");
 }
 
+/**
+ * Checks if given image fits into the (block) device.
+ *
+ * Checks if the image size fits into the block device referred to by the
+ * provided file descriptor.
+ * If the size cannot be determined, the image is assumed to fit.
+ *
+ * @param fd file descriptor of device to check
+ * @param image image to check
+ * @param error return location for a GError, or NULL
+ *
+ * @return TRUE if image fits into device or if no size can be determined. FALSE otherwise.
+ */
 static gboolean check_image_size(int fd, const RaucImage *image, GError **error)
 {
 	GError *ierror = NULL;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -2246,6 +2246,7 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 			"%sboot%d",
 			realdev,
 			INACTIVE_BOOT_PARTITION(part_active));
+	part_slot->size_limit = dest_slot->size_limit;
 
 	/* disable read-only on determined eMMC boot partition */
 	g_debug("Disabling read-only mode of slot device partition %s",
@@ -2292,7 +2293,7 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 	}
 
 	/* check size */
-	if (!check_image_size(g_unix_output_stream_get_fd(outstream), NULL, image, &ierror)) {
+	if (!check_image_size(g_unix_output_stream_get_fd(outstream), part_slot, image, &ierror)) {
 		res = FALSE;
 		g_propagate_error(error, ierror);
 		goto out;

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -39,25 +39,44 @@ GQuark r_update_error_quark(void)
  * provided file descriptor.
  * If the size cannot be determined, the image is assumed to fit.
  *
+ * Additionally, if a slot is given and the slot has a 'size-limit' set, the
+ * image is checked against this limit first.
+ *
  * @param fd file descriptor of device to check
+ * @param slot slot (e.g. for optional size-limit check)
  * @param image image to check
  * @param error return location for a GError, or NULL
  *
- * @return TRUE if image fits into device or if no size can be determined. FALSE otherwise.
+ * @return TRUE if image fits into device (or size-limit) or if no size can be determined. FALSE otherwise.
  */
-static gboolean check_image_size(int fd, const RaucImage *image, GError **error)
+static gboolean check_image_size(int fd, const RaucSlot *slot, const RaucImage *image, GError **error)
 {
 	GError *ierror = NULL;
 	goffset dev_size;
 
+	g_return_val_if_fail(slot, FALSE);
 	g_return_val_if_fail(image, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (slot->size_limit > 0 && (guint64)image->checksum.size > slot->size_limit) {
+		g_set_error(error, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED,
+				"Image size (%"G_GOFFSET_FORMAT " bytes) is larger than size-limit (%"G_GUINT64_FORMAT " bytes).",
+				image->checksum.size, slot->size_limit);
+		return FALSE;
+	}
 
 	dev_size = get_device_size(fd, &ierror);
 	if (g_error_matches(ierror, R_UTILS_ERROR, R_UTILS_ERROR_INAPPROPRIATE_IOCTL)) {
 		g_clear_error(&ierror);
 		g_info("Slot is not a block device, skipping size check");
 		return TRUE;
+	}
+
+	/* Sanity check for size limit being < device size.
+	 * Should be moved to a proper location for configuration vs. target checks (maybe context setup) and become an error later. */
+	if (slot->size_limit > 0 && slot->size_limit > (guint64)dev_size) {
+		g_warning("The size-limit (%"G_GUINT64_FORMAT " bytes) exceeds actual device size (%"G_GOFFSET_FORMAT " bytes).",
+				slot->size_limit, dev_size);
 	}
 
 	if (dev_size < image->checksum.size) {
@@ -81,6 +100,7 @@ static gboolean clear_slot(RaucSlot *slot, GError **error)
 	static gchar zerobuf[CLEAR_BLOCK_SIZE] = {};
 	g_autoptr(GOutputStream) outstream = NULL;
 	gint write_count = 0;
+	guint64 total_written = 0;
 
 	outstream = G_OUTPUT_STREAM(r_unix_output_stream_open_device(slot->device, NULL, &ierror));
 	if (outstream == NULL) {
@@ -89,7 +109,13 @@ static gboolean clear_slot(RaucSlot *slot, GError **error)
 	}
 
 	while (write_count != -1) {
-		write_count = g_output_stream_write(outstream, zerobuf, CLEAR_BLOCK_SIZE, NULL,
+		/* cap writes to slot->size_limit if set */
+		gsize write_size = CLEAR_BLOCK_SIZE;
+		if (slot->size_limit > 0 &&
+		    total_written + write_size > slot->size_limit)
+			write_size = slot->size_limit - total_written;
+
+		write_count = g_output_stream_write(outstream, zerobuf, write_size, NULL,
 				&ierror);
 		/*
 		 * G_IO_ERROR_NO_SPACE is expected here, because the block
@@ -105,7 +131,16 @@ static gboolean clear_slot(RaucSlot *slot, GError **error)
 				return FALSE;
 			}
 		}
+
+		total_written += write_count;
+		if (slot->size_limit > 0 && total_written >= slot->size_limit)
+			break;
 	}
+
+	if (slot->size_limit > 0)
+		g_message("Cleared first %"G_GOFFSET_FORMAT " bytes on %s", total_written, slot->device);
+	else
+		g_debug("Cleared %"G_GOFFSET_FORMAT " bytes on %s", total_written, slot->device);
 
 	if (!g_output_stream_close(outstream, NULL, &ierror)) {
 		g_propagate_error(error, ierror);
@@ -653,7 +688,7 @@ static gboolean copy_raw_image_to_dev(RaucImage *image, RaucSlot *slot, GError *
 	}
 
 	/* check size */
-	if (!check_image_size(g_unix_output_stream_get_fd(outstream), image, &ierror)) {
+	if (!check_image_size(g_unix_output_stream_get_fd(outstream), slot, image, &ierror)) {
 		res = FALSE;
 		g_propagate_error(error, ierror);
 		goto out;
@@ -707,7 +742,7 @@ static gboolean copy_block_hash_index_image_to_dev(RaucImage *image, RaucSlot *s
 		res = FALSE;
 		goto out;
 	}
-	if (!check_image_size(tmp->data_fd, image, &ierror)) {
+	if (!check_image_size(tmp->data_fd, slot, image, &ierror)) {
 		g_propagate_error(error, ierror);
 		res = FALSE;
 		goto out;
@@ -2257,7 +2292,7 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 	}
 
 	/* check size */
-	if (!check_image_size(g_unix_output_stream_get_fd(outstream), image, &ierror)) {
+	if (!check_image_size(g_unix_output_stream_get_fd(outstream), NULL, image, &ierror)) {
 		res = FALSE;
 		g_propagate_error(error, ierror);
 		goto out;

--- a/test/test_write_slot.py
+++ b/test/test_write_slot.py
@@ -69,3 +69,82 @@ def test_write_boot_emmc(system):
     assert "Slot written successfully" in out
     assert "Found active eMMC boot partition /dev/mmcblk0boot0" in err
     assert f"Boot partition {device}boot1 is now active" in err
+
+
+@needs_emmc
+def test_write_boot_emmc_size_limit(system):
+    """
+    Sets 'size-limit' option for boot-emmc slot and checks that after writing,
+    the data above the size-limit remains untouched.
+    """
+    device = os.environ["RAUC_TEST_EMMC"]
+    bootdevice = f"{device}boot0"
+    size = 1024 * 1024  # full size of eMMC boot partition
+    half_size = size // 2
+
+    # disable boot partition to have a fixed setup
+    check_call(["mmc", "bootpart", "enable", "0", "0", device])
+
+    system.config["slot.bootloader.0"] = {
+        "device": device,
+        "type": "boot-emmc",
+        "size-limit": f"{half_size}",
+    }
+    system.write_config()
+
+    # Prepare known data
+    original_data = os.urandom(size)
+    with open(f"/sys/block/{bootdevice[4:]}/force_ro", "w") as f:
+        f.write("0")
+    with open(bootdevice, "wb") as f:
+        f.write(original_data)
+    with open(f"/sys/block/{bootdevice[4:]}/force_ro", "w") as f:
+        f.write("1")
+
+    # write image
+    out, err, exitcode = run(f"{system.prefix} write-slot bootloader.0 install-content/rootfs.img")
+    assert exitcode == 0
+    assert "Slot written successfully" in out
+    assert "eMMC device was not enabled for booting, yet. Ignoring." in err
+    assert f"Boot partition {device}boot0 is now active" in err
+
+    assert f"Cleared first {half_size} bytes on /dev/mmcblk0boot0" in err
+
+    # Read back from device
+    with open(bootdevice, "rb") as f:
+        result_data = f.read(1024 * 1024)
+
+    # Check first 16 bytes below 512 KiB are zeroed
+    assert result_data[half_size - 0x10 : half_size] == b"\x00" * 0x10, "First 512 KiB is not zeroed"
+
+    # Check first 16 bytes above 512 KiB are intact
+    assert result_data[half_size : half_size + 0x10] == original_data[half_size : half_size + 0x10], (
+        "Second 512 KiB is not intact"
+    )
+
+
+@needs_emmc
+def test_write_boot_emmc_size_limit_too_large(system):
+    """
+    Sets 'size-limit' option for boot-emmc slot to a value larger then the
+    actual size of the partition and ensures RAUC prints a warning.
+    """
+    device = os.environ["RAUC_TEST_EMMC"]
+
+    # disable boot partition to have a fixed setup
+    check_call(["mmc", "bootpart", "enable", "0", "0", device])
+
+    system.config["slot.bootloader.0"] = {
+        "device": device,
+        "type": "boot-emmc",
+        "size-limit": "10M",
+    }
+    system.write_config()
+
+    out, err, exitcode = run(f"{system.prefix} write-slot bootloader.0 install-content/rootfs.img")
+    assert exitcode == 0
+    assert "Slot written successfully" in out
+    assert "eMMC device was not enabled for booting, yet. Ignoring." in err
+    assert f"Boot partition {device}boot0 is now active" in err
+
+    assert "The size-limit (10485760 bytes) exceeds actual device size" in err


### PR DESCRIPTION
For special cases, where e.g. the manufacturer decided to store data at the end of the boot partition and where this information is required and cannot be migrated, we allow specifying a `size-limit` option for the `boot-emmc` slot type that allows limiting the cleared/written size.

Fixes: #780