### PR TITLE
src/manifest: properly handle missing 'filename' in handle_missing_type()`

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -24,6 +24,12 @@ static gboolean handle_missing_type(RaucImage *image, GError **error)
 	if (image->hooks.install)
 		return TRUE;
 
+	if (!image->filename) {
+		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE,
+				"Failed to detect image type: Neither 'type' nor 'filename' given.");
+		return FALSE;
+	}
+
 	const gchar *derived_type = derive_image_type_from_filename_pattern(image->filename);
 	if (!derived_type) {
 		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE,

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -466,6 +466,32 @@ filename=rootfs-default.invalid\n\
 	free_manifest(rm);
 }
 
+static void test_manifest_load_missing_type_and_filename(void)
+{
+	g_autofree gchar *tmpdir;
+	g_autoptr(RaucManifest) rm = NULL;
+	g_autofree gchar* manifestpath = NULL;
+	gboolean res;
+	g_autoptr(GError) error = NULL;
+	const gchar *mffile = "\
+[update]\n\
+compatible=FooCorp Super BarBazzer\n\
+version=2025.10-1\n\
+\n\
+[image.rootfs]\n\
+";
+
+	tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+	g_assert_nonnull(tmpdir);
+
+	manifestpath = write_tmp_file(tmpdir, "manifest.raucm", mffile, NULL);
+	g_assert_nonnull(manifestpath);
+
+	res = load_manifest_file(manifestpath, &rm, &error);
+	g_assert_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE);
+	g_assert_false(res);
+}
+
 static void test_manifest_load_types_emptyfs_with_imagename_invalid(void)
 {
 	gchar *tmpdir;
@@ -980,6 +1006,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/manifest/load_types", test_manifest_load_types);
 	g_test_add_func("/manifest/load_types_invalid", test_manifest_load_types_invalid);
 	g_test_add_func("/manifest/load_types_filenext_not_mapped", test_manifest_load_types_fileext_not_mapped);
+	g_test_add_func("/manifest/missing_type_and_filename", test_manifest_load_missing_type_and_filename);
 	g_test_add_func("/manifest/load_types_emptyfs_valid", test_manifest_load_types_emptyfs_valid);
 	g_test_add_func("/manifest/load_types_emptyfs_with_filename_invalid", test_manifest_load_types_emptyfs_with_imagename_invalid);
 	g_test_add_func("/manifest/load_adaptive", test_manifest_load_adaptive);


### PR DESCRIPTION
During manifest parsing, handle_missing_type() gets called before having checked that a filename is present. Thus the method must properly handle this to not run into an assertion when calling
derive_image_type_from_filename_pattern().

Also add a test case for this.

Fixes:
| (rauc:676850): rauc-CRITICAL **: 08:48:58.847: derive_image_type_from_filename_pattern: assertion 'filename' failed

Fixes: ec13c538 ("src/update_handler: add image type to manifest")

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
