### PR TITLE
src/nbd: fix closing bad file descriptor

### DIFF
--- a/src/nbd.c
+++ b/src/nbd.c
@@ -1341,6 +1341,7 @@ gboolean r_nbd_start_server(RaucNBDServer *nbd_srv, GError **error)
 		g_subprocess_launcher_set_child_setup(launcher, nbd_server_child_setup, &child_args, NULL);
 		g_subprocess_launcher_setenv(launcher, "RAUC_NBD_SERVER", "", TRUE);
 		g_subprocess_launcher_take_fd(launcher, sockets[0], RAUC_SOCKET_FD);
+		sockets[0] = -1; /* GSubprocessLauncher takes ownership */
 
 		nbd_srv->sproc = r_subprocess_launcher_spawnv(launcher, args, &ierror);
 		if (nbd_srv->sproc == NULL) {
@@ -1356,8 +1357,6 @@ gboolean r_nbd_start_server(RaucNBDServer *nbd_srv, GError **error)
 		*sockp = sockets[0];
 		g_thread_new("nbd", nbd_server_thread, sockp);
 	}
-
-	sockets[0] = -1; /* GSubprocess takes ownership */
 
 	nbd_srv->sock = sockets[1];
 	sockets[1] = -1; /* RaucNBDServer takes ownership */


### PR DESCRIPTION
The input socket may be closed twice if an error occurs after its ownership has been transferred to the NBD server process (for example, if the server fails to start due to a permission error):

	not ok /nbd/check_invalid_bundle - GLib-FATAL-CRITICAL: g_close(fd:3) failed with EBADF. File descriptor tracking got corrupted.

The function g_subprocess_launcher_take_fd()[1] takes ownership of the file descriptor, meaning it is considered transferred as soon as the function returns. Later, g_subprocess_launcher_close()[2] will close the descriptor when the GSubprocessLauncher[3] object is freed.

Therefore, the caller must not close the file descriptor immediately after calling g_subprocess_launcher_take_fd().

This prevents the parent process from "double-closing" the input socket if an error occurs after it has been transferred to the NBD server process.

Fixes:

	Log of Meson test suite run on 2025-09-16T10:35:08.519413

	Inherited environment: test=nbd RAUC_TEST_MTD_NAND=/dev/mtd2 RAUC_TEST_HTTP_SERVER=1 HOME=/root OLDPWD=/ RAUC_TEST_BLOCK_LOOP=/dev/loop0 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 RAUC_TEST_NBD_SERVER=/home/gportay/src/rauc/build//rauc RAUC_TEST_MTD_UBI=/dev/ubi0 TERM=linux PATH=/tmp/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin G_DEBUG=gc-friendly LSAN_OPTIONS=suppressions=/home/gportay/src/rauc/test/asan.supp RAUC_TEST_MTD_UBIVOL=/dev/ubi0_0 G_SLICE=always-malloc ASAN_OPTIONS=malloc_context_size=64:fast_unwind_on_malloc=0 RAUC_TEST_MTD_NOR=/dev/mtd0 PWD=/home/gportay/src/rauc RAUC_TEST_CASYNC=1 LC_CTYPE=C.UTF-8

	==================================== 1/1 =====================================
	test:         nbd
	start time:   08:35:08
	duration:     0.14s
	result:       killed by signal 5 SIGTRAP
	command:      MESON_BUILD_DIR=/home/gportay/src/rauc/build MALLOC_PERTURB_=102 /home/gportay/src/rauc/build/test/nbd-test
	----------------------------------- stdout -----------------------------------
	TAP version 13
	# random seed: R02Sae83fd3f68f54aaddc402a49fab618b7
	1..25
	# Start of nbd tests
	# tmpdir: /tmp/rauc-KX1MC3
	#
	# rauc-MESSAGE: Remote URI detected, streaming bundle...
	# rauc-nbd-MESSAGE: starting the nbd server
	# rauc-subprocess-DEBUG: launching subprocess: /home/gportay/src/rauc/build//rauc
	not ok /nbd/check_invalid_bundle - GLib-FATAL-CRITICAL: g_close(fd:3) failed with EBADF. The tracking of file descriptors got messed up
	Bail out!
	----------------------------------- stderr -----------------------------------
	rauc-Message: 10:35:08.623: No data directory or status file set, falling back to per-slot status.
	Consider setting 'data-directory=<path>' or 'statusfile=<path>/per-slot' explicitly.
	rauc-Message: 10:35:08.625: Using per-slot statusfile. System status information not supported!
	rauc-Message: 10:35:08.628: Using system config file test/test.conf
	rauc-Message: 10:35:08.629: Getting Systeminfo: /home/gportay/src/rauc/test/bin/systeminfo.sh
	rauc-Message: 10:35:08.637: Failed to convert 'RAUC_TEST_VAR' line to variable

	(test program exited with status code -5)
	==============================================================================

	Summary of Failures:

	1/1 nbd ERROR            0.14s   killed by signal 5 SIGTRAP

	Ok:                 0
	Expected Fail:      0
	Fail:               1
	Unexpected Pass:    0
	Skipped:            0
	Timeout:            0

[1]: https://docs.gtk.org/gio/method.SubprocessLauncher.take_fd.html
[2]: https://docs.gtk.org/gio/method.SubprocessLauncher.close.html
[3]: https://docs.gtk.org/gio/class.SubprocessLauncher.html