### PR TITLE
src/main: register dummy Ctrl+C handler for non-service installation

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -230,6 +230,13 @@ static gboolean on_sigint(gpointer user_data)
 	return G_SOURCE_REMOVE;
 }
 
+static gboolean on_sigint_noop(gpointer user_data)
+{
+	g_print("\nCtrl+C is not supported.\n");
+
+	return G_SOURCE_CONTINUE;
+}
+
 static gboolean install_start(int argc, char **argv)
 {
 	GBusType bus_type = (!g_strcmp0(g_getenv("DBUS_STARTER_BUS_TYPE"), "session"))
@@ -343,6 +350,8 @@ static gboolean install_start(int argc, char **argv)
 			goto out_loop;
 		}
 	} else {
+		g_unix_signal_add(SIGINT, on_sigint_noop, args);
+
 		if (!determine_slot_states(&error)) {
 			g_printerr("Failed to determine slot states: %s\n", error->message);
 			g_clear_error(&error);


### PR DESCRIPTION
RAUC does not support interrupting the installation since a graceful shutdown at any point in time would result in additional complexity.

However, when compiled without service support, a Ctrl+C on the CLI would actually result in a hard installation abort, leaving resources (mounts, verity devices) uncleaned.

This registers a no-op handler using `g_unix_signal_add()` to ignore `SIGINT` while an installation is running.

Note:

Using `g_unix_signal_add()` has an unexpected side-effect for the `GMainLoop`. The call to `g_unix_signal_add()` will invoke `g_get_worker_context()` which unconditionally creates a new `"gmain"` thread that also serves as a main loop worker thread calling `g_main_context_iteration()` in a `while(TRUE)` loop.

This means that even if the main loop created by `g_main_loop_run()` completes, events from the main loop will be processed until the program terminates.

This is unexpected. But since we use `g_unix_signal_add()` for the service case already and haven't noticed issues there, it should be acceptable compared to the risk of a hard interrupt of an installation.

Replaces: #1841 
