### PR TITLE
src/config_file: clear 'variant_data' more consistently

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -558,7 +558,7 @@ static gboolean parse_system_section(const gchar *filename, GKeyFile *key_file, 
 	/* parse 'variant-name' key */
 	variant_data = key_file_consume_string(key_file, "system", "variant-name", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
-		variant_data = NULL;
+		g_clear_pointer(&variant_data, g_free);
 		g_clear_error(&ierror);
 	} else if (ierror) {
 		g_propagate_error(error, ierror);


### PR DESCRIPTION
Use `g_clear_pointer()` instead of simply assigning `NULL` when the 'variant-name' key is not found.

While the memory leak prevention is more theoretical, it keeps cleanup logic consistent (we already do so for 'variant-file') and also silences the following codecov-reported defect:

```
| 560     	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
| >>>     CID 1619518:         Resource leaks  (RESOURCE_LEAK)
| >>>     Overwriting "variant_data" in "variant_data = NULL" leaks the storage that "variant_data" points to.
| 561     		variant_data = NULL;
```

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
