### PR TITLE
Support bundle-defined global-pre/post-install hooks

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -859,7 +859,7 @@ The hooks section allows to provide a user-defined executable for
   List of hooks enabled for this bundle.
   See :ref:`sec-install-hooks` for more details.
 
-  Valid items are: ``install-check``
+  Valid items are: ``install-check``, ``pre-install``, ``post-install``
 
 .. _sec-manifest-handler:
 
@@ -1050,7 +1050,8 @@ way to add metadata to the manifest which is not interpreted by RAUC in any
 way.
 They are accessible via ``rauc info``, the :ref:`"InspectBundle" D-Bus API
 <gdbus-method-de-pengutronix-rauc-Installer.InspectBundle>`, pre-/post-install
-:ref:`handlers <sec-handler-interface>` and the ``install-check`` hook.
+:ref:`handlers <sec-handler-interface>`, the ``install-check`` hook and the
+``pre-install``/``post-install`` hooks.
 In future releases, they will be accessible in other hooks, as well.
 
 ``<key>`` (optional)
@@ -1930,7 +1931,7 @@ OUT *info* ``a{sv}``:
             The hook filename
 
         *info.hooks.hooks* variant ``as`` <hooks>:
-            An array of enabled hooks (i.e. ``install-check``)
+            An array of enabled hooks (i.e. ``install-check``, ``pre-install`` or ``post-install``)
 
     *info.handler* variant ``a{sv}`` <handler-dict>:
         The bundle's ``[handler]`` section content

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -402,6 +402,47 @@ the hook executable as the rejection reason message and provide it to the user:
 
   exit 0
 
+.. rubric:: Pre-Install Hook
+
+.. code-block:: cfg
+
+  [hooks]
+  filename=hook
+  hooks=pre-install
+
+The pre-install hook will be called right before all slot installations are started.
+This hook is executed after the system-defined pre-install handler and the install-check hook (if defined).
+It allows to perform preparation tasks that should run once before any slot is updated.
+
+.. rubric:: Post-Install Hook
+
+.. code-block:: cfg
+
+  [hooks]
+  filename=hook
+  hooks=post-install
+
+The post-install hook will be called right after all slot installations have finished successfully.
+This hook is executed before the system-defined post-install handler.
+It allows to perform cleanup or finalization tasks that should run once after all slots are updated,
+for example to notify external services or to perform cross-slot validation.
+
+.. code-block:: sh
+
+  #!/bin/sh
+
+  case "$1" in
+          post-install)
+                  # Log update completion
+                  echo "$(date -Iseconds) Updated to ${RAUC_MF_VERSION}" >> /data/update.log
+                  ;;
+          *)
+                  exit 1
+                  ;;
+  esac
+
+  exit 0
+
 .. _sec-slot-hooks:
 
 Slot Hooks

--- a/include/manifest.h
+++ b/include/manifest.h
@@ -17,6 +17,8 @@ GQuark r_manifest_error_quark(void);
 
 typedef struct {
 	gboolean install_check;
+	gboolean pre_install;
+	gboolean post_install;
 } InstallHooks;
 
 typedef struct {

--- a/src/install.c
+++ b/src/install.c
@@ -1652,6 +1652,18 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 		goto umount;
 	}
 
+	if (bundle->manifest->hooks.pre_install) {
+		run_bundle_hook(bundle->manifest, bundle->mount_point, "pre-install", &ierror);
+		if (ierror) {
+			res = FALSE;
+			g_propagate_prefixed_error(
+					error,
+					ierror,
+					"Pre-install hook failed: ");
+			goto umount;
+		}
+	}
+
 	if (bundle->manifest->handler_name) {
 		g_message("Using custom handler: %s", bundle->manifest->handler_name);
 		res = launch_and_wait_custom_handler(args, bundle->mount_point, bundle->manifest, target_group, handler_env, &ierror);
@@ -1663,6 +1675,18 @@ gboolean do_install_bundle(RaucInstallArgs *args, GError **error)
 	if (!res) {
 		g_propagate_prefixed_error(error, ierror, "Installation error: ");
 		goto umount;
+	}
+
+	if (bundle->manifest->hooks.post_install) {
+		run_bundle_hook(bundle->manifest, bundle->mount_point, "post-install", &ierror);
+		if (ierror) {
+			res = FALSE;
+			g_propagate_prefixed_error(
+					error,
+					ierror,
+					"Post-install hook failed: ");
+			goto umount;
+		}
 	}
 
 	if (r_context()->config->postinstall_handler) {

--- a/src/main.c
+++ b/src/main.c
@@ -961,6 +961,12 @@ static gchar *info_formatter_shell(RaucManifest *manifest)
 	if (manifest->hooks.install_check == TRUE) {
 		g_ptr_array_add(hooks, (gchar*) "install-check");
 	}
+	if (manifest->hooks.pre_install == TRUE) {
+		g_ptr_array_add(hooks, (gchar*) "pre-install");
+	}
+	if (manifest->hooks.post_install == TRUE) {
+		g_ptr_array_add(hooks, (gchar*) "post-install");
+	}
 	g_ptr_array_add(hooks, NULL);
 
 	temp_string = g_strjoinv(" ", (gchar**) hooks->pdata);
@@ -1043,6 +1049,12 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 	hooks = g_ptr_array_new();
 	if (manifest->hooks.install_check == TRUE) {
 		g_ptr_array_add(hooks, (gchar*) "install-check");
+	}
+	if (manifest->hooks.pre_install == TRUE) {
+		g_ptr_array_add(hooks, (gchar*) "pre-install");
+	}
+	if (manifest->hooks.post_install == TRUE) {
+		g_ptr_array_add(hooks, (gchar*) "post-install");
 	}
 	g_ptr_array_add(hooks, NULL);
 
@@ -1215,6 +1227,12 @@ static gchar* info_formatter_json_base(RaucManifest *manifest, gboolean pretty)
 	json_builder_begin_array(builder);
 	if (manifest->hooks.install_check == TRUE) {
 		json_builder_add_string_value(builder, "install-check");
+	}
+	if (manifest->hooks.pre_install == TRUE) {
+		json_builder_add_string_value(builder, "pre-install");
+	}
+	if (manifest->hooks.post_install == TRUE) {
+		json_builder_add_string_value(builder, "post-install");
 	}
 	json_builder_end_array(builder);
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -374,6 +374,10 @@ static gboolean parse_manifest(GKeyFile *key_file, RaucManifest **manifest, GErr
 	for (gsize j = 0; j < hook_entries; j++) {
 		if (g_strcmp0(bundle_hooks[j], "install-check") == 0) {
 			raucm->hooks.install_check = TRUE;
+		} else if (g_strcmp0(bundle_hooks[j], "pre-install") == 0) {
+			raucm->hooks.pre_install = TRUE;
+		} else if (g_strcmp0(bundle_hooks[j], "post-install") == 0) {
+			raucm->hooks.post_install = TRUE;
 		} else {
 			g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
 					"install hook type '%s' not supported", bundle_hooks[j]);
@@ -542,7 +546,7 @@ static gboolean check_manifest_common(const RaucManifest *mf, GError **error)
 
 	/* Check for hook file set if hooks are enabled */
 
-	if (mf->hooks.install_check == TRUE)
+	if ((mf->hooks.install_check == TRUE) || (mf->hooks.pre_install == TRUE) || (mf->hooks.post_install == TRUE))
 		have_hooks = TRUE;
 
 	for (GList *l = mf->images; l != NULL; l = l->next) {
@@ -953,6 +957,12 @@ static GKeyFile *prepare_manifest(const RaucManifest *mf)
 	if (mf->hooks.install_check == TRUE) {
 		g_ptr_array_add(hooks, g_strdup("install-check"));
 	}
+	if (mf->hooks.pre_install == TRUE) {
+		g_ptr_array_add(hooks, g_strdup("pre-install"));
+	}
+	if (mf->hooks.post_install == TRUE) {
+		g_ptr_array_add(hooks, g_strdup("post-install"));
+	}
 	g_ptr_array_add(hooks, NULL);
 	if (hooks->pdata && *hooks->pdata) {
 		g_key_file_set_string_list(key_file, "hooks", "hooks",
@@ -1126,6 +1136,10 @@ GVariant* r_manifest_to_dict(const RaucManifest *manifest)
 		g_variant_builder_init(&builder, G_VARIANT_TYPE("as"));
 		if (manifest->hooks.install_check)
 			g_variant_builder_add(&builder, "s", "install-check");
+		if (manifest->hooks.pre_install)
+			g_variant_builder_add(&builder, "s", "pre-install");
+		if (manifest->hooks.post_install)
+			g_variant_builder_add(&builder, "s", "post-install");
 		g_variant_dict_insert(&grp_dict, "hooks", "v", g_variant_builder_end(&builder));
 		g_variant_dict_insert(&root_dict, "hooks", "v", g_variant_dict_end(&grp_dict));
 	}

--- a/test/install-content/hook.sh
+++ b/test/install-content/hook.sh
@@ -17,6 +17,15 @@ case "$1" in
 		echo "No, I won't install this!" 1>&2
 		exit 10
 		;;
+	post-install)
+		test -n "$RAUC_MF_COMPATIBLE" || die_error "missing RAUC_MF_COMPATIBLE"
+		test -n "$RAUC_SYSTEM_COMPATIBLE" || die_error "missing RAUC_SYSTEM_COMPATIBLE"
+
+		test -d "$RAUC_MOUNT_PREFIX" || die_error "missing RAUC_MOUNT_PREFIX"
+
+		echo "$RAUC_MOUNT_PREFIX/post-install-stamp"
+		touch "$RAUC_MOUNT_PREFIX/post-install-stamp"
+		;;
 	slot-post-install)
 		test -n "$RAUC_SLOT_NAME" || die_error "missing RAUC_SLOT_NAME"
 		test -n "$RAUC_SLOT_CLASS" || die_error "missing RAUC_SLOT_CLASS"

--- a/test/install.c
+++ b/test/install.c
@@ -110,6 +110,30 @@ filename=appfs.ext4";
 	fixture_helper_set_up_bundle(fixture->tmpdir, manifest_file, &data->manifest_test_options);
 }
 
+static void install_fixture_set_up_bundle_global_post_install_hook(InstallFixture *fixture,
+		gconstpointer user_data)
+{
+	InstallData *data = (InstallData*) user_data;
+	const gchar *manifest_file = "\
+[update]\n\
+compatible=Test Config\n\
+\n\
+[hooks]\n\
+filename=hook.sh\n\
+hooks=post-install\n\
+\n\
+[image.rootfs]\n\
+filename=rootfs.ext4\n\
+\n\
+[image.appfs]\n\
+filename=appfs.ext4";
+
+	fixture->tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+
+	fixture_helper_set_up_system(fixture->tmpdir, NULL, NULL);
+	fixture_helper_set_up_bundle(fixture->tmpdir, manifest_file, &data->manifest_test_options);
+}
+
 /* Note: Also ensures having no image in a slot with an 'install' per-slot hook
  * is valid. */
 static void install_fixture_set_up_bundle_install_hook(InstallFixture *fixture,
@@ -1225,6 +1249,43 @@ static void install_test_bundle_hook_install_check(InstallFixture *fixture,
 	args->cleanup(args);
 }
 
+static void install_test_bundle_hook_global_post_install(InstallFixture *fixture,
+		gconstpointer user_data)
+{
+	g_autofree gchar *bundlepath = NULL;
+	g_autofree gchar *mountdir = NULL;
+	g_autofree gchar *stamppath = NULL;
+	RaucInstallArgs *args;
+	g_autoptr(GError) ierror = NULL;
+
+	/* needs to run as root */
+	if (!test_running_as_root())
+		return;
+
+	/* Set mount path to current temp dir */
+	mountdir = g_build_filename(fixture->tmpdir, "mount", NULL);
+	g_assert_nonnull(mountdir);
+	replace_strdup(&r_context_conf()->mountprefix, mountdir);
+	r_context();
+
+	bundlepath = g_build_filename(fixture->tmpdir, "bundle.raucb", NULL);
+	g_assert_nonnull(bundlepath);
+
+	g_assert_true(determine_slot_states(NULL));
+
+	args = install_args_new();
+	args->name = g_steal_pointer(&bundlepath);
+	args->notify = install_notify;
+	args->cleanup = install_cleanup;
+	g_assert_true(do_install_bundle(args, &ierror));
+
+	stamppath = g_build_filename(mountdir, "post-install-stamp", NULL);
+	g_assert(g_file_test(stamppath, G_FILE_TEST_IS_REGULAR));
+
+	args->status_result = 0;
+	args->cleanup(args);
+}
+
 static void install_test_bundle_hook_install(InstallFixture *fixture,
 		gconstpointer user_data)
 {
@@ -1574,6 +1635,19 @@ int main(int argc, char *argv[])
 		g_test_add(dup_test_printf(ptrs, "/install/bundle-hook/install-check/%s", format_name),
 				InstallFixture, install_data,
 				install_fixture_set_up_bundle_install_check_hook, install_test_bundle_hook_install_check,
+				install_fixture_tear_down);
+
+		install_data = dup_test_data(ptrs, (&(InstallData) {
+			.message_needles = NULL,
+			.manifest_test_options = {
+				.custom_handler = FALSE,
+				.hooks = TRUE,
+				.slots = TRUE,
+			},
+		}));
+		g_test_add(dup_test_printf(ptrs, "/install/bundle-hook/post-install/%s", format_name),
+				InstallFixture, install_data,
+				install_fixture_set_up_bundle_global_post_install_hook, install_test_bundle_hook_global_post_install,
 				install_fixture_tear_down);
 
 		install_data = dup_test_data(ptrs, (&(InstallData) {

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -137,6 +137,8 @@ static void check_manifest_contents(const RaucManifest *rm)
 	g_assert_true(r_manifest_has_artifact_image(rm, "appfs", "app-a"));
 
 	g_assert_true(rm->hooks.install_check);
+	g_assert_true(rm->hooks.pre_install);
+	g_assert_true(rm->hooks.post_install);
 
 	g_assert_cmpuint(g_hash_table_size(rm->meta), ==, 2);
 
@@ -172,6 +174,8 @@ static void test_save_load_manifest(void)
 	rm->handler_args = g_strdup("--foo");
 	rm->hook_name = g_strdup("hook.sh");
 	rm->hooks.install_check = TRUE;
+	rm->hooks.pre_install = TRUE;
+	rm->hooks.post_install = TRUE;
 
 	new_image = r_new_image();
 	new_image->slotclass = g_strdup("rootfs");

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -290,6 +290,12 @@ def test_install_hook_env(rauc_dbus_service_with_system, tmp_path, bundle):
         install-check)
             env | sort > "$RAUC_PYTEST_TMP/install-check-hook-env"
             ;;
+        pre-install)
+            env | sort > "$RAUC_PYTEST_TMP/pre-install-hook-env"
+            ;;
+        post-install)
+            env | sort > "$RAUC_PYTEST_TMP/post-install-hook-env"
+            ;;
         slot-pre-install)
             env | sort > "$RAUC_PYTEST_TMP/slot-pre-install-hook-env"
             ;;
@@ -305,7 +311,7 @@ def test_install_hook_env(rauc_dbus_service_with_system, tmp_path, bundle):
     esac
     """)
     )
-    bundle.manifest["hooks"]["hooks"] = "install-check"
+    bundle.manifest["hooks"]["hooks"] = "install-check;pre-install;post-install"
     bundle.manifest["image.rootfs"] = {
         "filename": "rootfs.img",
         "hooks": "pre-install;post-install",
@@ -332,6 +338,14 @@ def test_install_hook_env(rauc_dbus_service_with_system, tmp_path, bundle):
         assert "RAUC_SYSTEM_COMPATIBLE=Test Config\n" in check_lines
         assert "RAUC_SYSTEM_VARIANT=Default Variant\n" in check_lines
         assert "RAUC_META_TEST_FOO=bar\n" in check_lines
+
+    with open(tmp_path / "pre-install-hook-env") as f:
+        global_pre_lines = f.readlines()
+        assert check_lines == global_pre_lines
+
+    with open(tmp_path / "post-install-hook-env") as f:
+        global_post_lines = f.readlines()
+        assert check_lines == global_post_lines
 
     with open(tmp_path / "slot-pre-install-hook-env") as f:
         pre_lines = f.readlines()


### PR DESCRIPTION
This PR replaces #1820 with an Install-Hook based implementation.

## Overview

This PR implements support for global-pre/post-install hooks in the bundle's manifest file.
This enables hooks to be defined per bundle, so the old system no longer needs to predefine future actions in its handlers.

The need for this functionality was previously discussed in #275 and #342, but was not implemented until now.

## Example

In the manifest file:
```cfg
[hooks]
filename=hook.sh
hooks=global-pre-install;global-post-install
```

In `hook.sh`:
```sh
#!/bin/sh

case "$1" in
        global-pre-install)
                # Log update start
                echo "$(date -Iseconds) Starting update to ${RAUC_MF_VERSION}" >> /data/update.log
                ;;
        global-post-install)
                # Log update completion
                echo "$(date -Iseconds) Updated to ${RAUC_MF_VERSION}" >> /data/update.log
                # Schedule reboot to apply update
                shutdown -r +1 "Rebooting to complete RAUC update" &
                ;;
        *)
                exit 1
                ;;
esac

exit 0
```

Hooks and handlers are executed in the following order:

1. System-defined pre-install handler (defined in system.conf)
2. Bundle-defined global-pre-install hook (defined in the manifest file)
3. Installation process for each slot
4. Bundle-defined global-post-install hook
5. System-defined post-install handler

## Tests

Both pytest and glib tests passed successfully.
I added tests for global-pre/post-install hooks:

- Hook execution test in install-test (`test/install.c` and `test/install-content/hook.sh`)
- Manifest save/load test with new hook flags in manifest-test (`test_save_load_manifest()` in `test/manifest.c`)
- Environment variable verification test in pytest-install (`test_install_hook_env()` in `test/test_install.py`)

## Changes from #1820

- Changed from handler implementation to Install Hooks implementation
- No manifest file format changes required, as the existing [hooks] section is used
- No need to recreate `good-adaptive-meta-bundle.raucb` for testing, as `test_install_hook_env` creates bundles at runtime
- The install-check hook replaces the compatible check, so it cannot serve as a simple global-pre-install hook. Therefore, I implemented both global-pre-install and global-post-install hooks.