### PR TITLE
.github/workflows/tests: don't try to print old logfile locations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,7 +190,3 @@ jobs:
       if: ${{ failure() }}
       run: |
         cat build/meson-logs/testlog.txt || true
-        cat config.log || true
-        cat test/*.log || true
-        cat test-suite.log || true
-        cat rauc-*/_build/sub/test-suite.log || true


### PR DESCRIPTION
These log file locations are no longer valid, so remove them.