### PR TITLE
Improve casync seeding and slot detection (UBIFS support)

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -94,6 +94,57 @@ static gchar *resolve_loop_device(const gchar *devicepath, GError **error)
 	return g_strchomp(content);
 }
 
+/*
+ * Resolve UBI volume name notation (ubi<N>:<volname>) to device path.
+ * UBI volumes are mounted with notation like "ubi0:root" but the actual
+ * device is /dev/ubi0_0. This function resolves the name by looking up
+ * the volume name in /sys/class/ubi/ubi<N>_<M>/name.
+ */
+static gchar *resolve_ubi_volume(const gchar *devicepath)
+{
+	g_autoptr(GRegex) regex = NULL;
+	g_autoptr(GMatchInfo) match_info = NULL;
+	g_autofree gchar *ubi_num = NULL;
+	g_autofree gchar *vol_name = NULL;
+	g_autofree gchar *ubi_class_path = NULL;
+	g_autoptr(GDir) dir = NULL;
+
+	regex = g_regex_new("^ubi(\\d+):(.+)$", 0, 0, NULL);
+	g_assert_nonnull(regex);
+
+	g_regex_match(regex, devicepath, 0, &match_info);
+	if (!g_match_info_matches(match_info))
+		return g_strdup(devicepath);
+
+	ubi_num = g_match_info_fetch(match_info, 1);
+	vol_name = g_match_info_fetch(match_info, 2);
+
+	/* Search through /sys/class/ubi/ubi<N>_X/name for matching volume */
+	ubi_class_path = g_strdup("/sys/class/ubi");
+	dir = g_dir_open(ubi_class_path, 0, NULL);
+	if (dir) {
+		const gchar *entry;
+		g_autofree gchar *prefix = g_strdup_printf("ubi%s_", ubi_num);
+
+		while ((entry = g_dir_read_name(dir)) != NULL) {
+			if (g_str_has_prefix(entry, prefix)) {
+				g_autofree gchar *name_path = g_build_filename(ubi_class_path, entry, "name", NULL);
+				g_autofree gchar *name_content = NULL;
+
+				if (g_file_get_contents(name_path, &name_content, NULL, NULL)) {
+					g_strchomp(name_content);
+					if (g_strcmp0(name_content, vol_name) == 0) {
+						return g_strdup_printf("/dev/%s", entry);
+					}
+				}
+			}
+		}
+	}
+
+	/* Volume not found, return original */
+	return g_strdup(devicepath);
+}
+
 gboolean update_external_mount_points(GError **error)
 {
 	g_autolist(GUnixMountEntry) mountlist = NULL;
@@ -113,14 +164,17 @@ gboolean update_external_mount_points(GError **error)
 	for (GList *l = mountlist; l != NULL; l = l->next) {
 		GUnixMountEntry *m = (GUnixMountEntry*)l->data;
 		g_autofree gchar *devicepath = NULL;
+		g_autofree gchar *resolved_devicepath = NULL;
 		RaucSlot *s;
 		devicepath = resolve_loop_device(g_unix_mount_get_device_path(m), &ierror);
 		if (!devicepath) {
 			g_propagate_error(error, ierror);
 			return FALSE;
 		}
+		/* Resolve UBI volume names like ubi0:root to /dev/ubi0_0 */
+		resolved_devicepath = resolve_ubi_volume(devicepath);
 		s = find_config_slot_by_device(r_context()->config,
-				devicepath);
+				resolved_devicepath);
 		if (s) {
 			/* We might have multiple mount entries matching the same device and thus the same slot.
 			 * To avoid leaking the string returned by g_unix_mount_get_mount_path() here, we skip all further matches

--- a/src/slot.c
+++ b/src/slot.c
@@ -62,13 +62,26 @@ RaucSlot *r_slot_find_by_device(GHashTable *slots, const gchar *device)
 {
 	GHashTableIter iter;
 	RaucSlot *slot;
+	g_autofree gchar *resolved_device = NULL;
 
 	g_return_val_if_fail(slots, NULL);
 	g_return_val_if_fail(device, NULL);
 
+	/* Resolve symlinks in the search device */
+	resolved_device = r_realpath(device);
+	if (!resolved_device)
+		resolved_device = g_strdup(device);
+
 	g_hash_table_iter_init(&iter, slots);
 	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
-		if (g_strcmp0(slot->device, device) == 0) {
+		g_autofree gchar *resolved_slot_device = NULL;
+
+		/* Resolve symlinks in slot device for comparison */
+		resolved_slot_device = r_realpath(slot->device);
+		if (!resolved_slot_device)
+			resolved_slot_device = g_strdup(slot->device);
+
+		if (g_strcmp0(resolved_slot_device, resolved_device) == 0) {
 			return slot;
 		}
 	}

--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -583,6 +583,7 @@ static gboolean casync_extract_image(RaucImage *image, gchar *dest, int out_fd, 
 	gchar *store = NULL;
 	gchar *tmpdir = NULL;
 	gboolean seed_mounted = FALSE;
+	g_autofree gchar *seed_bind_mount = NULL;
 
 	g_assert_nonnull(r_context()->install_info);
 	g_assert_nonnull(r_context()->install_info->mounted_bundle);
@@ -602,22 +603,45 @@ static gboolean casync_extract_image(RaucImage *image, gchar *dest, int out_fd, 
 
 	if (g_str_has_suffix(image->filename, ".caidx")) {
 		/* We need to have the seed slot (bind) mounted to a distinct
-		 * path to allow seeding. E.g. using mount path '/' for the
-		 * rootfs slot seed is inaproppriate as it contains virtual
-		 * file systems, additional mounts, etc. */
+		 * path to allow seeding. Using mount path '/' for the rootfs
+		 * slot seed is inappropriate as it contains virtual file systems,
+		 * additional mounts, etc. If the slot is already externally mounted
+		 * (ext_mount_point), we create a ro-bind mount from it.
+		 * This is especially important for UBIFS. */
 		if (!seedslot->mount_point) {
-			g_debug("Mounting %s to use as casync seed", seedslot->device);
-			res = r_mount_slot(seedslot, &ierror);
-			if (!res) {
-				g_warning("Failed mounting for seeding: %s", ierror->message);
-				g_clear_error(&ierror);
-				goto extract;
+			if (seedslot->ext_mount_point) {
+				/* Create a ro-bind mount from the external mount point */
+				g_message("Using ext_mount_point %s for casync seed", seedslot->ext_mount_point);
+				seed_bind_mount = r_create_mount_point(seedslot->name, &ierror);
+				if (!seed_bind_mount) {
+					g_warning("Failed to create mount point for seed: %s", ierror->message);
+					g_clear_error(&ierror);
+					goto extract;
+				}
+				res = r_mount_full(seedslot->ext_mount_point, seed_bind_mount, NULL, "bind,ro", &ierror);
+				if (!res) {
+					g_warning("Failed to create ro-bind mount for seeding: %s", ierror->message);
+					g_clear_error(&ierror);
+					g_rmdir(seed_bind_mount);
+					g_clear_pointer(&seed_bind_mount, g_free);
+					goto extract;
+				}
+				seed_mounted = TRUE;
+			} else {
+				g_debug("Mounting %s to use as casync seed", seedslot->device);
+				res = r_mount_slot(seedslot, &ierror);
+				if (!res) {
+					g_warning("Failed mounting for seeding: %s", ierror->message);
+					g_clear_error(&ierror);
+					goto extract;
+				}
+				seed_mounted = TRUE;
 			}
-			seed_mounted = TRUE;
 		}
 
-		g_debug("Adding as casync directory tree seed: %s", seedslot->mount_point);
-		seed = g_strdup(seedslot->mount_point);
+		g_message("Adding as casync directory tree seed: %s",
+		          seedslot->mount_point ? seedslot->mount_point : seed_bind_mount);
+		seed = g_strdup(seedslot->mount_point ? seedslot->mount_point : seed_bind_mount);
 	} else {
 		GStatBuf seedstat;
 
@@ -655,16 +679,22 @@ extract:
 unmount_out:
 	/* Cleanup seed */
 	if (seed_mounted) {
-		g_message("Unmounting seed slot %s", seedslot->device);
-		ierror = NULL; /* any previous error was propagated already */
-		if (!r_umount_slot(seedslot, &ierror)) {
-			res = FALSE;
-			if (error && *error) {
-				/* the previous error is more relevant here */
-				g_warning("Ignoring umount error after previous error: %s", ierror->message);
-				g_clear_error(&ierror);
-			} else {
-				g_propagate_error(error, ierror);
+		if (seed_bind_mount) {
+			g_debug("Unmounting seed bind mount %s", seed_bind_mount);
+			r_umount(seed_bind_mount, NULL);
+			g_rmdir(seed_bind_mount);
+		} else {
+			g_message("Unmounting seed slot %s", seedslot->device);
+			ierror = NULL; /* any previous error was propagated already */
+			if (!r_umount_slot(seedslot, &ierror)) {
+				res = FALSE;
+				if (error && *error) {
+					/* the previous error is more relevant here */
+					g_warning("Ignoring umount error after previous error: %s", ierror->message);
+					g_clear_error(&ierror);
+				} else {
+					g_propagate_error(error, ierror);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR improves the robustness of RAUC when working with UBIFS and casync, specifically addressing issues with seeding from the active rootfs.

It implements the approach suggested in the discussion of #774 by using ext_mount_point as the source for a read-only bind mount when seeding. This avoids issues with re-mounting already mounted filesystems (like UBIFS) and allows safe seeding from the active slot.

Additionally, it improves slot detection by:

Resolving symlinks when matching devices in r_slot_find_by_device.
Resolving UBI volume names (e.g. ubi0:volname) to their device nodes to correctly detect external mount points.

Replaces  #774
Fixes #772

Disclaimer: I'm neither a C developer nor do I have deep knowledge of rauc. So I only figured out what the problems are, and did the tests. The patches are written by AI and reviewed by myself with my limited knowledge.