### PR TITLE
src/nbd: fix typo in comment

### DIFF
--- a/src/nbd.c
+++ b/src/nbd.c
@@ -571,7 +571,7 @@ static void start_read(struct RaucNBDContext *ctx, struct RaucNBDTransfer *xfer)
 		g_error("unexpected error from curl_multi_add_handle in %s", G_STRFUNC);
 }
 
-/* Appends Gstrv elements to curl_slist (strings are copied).
+/* Appends GStrv elements to curl_slist (strings are copied).
  * If curl_slist does not exist yet (NULL passed), it will be created.
  * The created list needs to be freed (after usage) by the caller with
  * curl_slist_free_all(). */


### PR DESCRIPTION
This fixes a typo in the comment by capitalizing the word 'Strv' in type GStrv.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
