### PR TITLE
test/Dockerfile: add python3-pyasn1 for testing

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get install -q -y --no-install-recommends \
   dosfstools \
   lcov \
   slirp \
+  python3-pyasn1 \
+  python3-pyasn1-modules \
   python3-pytest \
   python3-pydbus \
   python3-dasbus \


### PR DESCRIPTION
With the upcoming multisig support, we'll need to inspect CMS signatures in the pytest testsuite. Instead of trying to parse the 'openssl cms' text output or using the currently unmaintained asn1crypto module, use pyasn1 for the low-level parsing, so that we can build some convenience layer on top.