### PR TITLE
Fix Documentation of New Image `type` Option

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -342,7 +342,7 @@ With this set, you can freely choose the file extension, e.g.
 
    [image.bootloader]
    filename=boot.bin
-   type=image
+   type=raw
 
 .. note:: Ensure all devices in the field run a RAUC version that supports
    this feature before making use of it.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1075,10 +1075,10 @@ Supported file system image types are:
 
 Supported binary image types are:
 
-  * ``image``: Generic image format (raw binary data)
+  * ``raw``: Generic image format (raw binary data)
 
     .. note::
-      The ``image`` type is valid for all slot types and should be used for raw
+      The ``raw`` type is valid for all slot types and should be used for raw
       binary data like bootloader images, firmware binaries, etc.
 
 Supported archive types are:


### PR DESCRIPTION
Fix image type 'image' to be 'raw'
This got renamed during mainlining of this feature.
However, the documentation did not properly reflect this.