### PR TITLE
nbd: avoid race with udev during setup

### DIFF
--- a/include/nbd.h
+++ b/include/nbd.h
@@ -66,7 +66,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucNBDServer, r_nbd_free_server);
  *
  * @return TRUE on success, FALSE if an error occurred
  */
-gboolean r_nbd_setup_device(RaucNBDDevice *nbd_dev, GError **error);
+gboolean r_nbd_setup_device(RaucNBDDevice *nbd_dev, int *devicefd, GError **error);
 
 /**
  * Remove a previously configured NBD device from the kernel.

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -3094,7 +3094,7 @@ gboolean mount_bundle(RaucBundle *bundle, GError **error)
 		bundle->nbd_dev->data_size = bundle->size;
 		bundle->nbd_dev->sock = bundle->nbd_srv->sock;
 		bundle->nbd_srv->sock = -1;
-		res = r_nbd_setup_device(bundle->nbd_dev, &ierror);
+		res = r_nbd_setup_device(bundle->nbd_dev, &devicefd, &ierror);
 		if (!res) {
 			/* The setup failed, so the socket still belongs to the nbd_srv. */
 			bundle->nbd_srv->sock = bundle->nbd_dev->sock;

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -3059,7 +3059,7 @@ gboolean mount_bundle(RaucBundle *bundle, GError **error)
 	GError *ierror = NULL;
 	g_autofree gchar *mount_point = NULL;
 	g_autofree gchar *loopname = NULL;
-	gint loopfd = -1;
+	gint devicefd = -1;
 	gboolean res = FALSE;
 
 	g_return_val_if_fail(bundle != NULL, FALSE);
@@ -3084,7 +3084,7 @@ gboolean mount_bundle(RaucBundle *bundle, GError **error)
 
 	if (bundle->stream) { /* local or downloaded bundle */
 		gint bundlefd = g_file_descriptor_based_get_fd(G_FILE_DESCRIPTOR_BASED(bundle->stream));
-		res = r_setup_loop(bundlefd, &loopfd, &loopname, bundle->size, &ierror);
+		res = r_setup_loop(bundlefd, &devicefd, &loopname, bundle->size, &ierror);
 		if (!res) {
 			g_propagate_error(error, ierror);
 			goto out;
@@ -3176,8 +3176,8 @@ out:
 	if (mount_point) {
 		g_rmdir(mount_point);
 	}
-	if (loopfd >= 0)
-		g_close(loopfd, NULL);
+	if (devicefd >= 0)
+		g_close(devicefd, NULL);
 	return res;
 }
 

--- a/src/nbd.c
+++ b/src/nbd.c
@@ -142,7 +142,7 @@ out:
 	return nl;
 }
 
-gboolean r_nbd_setup_device(RaucNBDDevice *nbd_dev, GError **error)
+gboolean r_nbd_setup_device(RaucNBDDevice *nbd_dev, int *devicefd, GError **error)
 {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
@@ -177,9 +177,6 @@ gboolean r_nbd_setup_device(RaucNBDDevice *nbd_dev, GError **error)
 	NLA_PUT_U64(msg, NBD_ATTR_SIZE_BYTES, nbd_dev->data_size);
 	NLA_PUT_U64(msg, NBD_ATTR_BLOCK_SIZE_BYTES, 4096);
 	NLA_PUT_U64(msg, NBD_ATTR_SERVER_FLAGS, 0);
-	NLA_PUT_U64(msg, NBD_ATTR_CLIENT_FLAGS,
-			NBD_CFLAG_DISCONNECT_ON_CLOSE
-			);
 	NLA_PUT_U64(msg, NBD_ATTR_TIMEOUT, 300);
 
 	attr_sockets = nla_nest_start(msg, NBD_ATTR_SOCKETS);
@@ -202,6 +199,27 @@ gboolean r_nbd_setup_device(RaucNBDDevice *nbd_dev, GError **error)
 		g_error("failed to create nbd device");
 
 	nbd_dev->dev = g_strdup_printf("/dev/nbd%"G_GUINT32_FORMAT, nbd_dev->index);
+
+	*devicefd = open(nbd_dev->dev, O_RDWR|O_CLOEXEC);
+
+	msg = nlmsg_alloc();
+	if (!msg)
+		g_error("failed to allocate netlink message");
+
+	if (!genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, driver_id, 0, 0, NBD_CMD_RECONFIGURE, 0))
+		g_error("failed to add generic netlink headers to message");
+
+	NLA_PUT_U32(msg, NBD_ATTR_INDEX, nbd_dev->index);
+	NLA_PUT_U64(msg, NBD_ATTR_CLIENT_FLAGS,
+			NBD_CFLAG_DISCONNECT_ON_CLOSE
+			);
+
+	nl_socket_modify_cb(nl, NL_CB_VALID, NL_CB_CUSTOM, NULL, NULL);
+	if (nl_send_sync(nl, msg) < 0) {
+		res = FALSE;
+		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "netlink send_sync failed");
+		goto out;
+	}
 
 	g_message("setup done for %s", nbd_dev->dev);
 


### PR DESCRIPTION
With the NBD_CFLAG_DISCONNECT_ON_CLOSE flag set, the nbd device will be
automatically removed when there are no more users after it was was
opened the first time.

The idea here is, that the nbd device is created, and then immediately
mounted (possibly with dm-verity or dm-crypt in between). Wenn the
bundle ist later unmounted then the nbd device is automatically removed.

Unfortunately this is racy: udev will see the new device and open it
immediately. If it closes the device before it is mounted (or dm-verity
or dm-crypt is configured) then the nbd device is removed immediately
and mounting will fail.

So instead create the nbd device without NBD_CFLAG_DISCONNECT_ON_CLOSE,
open it to keep it busy and then reconfigure the device to set
NBD_CFLAG_DISCONNECT_ON_CLOSE.
The file descriptor is kept until the bundle is mounted.

Note that with this change, the nbd device will not be fully removed if
rauc dies between creating the nbd device and reconfiguring it, or if
reconfiguring fails.
