### PR TITLE
src: store boot_state in enum to allow 'unknown' state.

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -2196,6 +2196,7 @@ OUT *slot_status_array* ``a(sa{sv})``:
 
         * ``good``: Slot is bootable by the bootloader.
         * ``bad``: Slot will not be selected by the bootloader (unbootable).
+        * ``unknown``: Slot's boot status could not be determined.
 
         Only present for bootable slots.
 

--- a/include/slot.h
+++ b/include/slot.h
@@ -11,6 +11,12 @@ typedef enum {
 	ST_BOOTED = 4 | ST_ACTIVE,
 } SlotState;
 
+typedef enum {
+	ST_BOOT_UNKNOWN = 0,
+	ST_BOOT_BAD = 1,
+	ST_BOOT_GOOD = 2,
+} SlotBootState;
+
 typedef struct {
 	gchar *bundle_compatible;
 	gchar *bundle_version;
@@ -64,7 +70,7 @@ typedef struct _RaucSlot {
 
 	/** current state of the slot (runtime) */
 	SlotState state;
-	gboolean boot_good;
+	SlotBootState boot_state;
 	struct _RaucSlot *parent;
 	/** the name of the parent as parsed by config (parsing-internal use only) */
 	gchar *parent_name;
@@ -117,6 +123,16 @@ G_GNUC_WARN_UNUSED_RESULT;
  * @return a RaucSlot pointer or NULL
  */
 RaucSlot *r_slot_get_booted(GHashTable *slots);
+
+/**
+ * Get string representation of boot state
+ *
+ * @param bootstate boot state to turn into string
+ *
+ * @return string representation of boot state
+ */
+const gchar* r_slot_bootstate_to_str(SlotBootState bootstate)
+G_GNUC_WARN_UNUSED_RESULT;
 
 /**
  * Get string representation of slot state

--- a/src/install.c
+++ b/src/install.c
@@ -259,14 +259,18 @@ gboolean determine_boot_states(GError **error)
 	/* get boot state */
 	g_hash_table_iter_init(&iter, r_context()->config->slots);
 	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
+		gboolean boot_good;
 		g_autoptr(GError) ierror = NULL;
 
 		if (!slot->bootname)
 			continue;
 
-		if (!r_boot_get_state(slot, &slot->boot_good, &ierror)) {
+		if (!r_boot_get_state(slot, &boot_good, &ierror)) {
 			g_message("Failed to get boot state of '%s': %s", slot->name, ierror->message);
 			had_errors = TRUE;
+			slot->boot_state = ST_BOOT_UNKNOWN;
+		} else {
+			slot->boot_state = boot_good ? ST_BOOT_GOOD : ST_BOOT_BAD;
 		}
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -1479,7 +1479,7 @@ static void r_string_append_slot(GString *text, RaucSlot *slot, RaucStatusPrint 
 	if (slot->mount_point)
 		g_string_append_printf(text, "\n      mounted: %s", slot->mount_point);
 	if (slot->bootname)
-		g_string_append_printf(text, "\n      boot status: %s", slot->boot_good ? KGRN "good"KNRM : KRED "bad"KNRM);
+		g_string_append_printf(text, "\n      boot status: %s%s%s", (slot->boot_state == ST_BOOT_GOOD) ? KGRN : KRED, r_slot_bootstate_to_str(slot->boot_state), KNRM);
 	if (status_detailed && slot_state) {
 		g_string_append_printf(text, "\n      slot status:");
 		g_string_append_printf(text, "\n          bundle:");
@@ -1701,7 +1701,7 @@ static gchar* r_status_formatter_shell(RaucStatusPrint *status)
 		r_ptr_array_add_printf(entries, "RAUC_SLOT_PARENT_%d=%s", slotcnt, slot->parent ? slot->parent->name : "");
 		r_ptr_array_add_printf(entries, "RAUC_SLOT_MOUNTPOINT_%d=%s", slotcnt, slot->mount_point ?: "");
 		if (slot->bootname)
-			r_ptr_array_add_printf(entries, "RAUC_SLOT_BOOT_STATUS_%d=%s", slotcnt, slot->boot_good ? "good" : "bad");
+			r_ptr_array_add_printf(entries, "RAUC_SLOT_BOOT_STATUS_%d=%s", slotcnt, r_slot_bootstate_to_str(slot->boot_state));
 		else
 			r_ptr_array_add_printf(entries, "RAUC_SLOT_BOOT_STATUS_%d=", slotcnt);
 		if (status_detailed && slot_state) {
@@ -1853,7 +1853,7 @@ static gchar* r_status_formatter_json(RaucStatusPrint *status, gboolean pretty)
 		json_builder_add_string_value(builder, slot->mount_point);
 		json_builder_set_member_name(builder, "boot_status");
 		if (slot->bootname)
-			json_builder_add_string_value(builder, slot->boot_good ? "good" : "bad");
+			json_builder_add_string_value(builder, r_slot_bootstate_to_str(slot->boot_state));
 		else
 			json_builder_add_string_value(builder, NULL);
 		if (status_detailed && slot_state) {
@@ -2059,9 +2059,11 @@ static gboolean retrieve_slot_states_via_dbus(GHashTable **slots, GError **error
 		g_variant_dict_lookup(&dict, "mountpoint", "s", &slot->mount_point);
 		g_variant_dict_lookup(&dict, "boot-status", "s", &boot_good);
 		if (g_strcmp0(boot_good, "good") == 0) {
-			slot->boot_good = TRUE;
+			slot->boot_state = ST_BOOT_GOOD;
+		} else if (g_strcmp0(boot_good, "bad") == 0) {
+			slot->boot_state = ST_BOOT_BAD;
 		} else {
-			slot->boot_good = FALSE;
+			slot->boot_state = ST_BOOT_UNKNOWN;
 		}
 
 		if (status_detailed) {

--- a/src/service.c
+++ b/src/service.c
@@ -325,7 +325,7 @@ static GVariant* convert_slot_status_to_dict(RaucSlot *slot)
 	if (slot->mount_point || slot->ext_mount_point)
 		g_variant_dict_insert(&dict, "mountpoint", "s", slot->mount_point ? slot->mount_point : slot->ext_mount_point);
 	if (slot->bootname)
-		g_variant_dict_insert(&dict, "boot-status", "s", slot->boot_good ? "good" : "bad");
+		g_variant_dict_insert(&dict, "boot-status", "s", r_slot_bootstate_to_str(slot->boot_state));
 
 	if (slot_state->bundle_compatible)
 		g_variant_dict_insert(&dict, "bundle.compatible", "s", slot_state->bundle_compatible);

--- a/src/slot.c
+++ b/src/slot.c
@@ -94,6 +94,24 @@ RaucSlot *r_slot_get_booted(GHashTable *slots)
 }
 
 /* returns string representation of slot state */
+const gchar* r_slot_bootstate_to_str(SlotBootState bootstate)
+{
+	switch (bootstate) {
+		case ST_BOOT_UNKNOWN:
+			return "unknown";
+		case ST_BOOT_GOOD:
+			return "good";
+		case ST_BOOT_BAD:
+			return "bad";
+		default:
+			g_error("invalid boot status %d", bootstate);
+			return NULL;
+	}
+
+	g_assert_not_reached();
+}
+
+/* returns string representation of slot state */
 const gchar* r_slot_slotstate_to_str(SlotState slotstate)
 {
 	switch (slotstate) {


### PR DESCRIPTION
With the currently used boolean, RAUC has now way to differentiate between a failure during boot state determination and the boot state 'bad'.

Fixes: #1751

Reported-by: Marcus Hoffmann <marcus.hoffmann@othermo.de>

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
