### PR TITLE
docs,src: fix spelling mistakes

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -462,7 +462,7 @@ For encryption support, you have to add ``CONFIG_DM_CRYPT``, ``CONFIG_CRYPTO_AES
 .. note::
    On ARM SoCs, there are optimized alternative SHA256 implementations
    available (for example ``CONFIG_CRYPTO_SHA2_ARM_CE``, ``CRYPTO_SHA256_ARM``
-   or hardware accellerators such as ``CONFIG_CRYPTO_DEV_FSL_CAAM_AHASH_API``).
+   or hardware accelerators such as ``CONFIG_CRYPTO_DEV_FSL_CAAM_AHASH_API``).
 
 .. _sec_ref_host_tools:
 

--- a/src/artifacts.c
+++ b/src/artifacts.c
@@ -635,7 +635,7 @@ gboolean r_artifacts_prune(GError **error)
  *         [
  *             {
  *                 "name": s,           // string: Name of the artifact
- *                 "checksums:" aa{sv}  // array of aritfact instance dictionaries
+ *                 "checksums:" aa{sv}  // array of artifact instance dictionaries
  *                 [
  *                     {
  *                         "checksum": s,   // string: Checksum of the artifact

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -273,7 +273,7 @@ static gboolean casync_make_arch(const gchar *idxpath, const gchar *contentpath,
 	}
 	g_ptr_array_add(iargs, NULL);
 
-	/* Outer process calll */
+	/* Outer process call */
 	if (!check_pseudo_active()) {
 		g_ptr_array_add(args, g_strdup("fakeroot"));
 	}
@@ -634,7 +634,7 @@ static gboolean convert_images(RaucManifest *manifest, const gchar *dir, const g
 
 		if (tar_extracted_path && !g_strv_contains((const gchar * const *)image->convert, "tar-extract")) {
 			if (!rm_tree(tar_extracted_path, &ierror)) {
-				g_propagate_prefixed_error(error, ierror, "Failed to remove files extacted from tar: ");
+				g_propagate_prefixed_error(error, ierror, "Failed to remove files extracted from tar: ");
 				return FALSE;
 			}
 		}


### PR DESCRIPTION
Debian trixie contains codespell v.2.4.1 which detects some previously unnoticed spelling mistakes.