### PR TITLE
.github/workflows: run 'style' workflow on 'ubuntu-latest'

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   style:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
The version fo codespell on ubuntu-22.04 is already quite old. Newer versions often found issues better, thus just switch to 'ubuntu-latest'.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
