### PR TITLE
.mailmap: add mailmap to unifiy naming

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Enrico Jörns <ejo@pengutronix.de>
+Jan Lübbe <jlu@pengutronix.de>
+Marcus Hoffmann <marcus.hoffmann@othermo.de> <97530794+BubuOT@users.noreply.github.com>


### PR DESCRIPTION
This makes`git shortlog` work correctly.