### PR TITLE
Fix documentation Advanced Topics page

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1684,14 +1684,14 @@ happened on the system, use::
   [log.install-log]
   filename=install.log
   events=install
-  output-format=short
+  format=short
 
 Or, if you want a json-based log of all events, limited to 1M per log file and
 5 rotation files to keep, use::
 
   [log.all-json-log]
   filename=all-json.log
-  output-format=json
+  format=json
   max-size=1M
   max-files=5
 


### PR DESCRIPTION
This PR fixes the "Advanced Topics" page of the documentation.
When describing `[log.install-log]` section of the system configuration file, the page mentions the `output-format` field.
The right field name is `format`.

See code here : https://github.com/rauc/rauc/blob/master/src/config_file.c#L199

And the reference page here : https://github.com/rauc/rauc/blob/master/docs/reference.rst?plain=1#L712

