### PR TITLE
qemu-test: configure encryption key and cert

### DIFF
--- a/qemu-test-init
+++ b/qemu-test-init
@@ -161,6 +161,8 @@ if [ -n "$SERVICE" ]; then
   mkdir /etc/rauc
   cp qemu-test-rauc-config /etc/rauc/system.conf
   cp test/openssl-ca/dev-ca.pem /etc/rauc/ca.cert.pem
+  cp test/openssl-enc/keys/rsa-4096/private-key-000.pem /etc/rauc/enc-private-key.pem
+  cp test/openssl-enc/keys/rsa-4096/cert-000.pem /etc/rauc/enc-cert.pem
 
   # grub env
   mkdir -p /tmp/boot/grub

--- a/qemu-test-rauc-config
+++ b/qemu-test-rauc-config
@@ -16,6 +16,10 @@ path=ca.cert.pem
 [streaming]
 tls-ca=/etc/rauc/ca.cert.pem
 
+[encryption]
+key=enc-private-key.pem
+cert=enc-cert.pem
+
 [slot.rootfs.0]
 device=/dev/root
 bootname=A


### PR DESCRIPTION
This makes encrypted bundles easier to use with `./qemu-test system`.
