### PR TITLE
add pkcs11-provider to CI container

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:bookworm
 
+# Add backports for pkcs11-provider
+RUN echo "deb http://deb.debian.org/debian bookworm-backports main" \
+  > /etc/apt/sources.list.d/backports.list
+
 # Required for building
 RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
   gcc \
@@ -41,6 +45,7 @@ RUN apt-get install -q -y --no-install-recommends \
   opensc \
   opensc-pkcs11 \
   libengine-pkcs11-openssl \
+  pkcs11-provider \
   fakeroot \
   faketime \
   pseudo \


### PR DESCRIPTION
This prepares for testing the upcoming provider support.