### PR TITLE
src/main: show image type unconditionally

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1103,13 +1103,15 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 		if (img->artifact)
 			g_string_append_printf(text, "    Artifact:  %s\n", img->artifact);
 		if (img->filename) {
-			g_autofree gchar* formatted_size = g_format_size_full(img->checksum.size, G_FORMAT_SIZE_LONG_FORMAT);
 			g_string_append_printf(text, "    Filename:  %s\n", img->filename);
-			g_string_append_printf(text, "    Type:      %s%s\n", img->type, img->type_from_fileext ? " (detected)" : "");
-			g_string_append_printf(text, "    Checksum:  %s\n", img->checksum.digest);
-			g_string_append_printf(text, "    Size:      %s\n", formatted_size);
 		} else {
 			g_string_append_printf(text, "    (no image file)\n");
+		}
+		g_string_append_printf(text, "    Type:      %s%s\n", img->type, img->type_from_fileext ? " (detected)" : "");
+		if (img->filename) {
+			g_autofree gchar* formatted_size = g_format_size_full(img->checksum.size, G_FORMAT_SIZE_LONG_FORMAT);
+			g_string_append_printf(text, "    Checksum:  %s\n", img->checksum.digest);
+			g_string_append_printf(text, "    Size:      %s\n", formatted_size);
 		}
 
 		hooks = g_ptr_array_new();


### PR DESCRIPTION
There should always be a type, not only if there is an image. An example is the 'emptyfs' image type.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
