### PR TITLE
test/update_handler: extend get_update_handler tests

### DIFF
--- a/test/update_handler.c
+++ b/test/update_handler.c
@@ -701,6 +701,12 @@ int main(int argc, char *argv[])
 		{"ext4", "ext4", TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE | TEST_UPDATE_HANDLER_EXPECT_FAIL, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED},
 		{"ext4", "ext4", TEST_UPDATE_HANDLER_ADAPTIVE_BLOCK_HASH_IDX | TEST_UPDATE_HANDLER_IMAGE_TOO_LARGE | TEST_UPDATE_HANDLER_EXPECT_FAIL, R_UPDATE_ERROR, R_UPDATE_ERROR_FAILED},
 
+		{"nor", "img.caibx", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
+		{"nand", "img.caibx", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
+		{"vfat", "img.caibx", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
+		{"jffs2", "img.caibx", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
+		{"jffs2", "img", TEST_UPDATE_HANDLER_DEFAULT, 0, 0},
+
 		{0}
 	};
 	setlocale(LC_ALL, "C");
@@ -1132,6 +1138,37 @@ int main(int argc, char *argv[])
 			update_handler_fixture_set_up,
 			test_update_handler,
 			update_handler_fixture_tear_down);
+
+	g_test_add("/update_handler/get_handler/img.caibx_to_nor",
+			UpdateHandlerFixture,
+			&testpair_matrix[65],
+			NULL,
+			test_get_update_handler,
+			NULL);
+	g_test_add("/update_handler/get_handler/img.caibx_to_nand",
+			UpdateHandlerFixture,
+			&testpair_matrix[66],
+			NULL,
+			test_get_update_handler,
+			NULL);
+	g_test_add("/update_handler/get_handler/img.caibx_to_vfat",
+			UpdateHandlerFixture,
+			&testpair_matrix[67],
+			NULL,
+			test_get_update_handler,
+			NULL);
+	g_test_add("/update_handler/get_handler/img.caibx_to_jffs2",
+			UpdateHandlerFixture,
+			&testpair_matrix[68],
+			NULL,
+			test_get_update_handler,
+			NULL);
+	g_test_add("/update_handler/get_handler/img_to_jffs2",
+			UpdateHandlerFixture,
+			&testpair_matrix[69],
+			NULL,
+			test_get_update_handler,
+			NULL);
 
 	return g_test_run();
 }


### PR DESCRIPTION
Improve test coverage to ensure that all currently available handlers are properly tested. Add test cases for the following combinations:
- img.caibx to nor, vfat, and jffs2 filesystems
- img to jffs2 filesystem

The `img_to_nand_handler` is currently marked as explicitly unsupported, but it is still implicitly supported via the fallback handler `{"*.img.caibx", "*", img_to_raw_handler}`. To ensure that future refactoring does not introduce behavioral changes a test case for this combination is also added.
In case this is an unwanted use case, the situation should be resolved in a later pull request.

This PR should be merged before #1756