### PR TITLE
new d-bus property for the last transaction and bundle

### DIFF
--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -93,6 +93,8 @@
 
     <!-- Operation: Represents the current (global) operation rauc performs -->
     <property name="Operation" type="s" access="read"/>
+    <!-- LastBundle: Holds the path and filename to the last bundle rauc consumed -->
+    <property name="LastBundle" type="s" access="read"/>
     <!-- LastTransaction: the last (install) transaction Rauc performed -->
     <property name="LastTransaction" type="s" access="read"/>
     <!-- LastError: Holds a message describing the last error that occurred -->

--- a/src/de.pengutronix.rauc.Installer.xml
+++ b/src/de.pengutronix.rauc.Installer.xml
@@ -93,6 +93,8 @@
 
     <!-- Operation: Represents the current (global) operation rauc performs -->
     <property name="Operation" type="s" access="read"/>
+    <!-- LastTransaction: the last (install) transaction Rauc performed -->
+    <property name="LastTransaction" type="s" access="read"/>
     <!-- LastError: Holds a message describing the last error that occurred -->
     <property name="LastError" type="s" access="read"/>
     <!-- Progress: Provides installation progress information in the form

--- a/src/event_log.c
+++ b/src/event_log.c
@@ -205,6 +205,9 @@ static gchar *event_log_format_fields_readable(GLogLevelFlags log_level,
 		} else if (g_strcmp0(ifield->key, "BUNDLE_VERSION") == 0) {
 			key = "bundle version";
 			value = ifield->value;
+		} else if (g_strcmp0(ifield->key, "BUNDLE_NAME") == 0) {
+			key = "bundle name";
+			value = ifield->value;
 		} else if (g_strcmp0(ifield->key, "SLOT_NAME") == 0) {
 			key = "slot";
 			value = ifield->value;

--- a/src/install.c
+++ b/src/install.c
@@ -1307,6 +1307,7 @@ static void log_event_installation_done(RaucInstallArgs *args, RaucManifest *man
 		{"BUNDLE_HASH", "", -1},
 		{"BUNDLE_DESCRIPTION", "", -1},
 		{"BUNDLE_VERSION", "", -1},
+		{"BUNDLE_NAME", args->name, -1},
 		{"TRANSACTION_ID", args->transaction, -1},
 	};
 

--- a/src/install.c
+++ b/src/install.c
@@ -1549,6 +1549,10 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	if (!args->transaction)
 		args->transaction = g_uuid_string_random();
 
+	//ToDo: shouldn't the dbus property be updated *here*?
+	//(but here, the r_installer isn't accessible)
+	//r_installer_set_last_transaction(r_installer, args->transaction);
+
 	r_context_begin_step("do_install_bundle", "Installing", 10);
 
 	log_event_installation_started(args);

--- a/src/service.c
+++ b/src/service.c
@@ -92,6 +92,7 @@ static gboolean r_on_handle_install_bundle(
 	gboolean res;
 
 	g_print("input bundle: %s\n", source);
+	r_installer_set_last_bundle(interface, source);
 
 	res = !r_context_get_busy();
 	if (!res) {
@@ -179,6 +180,7 @@ static gboolean r_on_handle_inspect_bundle(RInstaller *interface,
 	gboolean res = TRUE;
 
 	g_print("bundle: %s\n", arg_bundle);
+	r_installer_set_last_bundle(interface, arg_bundle);
 
 	res = !r_context_get_busy();
 	if (!res) {
@@ -512,6 +514,7 @@ static gboolean auto_install(const gchar *source)
 		return FALSE;
 
 	g_message("input bundle: %s", source);
+	r_installer_set_last_bundle(r_installer, source);
 
 	res = !r_context_get_busy();
 	if (!res)

--- a/src/service.c
+++ b/src/service.c
@@ -104,6 +104,10 @@ static gboolean r_on_handle_install_bundle(
 	args->notify = service_install_notify;
 	args->cleanup = service_install_cleanup;
 
+	if (!args->transaction)
+		args->transaction = g_uuid_string_random();
+	r_installer_set_last_transaction(interface, args->transaction);
+
 	if (g_variant_dict_lookup(&dict, "ignore-compatible", "b", &args->ignore_compatible))
 		g_variant_dict_remove(&dict, "ignore-compatible");
 


### PR DESCRIPTION
The Rauc service already exposes properties for `Operation`, `Progress`  and `LastError`.

But there is (currently) no way to correlate these to an input file/bundle.

This PR would add two additional properties to fill that gap:
```
    <!-- LastBundle: Holds the path and filename to the last bundle rauc consumed -->
    <property name="LastBundle" type="s" access="read"/>
    <!-- LastTransaction: the last (install) transaction Rauc performed -->
    <property name="LastTransaction" type="s" access="read"/>
```

This would come in handy for scenarios where multiple parties interact with rauc: one application feeding it a bundle, another monitoring its operation state and errors, ...