### PR TITLE
qemu-test-init: wipe old logs to avoid confusion

### DIFF
--- a/qemu-test-init
+++ b/qemu-test-init
@@ -247,6 +247,8 @@ if [ -n "$INTERACTIVE_SHELL" ]; then
   sleep 1
 fi
 
+# Ensure previous testlog is wiped
+rm -f $BUILD_DIR/meson-logs/testlog.txt
 if meson test -C $BUILD_DIR --suite rauc $test -v; then
   touch qemu-test-ok
   echo "RESULT: PASSED"


### PR DESCRIPTION
If the meson call fails early, it does not produce a new log. However, if a previous run already created a log file, this will be shown instead. This might be confusing..

Thus, better remove the old log file before generating a new one.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
