### PR TITLE
meson_options: make use of boolean values

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,22 +2,22 @@
 option(
   'service',
   type : 'boolean',
-  value : 'true',
+  value : true,
   description : 'Enable/Disable background service')
 option(
   'create',
   type : 'boolean',
-  value : 'true',
+  value : true,
   description : 'Enable/Disable bundle creation and modification commands')
 option(
   'network',
   type : 'boolean',
-  value : 'true',
+  value : true,
   description : 'Enable/Disable network update mode')
 option(
   'streaming',
   type : 'boolean',
-  value : 'true',
+  value : true,
   description : 'Enable/Disable streaming update mode')
 option(
   'json',
@@ -37,7 +37,7 @@ option(
 option(
   'pkcs11_engine',
   type : 'boolean',
-  value : 'true',
+  value : true,
   description : 'Enable/Disable OpenSSL PKCS11 engine support')
 
 # other options
@@ -78,15 +78,15 @@ option(
 option(
   'htmldocs',
   type : 'boolean',
-  value : 'false',
+  value : false,
   description : 'Enable/Disable HTML documentation')
 option(
   'tests',
   type : 'boolean',
-  value : 'true',
+  value : true,
   description : 'Enable/Disable test suite')
 option(
   'fuzzing',
   type : 'boolean',
-  value : 'false',
+  value : false,
   description : 'Enable/Disable fuzz tests')


### PR DESCRIPTION
Using string literals for bool values is
deprecated, as stated in [1].
So change them to proper boolean values.

[1] https://mesonbuild.com/Release-notes-for-1-1-0.html#coercing-values-in-the-option-function-is-deprecated