### PR TITLE
test/test_bundle: drop `-progress` from `--mksquashfs-args`

### DIFF
--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -53,7 +53,7 @@ def test_bundle_mksquashfs_extra_args(tmp_path):
             --cert openssl-ca/dev/autobuilder-1.cert.pem \
             --key openssl-ca/dev/private/autobuilder-1.pem \
             bundle \
-            --mksquashfs-args="-comp xz -info -progress" \
+            --mksquashfs-args="-comp xz -info" \
             {tmp_path}/install-content {tmp_path}/out.raucb'
     )
 


### PR DESCRIPTION
Since d52f951 [1], which is part of squashfs-tools >= 4.7, a check exists that not both options -progress and -no-progress are set.

Since RAUC sets -no-progress by default, the check for --mksquashfs-args, which additionally sets -progress, starts to cause an error with recent mksquashfs versions:

| ERROR: Only one of -no-progress and -progress can be specified.  Both causes a conflict.

Fix this by just not setting -progress in the test case, since the actual option we set doesn't matter.

[1] https://github.com/plougher/squashfs-tools/commit/d52f9513f061cf8c76206c639e47d8afcceb8bb8

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
