### PR TITLE
src/event_log: add SYSLOG_IDENTIFIER to structured log messages

### DIFF
--- a/src/event_log.c
+++ b/src/event_log.c
@@ -362,8 +362,11 @@ GLogWriterOutput r_event_log_writer(GLogLevelFlags log_level, const GLogField *f
 	const gchar *log_domain = NULL;
 	const gchar *event_type = NULL;
 
-	/* Always log to default location, too */
-	g_log_writer_default(log_level, fields, n_fields, user_data);
+	/* Add SYSLOG_IDENTIFIER and pass also to default writer */
+	GLogField extended_fields[n_fields + 1];
+	memcpy(extended_fields, fields, sizeof(GLogField) * n_fields);
+	extended_fields[n_fields] = (GLogField){"SYSLOG_IDENTIFIER", g_get_prgname() ?: "rauc", -1};
+	g_log_writer_default(log_level, extended_fields, n_fields + 1, user_data);
 
 	/* get log domain */
 	for (gsize i = 0; i < n_fields; i++) {


### PR DESCRIPTION
GLib's g_log_structured() doesn't automatically include SYSLOG_IDENTIFIER, unlike the convenience functions (g_message, etc.) which go through g_log_structured_standard(). This causes messages logged via g_log_structured() to be missing from `journalctl -t rauc` output.

Add SYSLOG_IDENTIFIER to all log messages by extending the fields array in r_event_log_writer() before passing to g_log_writer_default(). Use g_get_prgname() with a fallback to "rauc" for cases where the program name hasn't been set yet.

Fixes #1860