### PR TITLE
Recreate Missing EFI Boot Entries

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -160,6 +160,19 @@ Example configuration:
   on watchdog resets.
   Behavior defaults to ``true`` if the option is not set.
 
+``efi-loader`` (optional)
+  Only valid when ``bootloader`` is set to ``efi``.
+  If set in combination with ``efi-cmdline``, an EFI boot entry for this slot
+  is (re)created with the given loader string via ``efibootmgr``'s ``--loader``
+  option during mark good/bad/active operations, if it is missing.
+
+``efi-cmdline`` (optional)
+  Only valid when ``bootloader`` is set to ``efi``.
+  If set in combination with ``efi-loader``, an EFI boot entry for this slot is
+  (re)created with the given command line string via ``efibootmgr``'s
+  ``--unicode`` option during mark good/bad/active operations, if it is
+  missing.
+
 .. _activate-installed:
 
 ``activate-installed`` (optional)

--- a/include/slot.h
+++ b/include/slot.h
@@ -59,6 +59,8 @@ typedef struct _RaucSlot {
 	guint64 region_size;
 	/** limit the writable size of the boot partition (for boot-emmc) */
 	guint64 size_limit;
+	gchar *efi_loader;
+	gchar *efi_cmdline;
 
 	/** current state of the slot (runtime) */
 	SlotState state;

--- a/src/bootloaders/efi.c
+++ b/src/bootloaders/efi.c
@@ -276,6 +276,9 @@ static gboolean efi_set_temp_primary(RaucSlot *slot, GError **error)
 	GError *ierror = NULL;
 	efi_bootentry *efi_slot_entry = NULL;
 
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
 	if (!efi_bootorder_get(NULL, &entries, NULL, NULL, &ierror)) {
 		g_propagate_error(error, ierror);
 		return FALSE;

--- a/src/bootloaders/efi.c
+++ b/src/bootloaders/efi.c
@@ -23,6 +23,73 @@ static void efi_bootentry_free(efi_bootentry *entry)
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(efi_bootentry, efi_bootentry_free);
 
+static gboolean efi_bootentry_create(RaucSlot *slot, GError **error)
+{
+	g_autoptr(GSubprocess) sub = NULL;
+	g_autofree gchar *realdev = NULL, *realdev_basename = NULL;
+	g_autofree gchar *sysfs_part_path = NULL, *part_num = NULL;
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(slot->bootname, FALSE);
+	g_return_val_if_fail(slot->efi_loader, FALSE);
+	g_return_val_if_fail(slot->efi_cmdline, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	realdev = r_realpath(slot->device);
+	if (realdev == NULL) {
+		g_set_error(
+				error,
+				R_BOOTCHOOSER_ERROR,
+				R_BOOTCHOOSER_ERROR_FAILED,
+				"Can't resolve device %s for EFI boot entry",
+				slot->device);
+		return FALSE;
+	}
+
+	realdev_basename = g_path_get_basename(realdev);
+	/* use /sys/class/block because it contains partition entries */
+	sysfs_part_path = g_build_filename("/sys/class/block", realdev_basename, "partition", NULL);
+	if (!g_file_get_contents(sysfs_part_path, &part_num, NULL, &ierror)) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	/* File contains newline, modify in-place */
+	g_strchomp(part_num);
+
+	sub = r_subprocess_new(
+			G_SUBPROCESS_FLAGS_NONE,
+			&ierror,
+			EFIBOOTMGR_NAME,
+			"--create-only",
+			"--disk", realdev,
+			"--part", part_num,
+			"--label", slot->bootname,
+			"--loader", slot->efi_loader,
+			"--unicode", slot->efi_cmdline,
+			NULL);
+
+	if (!sub) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to start " EFIBOOTMGR_NAME ": ");
+		return FALSE;
+	}
+
+	if (!g_subprocess_wait_check(sub, NULL, &ierror)) {
+		g_propagate_prefixed_error(
+				error,
+				ierror,
+				"Failed to run " EFIBOOTMGR_NAME ": ");
+		return FALSE;
+	}
+
+	g_debug("Created missing EFI boot entry for %s", slot->bootname);
+
+	return TRUE;
+}
+
 static gboolean efi_bootorder_set(gchar *order, GError **error)
 {
 	g_autoptr(GSubprocess) sub = NULL;
@@ -270,6 +337,73 @@ out:
 	return res;
 }
 
+/* Parses output of efibootmgr and returns information obtained, creating
+ * missing EFI boot entry for slot.
+ *
+ * Wrapper around efi_bootorder_get() that creates a missing EFI boot entry for
+ * the provided RAUC slot if efi-loader and efi-cmdline are configured.
+ *
+ * @param slot The RAUC slot to create a EFI boot entry for if it's missing
+ * @param bootorder_entries See efi_bootorder_get()
+ * @param all_entries See efi_bootorder_get()
+ * @param error Return location for a GError
+ */
+static gboolean efi_bootorder_prepare(RaucSlot *slot, GList **bootorder_entries, GList **all_entries, GError **error)
+{
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(bootorder_entries == NULL || *bootorder_entries == NULL, FALSE);
+	g_return_val_if_fail(all_entries != NULL && *all_entries == NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (!efi_bootorder_get(bootorder_entries, all_entries, NULL, NULL, &ierror)) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	/* Lookup efi boot entry matching slot */
+	for (GList *entry = *all_entries; entry != NULL; entry = entry->next) {
+		efi_bootentry *efi = entry->data;
+		if (g_strcmp0(efi->name, slot->bootname) == 0) {
+			/* EFI boot entry exists, no further action needed */
+			g_debug("EFI boot entry for bootname '%s' already exists", slot->bootname);
+			return TRUE;
+		}
+	}
+
+	/* Clear previously retrieved entries */
+	if (*all_entries)
+		g_list_free_full(g_steal_pointer(all_entries), (GDestroyNotify)efi_bootentry_free);
+	if (bootorder_entries && *bootorder_entries)
+		g_list_free(g_steal_pointer(bootorder_entries));
+
+	/* No efi-loader/efi-cmdline given, bail out */
+	if (!slot->efi_loader || !slot->efi_cmdline) {
+		g_set_error(
+				error,
+				R_BOOTCHOOSER_ERROR,
+				R_BOOTCHOOSER_ERROR_FAILED,
+				"Did not find efi entry for bootname '%s'!", slot->bootname);
+		return FALSE;
+	}
+
+
+	/* Create missing EFI entry */
+	if (!efi_bootentry_create(slot, &ierror)) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	/* Retrieve EFI entries one more time */
+	if (!efi_bootorder_get(bootorder_entries, all_entries, NULL, NULL, error)) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
 static gboolean efi_set_temp_primary(RaucSlot *slot, GError **error)
 {
 	g_autolist(efi_bootentry) entries = NULL;
@@ -279,7 +413,7 @@ static gboolean efi_set_temp_primary(RaucSlot *slot, GError **error)
 	g_return_val_if_fail(slot, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (!efi_bootorder_get(NULL, &entries, NULL, NULL, &ierror)) {
+	if (!efi_bootorder_prepare(slot, NULL, &entries, &ierror)) {
 		g_propagate_error(error, ierror);
 		return FALSE;
 	}
@@ -293,14 +427,8 @@ static gboolean efi_set_temp_primary(RaucSlot *slot, GError **error)
 		}
 	}
 
-	if (!efi_slot_entry) {
-		g_set_error(
-				error,
-				R_BOOTCHOOSER_ERROR,
-				R_BOOTCHOOSER_ERROR_FAILED,
-				"Did not find efi entry for bootname '%s'!", slot->bootname);
-		return FALSE;
-	}
+	/* efi_bootorder_prepare() above made sure a proper entry exists */
+	g_assert_nonnull(efi_slot_entry);
 
 	if (!efi_set_bootnext(efi_slot_entry->num, &ierror)) {
 		g_propagate_prefixed_error(error, ierror, "Setting bootnext failed: ");
@@ -324,7 +452,7 @@ static gboolean efi_modify_persistent_bootorder(RaucSlot *slot, gboolean prepend
 	g_return_val_if_fail(slot, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (!efi_bootorder_get(&entries, &all_entries, NULL, NULL, &ierror)) {
+	if (!efi_bootorder_prepare(slot, &entries, &all_entries, &ierror)) {
 		g_propagate_error(error, ierror);
 		return FALSE;
 	}
@@ -348,14 +476,8 @@ static gboolean efi_modify_persistent_bootorder(RaucSlot *slot, gboolean prepend
 			}
 		}
 
-		if (!efi_slot_entry) {
-			g_set_error(
-					error,
-					R_BOOTCHOOSER_ERROR,
-					R_BOOTCHOOSER_ERROR_FAILED,
-					"No entry for bootname '%s' found", slot->bootname);
-			return FALSE;
-		}
+		/* efi_bootorder_prepare() above made sure a proper entry exists */
+		g_assert_nonnull(efi_slot_entry);
 
 		entries = g_list_prepend(entries, efi_slot_entry);
 	}

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1037,6 +1037,11 @@ static GHashTable *parse_slots(const char *filename, RaucConfig *c, GKeyFile *ke
 				}
 			}
 
+			if (g_strcmp0(c->system_bootloader, "efi") == 0) {
+				slot->efi_loader = key_file_consume_string(key_file, groups[i], "efi-loader", NULL);
+				slot->efi_cmdline = key_file_consume_string(key_file, groups[i], "efi-cmdline", NULL);
+			}
+
 			if (!check_remaining_keys(key_file, groups[i], &ierror)) {
 				g_propagate_error(error, ierror);
 				return NULL;

--- a/src/slot.c
+++ b/src/slot.c
@@ -26,6 +26,8 @@ void r_slot_free(gpointer value)
 	g_free(slot->ext_mount_point);
 	g_clear_pointer(&slot->status, r_slot_free_status);
 	g_free(slot->data_directory);
+	g_free(slot->efi_loader);
+	g_free(slot->efi_cmdline);
 	g_free(slot);
 }
 

--- a/test/bin/efibootmgr
+++ b/test/bin/efibootmgr
@@ -52,9 +52,12 @@ def json_mode(args, vars_file):
             sys.exit(1)
 
         # Find next available boot number
-        existing_nums = [int(num, 16) for num in data["boot_entries"].keys()]
-        next_num = max(existing_nums) + 1 if existing_nums else 0
-        boot_num = f"{next_num:04X}"
+        existing_nums = data["boot_entries"].keys()
+        for i in range(len(existing_nums) + 2):
+            candidate = f"{i:04X}"
+            if candidate not in existing_nums:
+                boot_num = candidate
+                break
 
         data["boot_entries"][boot_num] = {"label": args.label}
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -736,3 +736,19 @@ def http_server(env_setup):
     server = HTTPServer()
     yield server
     server.stop()
+
+
+@pytest.fixture
+def blk_dev_partitions():
+    try:
+        blkdev = os.environ["RAUC_TEST_BLOCK_LOOP"]
+    except KeyError:
+        pytest.skip("RAUC_TEST_BLOCK_LOOP undefined")
+
+    partitioning = b"""
+start=2048, size=64492
+start=66540, size=64492
+    """
+    subprocess.run(["sfdisk", "-X", "gpt", blkdev], input=partitioning, check=True)
+
+    return iter((f"{blkdev}p1", f"{blkdev}p2"))

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -282,7 +282,7 @@ def test_status_mark_good_efi(tmp_path, create_system_files, system, efi_mock):
     os.environ["EFIBOOTMGR_VAR_FILE"] = str(efi_vars_file)
 
     with system.running_service("A"):
-        # mark rootfs.0 (system0) good
+        # mark rootfs.0 (A) good
         _, err, exitcode = run("rauc status mark-good rootfs.0")
         assert not err
         assert exitcode == 0
@@ -310,12 +310,12 @@ def test_status_mark_bad_efi(tmp_path, create_system_files, system, efi_mock):
     os.environ["EFIBOOTMGR_VAR_FILE"] = str(efi_vars_file)
 
     with system.running_service("A"):
-        # mark rootfs.1 (system1) bad
+        # mark rootfs.1 (B) bad
         _, err, exitcode = run("rauc status mark-bad rootfs.1")
         assert not err
         assert exitcode == 0
 
-        # Verify system1 (0002) was removed from boot order
+        # Verify system B (0002) was removed from boot order
         result_state = json.loads(efi_vars_file.read_text())
         assert result_state["boot_order"] == ["0001"]
 
@@ -338,11 +338,11 @@ def test_status_mark_active_efi(tmp_path, create_system_files, system, efi_mock)
     os.environ["EFIBOOTMGR_VAR_FILE"] = str(efi_vars_file)
 
     with system.running_service("A"):
-        # mark rootfs.1 (system1) active/primary
+        # mark rootfs.1 (B) active/primary
         _, err, exitcode = run("rauc status mark-active rootfs.1")
         assert not err
         assert exitcode == 0
 
-        # Verify system1 (0002) set as BootNext
+        # Verify system B (0002) set as BootNext
         result_state = json.loads(efi_vars_file.read_text())
         assert result_state["boot_next"] == "0002"

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -251,11 +251,11 @@ bootstate.B.remaining_attempts=3
 
 
 EFI_INITIAL_STATE = {
-    "boot_current": "0001",
+    "boot_current": "0000",
     "timeout": 0,
-    "boot_order": ["0001", "0002"],
+    "boot_order": ["0000", "0001"],
     "boot_next": None,
-    "boot_entries": {"0001": {"label": "A"}, "0002": {"label": "B"}},
+    "boot_entries": {"0000": {"label": "A"}, "0001": {"label": "B"}},
 }
 
 
@@ -289,7 +289,7 @@ def test_status_mark_good_efi(tmp_path, create_system_files, system, efi_mock):
 
         # Verify boot order unchanged (mark-good doesn't modify boot order)
         result_state = json.loads(efi_vars_file.read_text())
-        assert result_state["boot_order"] == ["0001", "0002"]
+        assert result_state["boot_order"] == ["0000", "0001"]
 
 
 @have_qemu
@@ -315,9 +315,9 @@ def test_status_mark_bad_efi(tmp_path, create_system_files, system, efi_mock):
         assert not err
         assert exitcode == 0
 
-        # Verify system B (0002) was removed from boot order
+        # Verify system B (0001) was removed from boot order
         result_state = json.loads(efi_vars_file.read_text())
-        assert result_state["boot_order"] == ["0001"]
+        assert result_state["boot_order"] == ["0000"]
 
 
 @have_qemu
@@ -343,6 +343,6 @@ def test_status_mark_active_efi(tmp_path, create_system_files, system, efi_mock)
         assert not err
         assert exitcode == 0
 
-        # Verify system B (0002) set as BootNext
+        # Verify system B (0001) set as BootNext
         result_state = json.loads(efi_vars_file.read_text())
-        assert result_state["boot_next"] == "0002"
+        assert result_state["boot_next"] == "0001"

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -264,6 +264,14 @@ def efi_mock(monkeypatch):
     monkeypatch.setenv("PATH", os.path.abspath("bin"), prepend=os.pathsep)
 
 
+def create_efi_system_config(system):
+    system.prepare_minimal_config()
+    system.config["system"]["bootloader"] = "efi"
+    del system.config["system"]["grubenv"]
+
+    system.write_config()
+
+
 @have_qemu
 def test_status_mark_good_efi(tmp_path, create_system_files, system, efi_mock):
     """
@@ -271,10 +279,7 @@ def test_status_mark_good_efi(tmp_path, create_system_files, system, efi_mock):
 
     Leverages the mock efibootmgr with JSON storage mode.
     """
-    system.prepare_minimal_config()
-    system.config["system"]["bootloader"] = "efi"
-    del system.config["system"]["grubenv"]
-    system.write_config()
+    create_efi_system_config(system)
 
     # Create JSON file with initial EFI boot state
     efi_vars_file = tmp_path / "efi_vars.json"
@@ -299,10 +304,7 @@ def test_status_mark_bad_efi(tmp_path, create_system_files, system, efi_mock):
 
     Leverages the mock efibootmgr with JSON storage mode.
     """
-    system.prepare_minimal_config()
-    system.config["system"]["bootloader"] = "efi"
-    del system.config["system"]["grubenv"]
-    system.write_config()
+    create_efi_system_config(system)
 
     # Create JSON file with initial EFI boot state
     efi_vars_file = tmp_path / "efi_vars.json"
@@ -327,10 +329,7 @@ def test_status_mark_active_efi(tmp_path, create_system_files, system, efi_mock)
 
     Leverages the mock efibootmgr with JSON storage mode.
     """
-    system.prepare_minimal_config()
-    system.config["system"]["bootloader"] = "efi"
-    del system.config["system"]["grubenv"]
-    system.write_config()
+    create_efi_system_config(system)
 
     # Create JSON file with initial EFI boot state
     efi_vars_file = tmp_path / "efi_vars.json"

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 
@@ -264,26 +265,43 @@ def efi_mock(monkeypatch):
     monkeypatch.setenv("PATH", os.path.abspath("bin"), prepend=os.pathsep)
 
 
-def create_efi_system_config(system):
+def create_efi_system_config(system, blk_dev_partitions, *, configure_efi_entry=False):
     system.prepare_minimal_config()
     system.config["system"]["bootloader"] = "efi"
     del system.config["system"]["grubenv"]
+
+    system.config["slot.rootfs.0"]["device"] = next(blk_dev_partitions)
+    system.config["slot.rootfs.1"]["device"] = next(blk_dev_partitions)
+
+    if configure_efi_entry:
+        system.config["slot.rootfs.0"]["efi-loader"] = r"\\EFI\\BOOT\\BOOTX64.EFI"
+        system.config["slot.rootfs.0"]["efi-cmdline"] = "@1"
+        system.config["slot.rootfs.1"]["efi-loader"] = r"\\EFI\\BOOT\\BOOTX64.EFI"
+        system.config["slot.rootfs.1"]["efi-cmdline"] = "@2"
 
     system.write_config()
 
 
 @have_qemu
-def test_status_mark_good_efi(tmp_path, create_system_files, system, efi_mock):
+@pytest.mark.parametrize("efi_entry_missing", [False, True], ids=["efi_entry_exists", "efi_entry_missing"])
+def test_status_mark_good_efi(tmp_path, create_system_files, system, efi_mock, blk_dev_partitions, efi_entry_missing):
     """
-    Tests that 'mark-good' call for EFI does not alter boot order.
+    Tests that 'mark-good' call for EFI does not alter boot order and a missing matching EFI boot
+    entry (efi-loader/efi-cmdline configured) is recreated.
 
     Leverages the mock efibootmgr with JSON storage mode.
     """
-    create_efi_system_config(system)
+    create_efi_system_config(system, blk_dev_partitions, configure_efi_entry=efi_entry_missing)
 
     # Create JSON file with initial EFI boot state
+    efi_state = copy.deepcopy(EFI_INITIAL_STATE)
+    if efi_entry_missing:
+        # Delete boot entry 0000 for system A
+        del efi_state["boot_entries"]["0000"]
+        efi_state["boot_order"].remove("0000")
+
     efi_vars_file = tmp_path / "efi_vars.json"
-    efi_vars_file.write_text(json.dumps(EFI_INITIAL_STATE))
+    efi_vars_file.write_text(json.dumps(efi_state))
     os.environ["EFIBOOTMGR_VAR_FILE"] = str(efi_vars_file)
 
     with system.running_service("A"):
@@ -292,23 +310,34 @@ def test_status_mark_good_efi(tmp_path, create_system_files, system, efi_mock):
         assert not err
         assert exitcode == 0
 
-        # Verify boot order unchanged (mark-good doesn't modify boot order)
+        # Verify EFI state is unchanged:
+        # efi_entry_missing=False: mark-good doesn't modify boot order,
+        # efi_entry_missing=True: boot entry is created with the same number as before and
+        #                         mark-good puts it back in boot order
         result_state = json.loads(efi_vars_file.read_text())
-        assert result_state["boot_order"] == ["0000", "0001"]
+        assert result_state == EFI_INITIAL_STATE
 
 
 @have_qemu
-def test_status_mark_bad_efi(tmp_path, create_system_files, system, efi_mock):
+@pytest.mark.parametrize("efi_entry_missing", [False, True], ids=["efi_entry_exists", "efi_entry_missing"])
+def test_status_mark_bad_efi(tmp_path, create_system_files, system, efi_mock, blk_dev_partitions, efi_entry_missing):
     """
-    Tests that 'mark-bad' call for EFI removes slot from boot order.
+    Tests that 'mark-bad' call for EFI removes slot from boot order and a missing matching EFI boot
+    entry (efi-loader/efi-cmdline configured) is recreated.
 
     Leverages the mock efibootmgr with JSON storage mode.
     """
-    create_efi_system_config(system)
+    create_efi_system_config(system, blk_dev_partitions, configure_efi_entry=efi_entry_missing)
 
     # Create JSON file with initial EFI boot state
+    efi_state = copy.deepcopy(EFI_INITIAL_STATE)
+    if efi_entry_missing:
+        # Delete boot entry 0001 for system B
+        del efi_state["boot_entries"]["0001"]
+        efi_state["boot_order"].remove("0001")
+
     efi_vars_file = tmp_path / "efi_vars.json"
-    efi_vars_file.write_text(json.dumps(EFI_INITIAL_STATE))
+    efi_vars_file.write_text(json.dumps(efi_state))
     os.environ["EFIBOOTMGR_VAR_FILE"] = str(efi_vars_file)
 
     with system.running_service("A"):
@@ -317,23 +346,36 @@ def test_status_mark_bad_efi(tmp_path, create_system_files, system, efi_mock):
         assert not err
         assert exitcode == 0
 
-        # Verify system B (0001) was removed from boot order
         result_state = json.loads(efi_vars_file.read_text())
+        # Verify system B (0001) was removed from boot order
         assert result_state["boot_order"] == ["0000"]
+        # Everything else should be unchanged
+        assert result_state["boot_entries"] == EFI_INITIAL_STATE["boot_entries"]
+        assert result_state["boot_next"] == EFI_INITIAL_STATE["boot_next"]
 
 
 @have_qemu
-def test_status_mark_active_efi(tmp_path, create_system_files, system, efi_mock):
+@pytest.mark.parametrize("efi_entry_missing", [False, True], ids=["efi_entry_exists", "efi_entry_missing"])
+def test_status_mark_active_efi(
+    tmp_path, create_system_files, system, efi_mock, blk_dev_partitions, efi_entry_missing
+):
     """
-    Tests that 'mark-active' call for EFI moves slot to primary position in boot order.
+    Tests that 'mark-active' call for EFI moves slot to primary position in boot order and a
+    missing matching EFI boot entry (efi-loader/efi-cmdline configured) is recreated.
 
     Leverages the mock efibootmgr with JSON storage mode.
     """
-    create_efi_system_config(system)
+    create_efi_system_config(system, blk_dev_partitions, configure_efi_entry=efi_entry_missing)
 
     # Create JSON file with initial EFI boot state
+    efi_state = copy.deepcopy(EFI_INITIAL_STATE)
+    if efi_entry_missing:
+        # Delete boot entry 0001 for system B
+        del efi_state["boot_entries"]["0001"]
+        efi_state["boot_order"].remove("0001")
+
     efi_vars_file = tmp_path / "efi_vars.json"
-    efi_vars_file.write_text(json.dumps(EFI_INITIAL_STATE))
+    efi_vars_file.write_text(json.dumps(efi_state))
     os.environ["EFIBOOTMGR_VAR_FILE"] = str(efi_vars_file)
 
     with system.running_service("A"):
@@ -342,6 +384,69 @@ def test_status_mark_active_efi(tmp_path, create_system_files, system, efi_mock)
         assert not err
         assert exitcode == 0
 
-        # Verify system B (0001) set as BootNext
         result_state = json.loads(efi_vars_file.read_text())
+        # Verify system B (0001) set as BootNext
         assert result_state["boot_next"] == "0001"
+        # Everything else should be unchanged
+        assert result_state["boot_order"] == EFI_INITIAL_STATE["boot_order"]
+        assert result_state["boot_entries"] == EFI_INITIAL_STATE["boot_entries"]
+
+
+@have_qemu
+def test_status_mark_efi_missing_unconfigured_boot_entry(
+    tmp_path, create_system_files, system, blk_dev_partitions, efi_mock
+):
+    """
+    Tests that mark calls for a slot without corresponding EFI boot entry and without
+    efi-loader/efi-cmdline fail as expected and the EFI boot entries are untouched.
+
+    Leverages the mock efibootmgr with JSON storage mode.
+    """
+    create_efi_system_config(system, blk_dev_partitions, configure_efi_entry=False)
+
+    # create JSON file with initial EFI boot state
+    efi_state = copy.deepcopy(EFI_INITIAL_STATE)
+    # Delete boot entry 0000 for system A
+    del efi_state["boot_entries"]["0000"]
+    efi_state["boot_order"].remove("0000")
+
+    efi_vars_file = tmp_path / "efi_vars.json"
+    efi_vars_file.write_text(json.dumps(efi_state))
+    os.environ["EFIBOOTMGR_VAR_FILE"] = str(efi_vars_file)
+
+    with system.running_service("A"):
+        # mark rootfs.0 (A) good without a corresponding boot entry
+        _, err, exitcode = run("rauc status mark-good rootfs.0")
+        assert (
+            err.strip()
+            == "rauc mark: Failed marking slot rootfs.0 as good:  efi backend: Did not find efi entry for bootname 'A'!"
+        )
+        assert exitcode == 1
+
+        result_state = json.loads(efi_vars_file.read_text())
+        # EFI state should be unchanged
+        assert result_state == efi_state
+
+        # mark rootfs.0 (A) bad without a corresponding boot entry
+        _, err, exitcode = run("rauc status mark-bad rootfs.0")
+        assert (
+            err.strip()
+            == "rauc mark: Failed marking slot rootfs.0 as bad:  efi backend: Did not find efi entry for bootname 'A'!"
+        )
+        assert exitcode == 1
+
+        result_state = json.loads(efi_vars_file.read_text())
+        # EFI state should be unchanged
+        assert result_state == efi_state
+
+        # mark rootfs.0 (A) active without a corresponding boot entry
+        _, err, exitcode = run("rauc status mark-active rootfs.0")
+        assert (
+            err.strip()
+            == "rauc mark: failed to activate slot rootfs.0: efi backend: Did not find efi entry for bootname 'A'!"
+        )
+        assert exitcode == 1
+
+        result_state = json.loads(efi_vars_file.read_text())
+        # EFI state should be unchanged
+        assert result_state == efi_state


### PR DESCRIPTION
Some UEFI implementations tend to remove boot entries if they point to unmountable filesystems (which can happen due to a power cycle while installing).

Allow RAUC to recreate missing EFI entries for slots with a bootname using the new slot options "efi-loader" and "efi-cmdline".

Implement this by wrapping `efi_bootorder_get()` for callers which will actually modify the boot entries. All other callers still use `efi_bootorder_get()` directly, so no unncecessary writes happen.

Add a variant to each of the existing EFI mark tests covering this new behavior. Also add a test for a missing slot without the new slot options during mark good/bad/active operations testing the failure case.
                                                        

---

Tested on x86 hardware whose UEFI implementation is not affected by the bug by dropping the inactive boot entry manually via `efibootmgr --delete-bootnum --bootnum 000x` and `rauc mark-good rootfs.1`.

RAUC system.conf used for testing:

```
[system]
compatible=foo
bootloader=efi
bundle-formats=-plain

[keyring]
path=/etc/rauc/ca.cert.pem

[slot.esp.0]
device=/dev/disk/by-partlabel/ESP-A
bootname=system0
efi-loader=\\EFI\\BOOT\\BOOTX64.EFI
efi-cmdline=@1

[slot.rootfs.0]
device=/dev/disk/by-partlabel/rootfs-A
type=raw
parent=esp.0

[slot.esp.1]
device=/dev/disk/by-partlabel/ESP-B
bootname=system1
efi-loader=\\EFI\\BOOT\\BOOTX64.EFI
efi-cmdline=@2

[slot.rootfs.1]
device=/dev/disk/by-partlabel/rootfs-B
type=raw
parent=esp.1
```

Implements first part of #1701 ("create if entries are found missing while we write bootnext/bootorder", as outlined in https://github.com/rauc/rauc/issues/1701#issuecomment-2812343799).