### PR TITLE
improve handling of bundles with multiple signatures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,23 +135,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release:
-        - "ubuntu:20.04"
-        - "ubuntu:22.04"
-        - "ubuntu:24.04"
-        - "debian:bullseye"
-        - "debian:bookworm"
-        - "debian:trixie"
-        - "debian:testing"
         include:
+        - release: "ubuntu:20.04"
+        - release: "ubuntu:22.04"
         - release: "ubuntu:24.04"
-          test: true
+          test: "base"
+        - release: "debian:bullseye"
         - release: "debian:bookworm"
-          test: true
+          test: "base"
         - release: "debian:trixie"
-          test: true
+          test: "base"
+        - release: "debian:trixie"
+          test: "multisig"
         - release: "debian:testing"
-          test: true
+          test: "base"
     steps:
     - uses: actions/checkout@v4
 
@@ -173,6 +170,15 @@ jobs:
       run: |
         podman exec -e DEBIAN_FRONTEND='noninteractive' -i -u root stable apt-get install -qy python3-pytest python3-dasbus python3-aiohttp python3-requests python3-pyasn1 python3-pyasn1-modules openssl e2fsprogs grub-common faketime
 
+    - name: Install multisig test dependencies
+      if: ${{ matrix.test == 'multisig' }}
+      run: |
+        wget https://github.com/jluebbe/openssl-deb/releases/download/verify-partial-20250808/libssl-dev_3.5.1-1.1_amd64.deb
+        wget https://github.com/jluebbe/openssl-deb/releases/download/verify-partial-20250808/libssl3t64_3.5.1-1.1_amd64.deb
+        wget https://github.com/jluebbe/openssl-deb/releases/download/verify-partial-20250808/openssl_3.5.1-1.1_amd64.deb
+        wget https://github.com/jluebbe/openssl-deb/releases/download/verify-partial-20250808/openssl-provider-legacy_3.5.1-1.1_amd64.deb
+        podman exec -e DEBIAN_FRONTEND='noninteractive' -i -u root stable dpkg -i *.deb
+
     - name: Configure
       run: |
         podman exec -i stable meson setup -Dgpt=disabled -Dwerror=true build
@@ -187,6 +193,6 @@ jobs:
         podman exec -i stable meson test -C build --suite rauc --timeout-multiplier 3
 
     - name: Show logs
-      if: ${{ failure() }}
+      if: ${{ always() }}
       run: |
         cat build/meson-logs/testlog.txt || true

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -302,6 +302,22 @@ signature.
   can not be authenticated.
   If CRL checking is needed, the PKI needs to be structured with this in mind.
 
+``allow-single-signature=<true/false>`` (optional)
+  If this option is set to ``true``, RAUC will accept a bundle with multiple
+  signatures even if only one of them can be verified.
+  Otherwise, RAUC uses OpenSSL's default behavior of requiring successful
+  verification of all signatures.
+  This can be used to simplify a key rotation process: Instead of signing the
+  same bundle contents with the old and new keys separately and documenting
+  when to use each resulting bundle, a single bundle is enough.
+
+  Additional signatures can be added to a bundle by using ``rauc resign`` with
+  the ``--append`` option.
+
+  .. note::
+     Note that changes in OpenSSL are needed to support this.
+     See OpenSSL PR #27604, which might be included in OpenSSL 4.0.
+
 ``allowed-signer-cns=Name 1;Other Name`` (optional)
   If this config parameter is set, RAUC will check the ``CommonName`` field
   of the bundle's signer certificates against this semicolon-separated list.

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -68,13 +68,17 @@ typedef struct {
 	gboolean activate_installed;
 	gchar *data_directory;
 	gchar *statusfile_path;
+
+	/* keyring */
 	gchar *keyring_path;
 	gchar *keyring_directory;
 	gboolean keyring_allow_partial_chain;
+	gboolean keyring_allow_single_signature;
 	gboolean keyring_check_crl;
 	gchar *keyring_check_purpose;
 	gchar **keyring_allowed_signer_cns;
 	gboolean use_bundle_signing_time;
+
 	/* bit mask for allowed formats */
 	guint bundle_formats_mask;
 	/* enable complete read before mount */

--- a/meson.build
+++ b/meson.build
@@ -176,6 +176,13 @@ endif
 # as they are deprecated in favor of providers API
 conf.set10('ENABLE_OPENSSL_PKCS11_ENGINE', get_option('pkcs11_engine'))
 
+openssl_verify_partial = cc.get_define(
+  'CMS_VERIFY_PARTIAL',
+  dependencies : openssldep,
+  prefix : '#include <openssl/cms.h>',
+)
+conf.set10('ENABLE_OPENSSL_VERIFY_PARTIAL', openssl_verify_partial != '')
+
 gnome = import('gnome')
 dbus_ifaces = files('src/de.pengutronix.rauc.Installer.xml')
 dbus_sources = gnome.gdbus_codegen(

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -3,6 +3,7 @@
 
 #include "artifacts.h"
 #include "bootchooser.h"
+#include "config.h"
 #include "config_file.h"
 #include "context.h"
 #include "event_log.h"
@@ -709,6 +710,26 @@ static gboolean parse_keyring_section(const gchar *filename, GKeyFile *key_file,
 		return FALSE;
 	}
 	g_key_file_remove_key(key_file, "keyring", "allow-partial-chain", NULL);
+
+	gboolean keyring_allow_single_signature = g_key_file_get_boolean(key_file, "keyring", "allow-single-signature", &ierror);
+	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND) ||
+	    g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_GROUP_NOT_FOUND)) {
+		keyring_allow_single_signature = FALSE;
+		g_clear_error(&ierror);
+	} else if (ierror) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+	g_key_file_remove_key(key_file, "keyring", "allow-single-signature", NULL);
+	if (!ENABLE_OPENSSL_VERIFY_PARTIAL && keyring_allow_single_signature) {
+		g_set_error(
+				error,
+				G_KEY_FILE_ERROR,
+				G_KEY_FILE_ERROR_INVALID_VALUE,
+				"Keyring section option 'allow-single-signature' is not supported because OpenSSL does not define CMS_VERIFY_PARTIAL");
+		return FALSE;
+	}
+	c->keyring_allow_single_signature = keyring_allow_single_signature;
 
 	c->use_bundle_signing_time = g_key_file_get_boolean(key_file, "keyring", "use-bundle-signing-time", &ierror);
 	if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND) ||

--- a/src/signature.c
+++ b/src/signature.c
@@ -1107,7 +1107,9 @@ static STACK_OF(X509) *cms_get_signer_certs(CMS_ContentInfo *cms, GError **error
 	g_return_val_if_fail(cms != NULL, NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
-	g_autoptr(R_X509_STACK) signers = CMS_get0_signers(cms);
+	g_autoptr(R_X509_STACK) signers = NULL;
+#if !ENABLE_OPENSSL_VERIFY_PARTIAL
+	signers = CMS_get0_signers(cms);
 	if (signers == NULL) {
 		g_set_error_literal(
 				error,
@@ -1116,6 +1118,31 @@ static STACK_OF(X509) *cms_get_signer_certs(CMS_ContentInfo *cms, GError **error
 				"Failed to obtain signer info");
 		return NULL;
 	}
+#else
+	signers = sk_X509_new_null();
+	STACK_OF(CMS_SignerInfo) *sinfos = CMS_get0_SignerInfos(cms);
+	for (int i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++) {
+		CMS_SignerInfo *si = sk_CMS_SignerInfo_value(sinfos, i);
+
+		/* We only want to consider signatures that passed OpenSSL's
+		 * verification. */
+		if (!CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_RESULT))
+			continue;
+
+		X509 *si_signer = CMS_SignerInfo_get0_signer_cert(si);
+		if (si_signer == NULL) {
+			g_set_error_literal(
+					error,
+					R_SIGNATURE_ERROR,
+					R_SIGNATURE_ERROR_GET_SIGNER,
+					"Failed to obtain signer certificate from signer info");
+			return NULL;
+		}
+
+		if (!sk_X509_push(signers, si_signer))
+			g_error("cms_get_signer_cert: sk_X509_push failed");
+	}
+#endif
 
 	/* provide a stable order of signers */
 	sk_X509_set_cmp_func(signers, cmp_x509);
@@ -1538,6 +1565,11 @@ gboolean cms_verify_bytes(GBytes *content, GBytes *sig, X509_STORE *store, CMS_C
 		/* use signing time for verification */
 		X509_VERIFY_PARAM_set_time(param, signingtime);
 	}
+
+#if ENABLE_OPENSSL_VERIFY_PARTIAL
+	if (r_context()->config->keyring_allow_single_signature)
+		verify_flags |= CMS_VERIFY_PARTIAL;
+#endif
 
 	if (detached)
 		verified = CMS_verify(icms, NULL, store, incontent, NULL, verify_flags | CMS_DETACHED);

--- a/test/signature.c
+++ b/test/signature.c
@@ -967,6 +967,30 @@ static void signature_append_inline(SignatureFixture *fixture, gconstpointer use
 	g_assert_null(manifest);
 }
 
+/* assert that the cert has the expected common name */
+static G_GNUC_UNUSED void assert_X509_subject_cn(const X509 *cert, const gchar *expected)
+{
+	g_assert_nonnull(cert);
+
+	X509_NAME *name = X509_get_subject_name(cert);
+	g_assert_nonnull(name);
+
+	int index = X509_NAME_get_index_by_NID(name, NID_commonName, -1);
+	g_assert_cmpint(index, >=, 0);
+
+	const X509_NAME_ENTRY *cn = X509_NAME_get_entry(name, index);
+	g_assert_nonnull(cn);
+
+	const unsigned char* cn_value = ASN1_STRING_get0_data(X509_NAME_ENTRY_get_data(cn));
+	g_assert_nonnull(cn_value);
+
+	/* the should be no more common names */
+	index = X509_NAME_get_index_by_NID(name, NID_commonName, index);
+	g_assert_cmpint(index, ==, -1);
+
+	g_assert_cmpstr(expected, ==, (gchar*)cn_value);
+}
+
 static void signature_append_partial(SignatureFixture *fixture, gconstpointer user_data)
 {
 	gboolean res;

--- a/test/test_resign.py
+++ b/test/test_resign.py
@@ -127,18 +127,23 @@ def test_resign_append(tmp_path):
     assert out_bundle.exists()
     assert get_signers(out_bundle) == {SIGNERS["release-1"], SIGNERS["autobuilder-1"]}
 
+    # no path for the signature by Autobuilder-1
     out, err, exitcode = run(f"rauc --keyring openssl-ca/rel-ca.pem info {out_bundle}")
     assert exitcode == 1
     assert "unable to get local issuer certificate" in err
 
+    # no path for the signature by Release-1
     out, err, exitcode = run(f"rauc --keyring openssl-ca/dev-only-ca.pem info {out_bundle}")
     assert exitcode == 1
     assert "unable to get local issuer certificate" in err
 
-    # verification with multiple signatures is not supported yet
+    # dev-ca also allows release signatures
     out, err, exitcode = run(f"rauc --keyring openssl-ca/dev-ca.pem info {out_bundle}")
-    assert exitcode == 1
-    assert "Unsupported number of signers: 2" in err
+    assert exitcode == 0
+    assert (
+        "Verified detached signature by 'O = Test Org, CN = Test Org Autobuilder-1', 'O = Test Org, CN = Test Org Release-1'"
+        in err
+    )
 
 
 def test_resign_verity_append(tmp_path):
@@ -161,18 +166,23 @@ def test_resign_verity_append(tmp_path):
     assert out_bundle.exists()
     assert get_signers(out_bundle) == {SIGNERS["release-1"], SIGNERS["autobuilder-1"]}
 
+    # no path for the signautre by Autobuilder-1
     out, err, exitcode = run(f"rauc --keyring openssl-ca/rel-ca.pem info {out_bundle}")
     assert exitcode == 1
     assert "unable to get local issuer certificate" in err
 
+    # no path for the signature by Release-1
     out, err, exitcode = run(f"rauc --keyring openssl-ca/dev-only-ca.pem info {out_bundle}")
     assert exitcode == 1
     assert "unable to get local issuer certificate" in err
 
-    # verification with multiple signatures is not supported yet
+    # dev-ca also allows release signatures
     out, err, exitcode = run(f"rauc --keyring openssl-ca/dev-ca.pem info {out_bundle}")
-    assert exitcode == 1
-    assert "Unsupported number of signers: 2" in err
+    assert exitcode == 0
+    assert (
+        "Verified inline signature by 'O = Test Org, CN = Test Org Autobuilder-1', 'O = Test Org, CN = Test Org Release-1'"
+        in err
+    )
 
 
 def test_resign_crypt(tmp_path):

--- a/test/test_resign.py
+++ b/test/test_resign.py
@@ -1,6 +1,6 @@
 import shutil
 
-from conftest import have_faketime
+from conftest import have_faketime, string_in_config_h
 from helper import run
 from decode_cms import decode_cms
 
@@ -184,6 +184,26 @@ def test_resign_verity_append(tmp_path):
         in err
     )
 
+    if string_in_config_h("ENABLE_OPENSSL_VERIFY_PARTIAL 1"):
+        out, err, exitcode = run(
+            f"rauc -C keyring:allow-single-signature=true --keyring openssl-ca/rel-ca.pem info {out_bundle}"
+        )
+        assert "Verified inline signature by 'O = Test Org, CN = Test Org Release-1'" in err
+        assert exitcode == 0
+
+        out, err, exitcode = run(
+            f"rauc -C keyring:allow-single-signature=true --keyring openssl-ca/dev-only-ca.pem info {out_bundle}"
+        )
+        assert "Verified inline signature by 'O = Test Org, CN = Test Org Autobuilder-1'" in err
+        assert exitcode == 0
+    else:
+        out, err, exitcode = run(f"rauc -C keyring:allow-single-signature=true info {out_bundle}")
+        assert (
+            "Keyring section option 'allow-single-signature' is not supported because OpenSSL does not define CMS_VERIFY_PARTIAL"
+            in err
+        )
+        assert exitcode == 1
+
 
 def test_resign_crypt(tmp_path):
     # copy to tmp path for safe ownership check
@@ -347,3 +367,10 @@ def test_resign_append_intermediate(tmp_path):
     out, err, exitcode = run(f"rauc --keyring openssl-ca/root-ca.pem info {out_bundle}")
     assert exitcode == 1
     assert "unable to get local issuer certificate" in err
+
+    if string_in_config_h("ENABLE_OPENSSL_VERIFY_PARTIAL 1"):
+        out, err, exitcode = run(
+            f"rauc -C keyring:allow-single-signature=true --keyring openssl-ca/root-ca.pem info {out_bundle}"
+        )
+        assert "Verified inline signature by 'O = Test Org, CN = Test Org Autobuilder-1'" in err
+        assert exitcode == 0


### PR DESCRIPTION
The main use cases for multiple signatures on one message are:

* Simplify CA certificate roll-over by signing messages with keys in
  both the old and new hierarchies during a transition period.
  Recipients would have either the old or new CA installed (or
  temporarily even both). In either case, we'd like to accept any
  message which has at least one signature that can be verified.

* Support user-implemented verification policies which require
  signatures from multiple specific signers.

* Support user-implemented verification policies which require a minimum
  number of signatures from different signers under under a trusted CA.

On OpenSSL versions which support `CMS_VERIFY_PARTIAL` (which is
not yet merged), we can accept a bundle with multiple signatures even if
only one of them can be verified. We use the config option
`allow-single-signature=true` to enable this and keep the existing behavior
of requiring successful verification of all signatures as the default for
backwards compatibility.

This can be used to simplify a key rotation process: Instead of signing the
same bundle contents with the old and new keys separately and documenting
when to use each resulting bundle, a single bundle is enough.

In the future, we can build on the OpenSSL feature to actually require multiple signatures from different/specific signers.