### PR TITLE
Feature: OpenSSL providers support

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -299,6 +299,10 @@ For example, a bundle can be signed with a certificate and key available as
     <input-dir> <output-file>
 
 .. note::
+  PKCS#11 URI support requires either ``pkcs11_engine`` (legacy) or ``pkcs11_providers``
+  feature enabled on the compile time.
+
+.. note::
   Most PKCS#11 implementations require a PIN for signing operations.
   You can either enter the PIN interactively as requested by RAUC or use the
   ``RAUC_PKCS11_PIN`` environment variable to specify the PIN to use.

--- a/meson.build
+++ b/meson.build
@@ -160,6 +160,13 @@ if get_option('streaming')
   sources_rauc += files('src/nbd.c')
 endif
 
+openssl_engine = get_option('pkcs11_engine')
+openssl_providers = get_option('pkcs11_providers')
+
+if openssl_engine and openssl_providers
+  error('Openssl engine support (legacy) and Openssl providers support cannot be enabled at the same time')
+endif
+
 conf.set10('ENABLE_EMMC_BOOT_SUPPORT', cc.has_header('linux/mmc/ioctl.h'))
 
 conf.set10('ENABLE_GPT', fdiskdep.found())
@@ -175,6 +182,7 @@ endif
 # To allow building against OpenSSL 3.0 and 4.0 without engine support
 # as they are deprecated in favor of providers API
 conf.set10('ENABLE_OPENSSL_PKCS11_ENGINE', get_option('pkcs11_engine'))
+conf.set10('ENABLE_OPENSSL_PKCS11_PROVIDERS', get_option('pkcs11_providers'))
 
 gnome = import('gnome')
 dbus_ifaces = files('src/de.pengutronix.rauc.Installer.xml')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -38,7 +38,12 @@ option(
   'pkcs11_engine',
   type : 'boolean',
   value : true,
-  description : 'Enable/Disable OpenSSL PKCS11 engine support')
+  description : 'Enable/Disable OpenSSL PKCS11 engine support (legacy)')
+option(
+  'pkcs11_providers',
+  type : 'boolean',
+  value : false,
+  description : 'Enable/Disable OpenSSL PKCS11 providers support')
 
 # other options
 option(

--- a/src/context.c
+++ b/src/context.c
@@ -823,12 +823,12 @@ RaucContext *r_context_conf(void)
 		// let us handle broken pipes explicitly
 		signal(SIGPIPE, SIG_IGN);
 
-		if (!network_init(&ierror)) {
+		if (!signature_init(&ierror)) {
 			g_warning("%s", ierror->message);
 			g_error_free(ierror);
 			return NULL;
 		}
-		if (!signature_init(&ierror)) {
+		if (!network_init(&ierror)) {
 			g_warning("%s", ierror->message);
 			g_error_free(ierror);
 			return NULL;

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
   libdbus-1-dev \
   libjson-glib-dev \
   libfdisk-dev \
-  libnl-genl-3-dev
+  libnl-genl-3-dev \
+  pkcs11-provider
 
 # Required for building the cgi example
 RUN apt-get install -q -y --no-install-recommends \

--- a/test/meson.build
+++ b/test/meson.build
@@ -44,6 +44,7 @@ extra_test_sources = files([
 
 test_env = environment()
 test_env.set('MESON_BUILD_DIR', meson.build_root())
+test_env.set('OPENSSL_CONF', join_paths(meson.build_root(), '..', 'test', 'openssl-pkcs11.cnf'))
 if composefsdep.found()
   test_env.prepend('PATH', meson.build_root() + '/subprojects/composefs/tools')
 endif

--- a/test/openssl-pkcs11.cnf
+++ b/test/openssl-pkcs11.cnf
@@ -1,0 +1,18 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+module = /usr/lib/x86_64-linux-gnu/ossl-modules/pkcs11.so
+pkcs11-module-path = /usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so
+pkcs11-module-token-pin = 1111
+pkcs11-module-quirks = no-deinit
+activate = 1


### PR DESCRIPTION
This change introduces new build option: pkcs11_providers
When the option is enabled (instead of pkcs11_engine), Rauc uses newer Openssl providers API for PKCS#11 operations (requires Openssl >= 3) instead of legacy Openssl engine API which is already deprecated. Engine API will likely be removed on next major Openssl 4.

https://openssl-communities.org/d/rxYpMNVn/api-deprecation-announcement-for-openssl4-0

This change also updates the test environment so that tests can also be run with the new option.
