### PR TITLE
src/main: set GLib program name for syslog identifier

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3055,6 +3055,8 @@ int main(int argc, char **argv)
 {
 	GLogLevelFlags fatal_mask;
 
+	g_set_prgname("rauc");
+
 #if GLIB_CHECK_VERSION(2, 68, 0)
 	/* To use this function, without bumping the maximum GLib allowed version,
 	 * we temporarily disable the deprecation warnings */


### PR DESCRIPTION
Set the GLib program name early in main() so that log messages sent to the journal have the SYSLOG_IDENTIFIER field set to "rauc". This works with GLib's structured logging, which uses g_get_prgname() to set SYSLOG_IDENTIFIER when logging to the journal (implemented in GLib 2.85.0 and newer).

See: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4589

Fixes #1860