### PR TITLE
utils: add r_get_boottime for CLOCK_BOOTTIME

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -516,3 +516,11 @@ gchar *r_format_duration(gint64 total_seconds);
  */
 gchar *r_regex_match_simple(const gchar *pattern, const gchar *string)
 G_GNUC_WARN_UNUSED_RESULT;
+
+/**
+ * Reads CLOCK_BOOTTIME via clock_gettime().
+ *
+ * @return the time value in microseconds
+ */
+gint64 r_get_boottime(void)
+G_GNUC_WARN_UNUSED_RESULT;

--- a/src/utils.c
+++ b/src/utils.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+#include <time.h>
 
 #include "utils.h"
 
@@ -1125,4 +1126,14 @@ gchar *r_regex_match_simple(const gchar *pattern, const gchar *string)
 		return g_match_info_fetch(match, 1);
 
 	return NULL;
+}
+
+gint64 r_get_boottime(void)
+{
+	struct timespec ts;
+
+	if (clock_gettime(CLOCK_BOOTTIME, &ts) != 0)
+		g_error("RAUC needs CLOCK_BOOTTIME (failed with %s)", g_strerror(errno));
+
+	return (((gint64) ts.tv_sec) * 1000000) + (ts.tv_nsec / 1000);
 }

--- a/test/utils.c
+++ b/test/utils.c
@@ -552,6 +552,19 @@ static void tempfile_cleanup_test(void)
 	g_test_assert_expected_messages();
 }
 
+static void boottime_test(void)
+{
+	gint64 a = r_get_boottime();
+	g_usleep(100000);
+	gint64 b = r_get_boottime();
+
+	g_assert_cmpint(b, >, a);
+	gint64 diff = b - a;
+
+	g_assert_cmpint(diff, >=, 100000);
+	g_assert_cmpint(diff, <=, 110000);
+}
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -572,6 +585,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/utils/format_duration", format_duration_test);
 	g_test_add_func("/utils/regex_match", regex_match_test);
 	g_test_add_func("/utils/tempfile_cleanup", tempfile_cleanup_test);
+	g_test_add_func("/utils/boottime", boottime_test);
 
 	return g_test_run();
 }


### PR DESCRIPTION
Compared to CLOCK_MONOTONIC, this includes any time that the system is suspend, which will be useful for scheduling polling intervals in the future.