### PR TITLE
src/context: parse the case cmdline contain root=None

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -96,7 +96,7 @@ static gchar* get_cmdline_bootname_root(const gchar *cmdline)
 	if (!bootname)
 		bootname = r_regex_match_simple("systemd\\.verity_root_data=(\\S+)", cmdline);
 
-	if (!bootname)
+	if (!bootname || strncmp(bootname, "None", 4) == 0)
 		return NULL;
 
 	if (strncmp(bootname, "PARTLABEL=", 10) == 0) {


### PR DESCRIPTION
In the case of the cmdline contain root=None, rauc service fail. It is because the function get_cmdline_bootname_root() does not provide for this scenario and continue to the end before crashing. If cmdline contain root=None, the function get_cmdline_bootname_root() should give the same result as for case root=xxx is not define, namely returning NULL to avoid rauc failures.
root=None on cmdline can occur on Yocto images for x86_64 system.
