### PR TITLE
src/manifest: assign g_autofree pointer to NULL

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -416,7 +416,7 @@ gboolean load_manifest_mem(GBytes *mem, RaucManifest **manifest, GError **error)
 gboolean load_manifest_file(const gchar *filename, RaucManifest **manifest, GError **error)
 {
 	GError *ierror = NULL;
-	g_autofree gchar *data;
+	g_autofree gchar *data = NULL;
 	gsize length;
 	g_autoptr(GKeyFile) key_file = NULL;
 	g_autofree gchar *manifest_checksum = NULL;


### PR DESCRIPTION
This assigns g_autofree pointer to NULL at declaration to avoid freeing a dangling pointer if the function returns before the pointer is actually assigned. For example, the function may return if the parameters are not set correctly.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
