### PR TITLE
.github/workflows/scan-build: switch from Debian unstable to trixie

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: debian:unstable
+      image: debian:trixie
       options: --user=root
     steps:
     - name: Install dependencies


### PR DESCRIPTION
The dependency installation currently fails with
```
   clang-19 : Depends: libc6-dev but it is not installable
              Recommends: llvm-19-dev but it is not installable
  ...
  E: Unable to correct problems, you have held broken packages.
  E: The following information from --solver 3.0 may provide additional context:
     Unable to satisfy dependencies. Reached two conflicting decisions:
     1. libc6-dev:amd64 is selected for install because:
        1. clang-tools:amd64=1:19.0-63 is selected for install
        2. clang-tools:amd64 Depends clang-tools-19 (>= 19~) 3. clang-tools-19:amd64 Depends clang-19 (= 1:19.1.7-7) 4. clang-19:amd64 Depends libc6-dev 2. libc6-dev:amd64 Depends linux-libc-dev but none of the choices are installable: [no choices]
```
Use Debian trixie instead to avoid issues like this.