### PR TITLE
test/test_mark: add minimal check for calling barebox backend via mark

### DIFF
--- a/qemu-test-init
+++ b/qemu-test-init
@@ -78,6 +78,9 @@ fi
 mkdir /tmp/bin
 export PATH=/tmp/bin:$PATH
 
+cp test/bin/barebox-state /tmp/bin/barebox-state
+chmod +x /tmp/bin/barebox-state
+
 # create helper scripts to manage coverage data
 if [ -n "$GCOV_PREFIX" ]; then
   cat > /tmp/bin/save_gcov_data <<EOF

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -81,6 +81,14 @@ def _have_grub():
 have_grub = pytest.mark.skipif(not _have_grub(), reason="Have no grub-editenv")
 
 
+def _have_barebox():
+    out, err, exitcode = run("which barebox-state")
+    return exitcode == 0
+
+
+have_barebox = pytest.mark.skipif(not _have_barebox(), reason="Have no barebox-state")
+
+
 def _have_openssl():
     out, err, exitcode = run("openssl version")
     return exitcode == 0

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -1,6 +1,7 @@
 import json
+import os
 
-from conftest import have_grub, no_service
+from conftest import have_barebox, have_grub, no_service
 from helper import run
 from helper import slot_data_from_json
 
@@ -181,3 +182,67 @@ def test_status_mark_active_dbus(rauc_dbus_service_with_system):
     assert slot_data_from_json(status_data, "rootfs.0")["boot_status"] == "good"
     assert slot_data_from_json(status_data, "rootfs.1")["boot_status"] == "good"
     assert status_data["boot_primary"] == "rootfs.1"
+
+
+@have_barebox
+def test_status_mark_bad_barebox(tmp_path, create_system_files, system):
+    """
+    Tests that 'mark-bad' call for barebox alters the barebox state
+    variables appropriately.
+
+    Leverages the 'barebox-state' dummy with variables pre-set from env.
+    """
+
+    system.prepare_minimal_config()
+    system.config["system"]["bootloader"] = "barebox"
+    del system.config["system"]["grubenv"]
+    system.write_config()
+    os.environ["BAREBOX_STATE_VARS_PRE"] = """
+bootstate.A.priority=20
+bootstate.B.priority=21
+bootstate.A.remaining_attempts=3
+bootstate.B.remaining_attempts=3
+"""
+    os.environ["BAREBOX_STATE_VARS_POST"] = """
+bootstate.A.priority=20
+bootstate.B.priority=0
+bootstate.A.remaining_attempts=3
+bootstate.B.remaining_attempts=0
+"""
+    with system.running_service("A"):
+        # mark rootfs.1 (B) bad
+        out, err, exitcode = run("rauc status mark-bad rootfs.1")
+        assert not err
+        assert exitcode == 0
+
+
+@have_barebox
+def test_status_mark_active_barebox(tmp_path, create_system_files, system):
+    """
+    Tests that 'mark-primary' call for barebox alters the barebox state
+    variables appropriately.
+
+    Leverages the 'barebox-state' dummy with variables pre-set from env.
+    """
+
+    system.prepare_minimal_config()
+    system.config["system"]["bootloader"] = "barebox"
+    del system.config["system"]["grubenv"]
+    system.write_config()
+    os.environ["BAREBOX_STATE_VARS_PRE"] = """
+bootstate.A.priority=21
+bootstate.B.priority=20
+bootstate.A.remaining_attempts=3
+bootstate.B.remaining_attempts=0
+"""
+    os.environ["BAREBOX_STATE_VARS_POST"] = """
+bootstate.A.priority=10
+bootstate.B.priority=20
+bootstate.A.remaining_attempts=3
+bootstate.B.remaining_attempts=3
+"""
+    with system.running_service("A"):
+        # mark rootfs.1 (B) active/primary
+        out, err, exitcode = run("rauc status mark-active rootfs.1")
+        assert not err
+        assert exitcode == 0


### PR DESCRIPTION
So far, we have no test for invoking RAUC's barebox boot selection backend through 'mark' methods.

While this is not an ideal solution since it only leverages the 'barebox-state' dummy binary, it at least allows to test if mark operations would alter the barebox state variable.

We test 'mark-bad' and 'mark-primary' here, which is essentially what would happen during a normal update.