### PR TITLE
src/update_handler: remove NULL check after dereferencing part_slot

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -2327,7 +2327,7 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 
 out:
 	/* ensure that the eMMC boot partition is read-only afterwards */
-	if (!res && part_slot)
+	if (!res)
 		r_emmc_force_part_ro(part_slot->device, NULL);
 
 	return res;


### PR DESCRIPTION
With the change made in 705c9e5d ("src/update_handler: replace some gotos by immediate return"), there are now paths that may leave 'part_slot' NULL (and it's also always dereferenced before).

Thus, we can safely remove the check after the goto.

Fixes inconsistency reported by coverity:
> CID 1611650: (#1 of 1): Dereference before null check (REVERSE_INULL)
> check_after_deref: Null-checking part_slot suggests that it may be null, but it has already been dereferenced on all paths leading to the check

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
