### PR TITLE
doc: use semantic line breaks

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -710,7 +710,8 @@ To let your system access the separate storage location, it has to be mounted
 into your rootfs.
 Note that if you intend to store configurable system information on your data
 partition, you have to map the default Linux paths (such as ``/etc/passwd``) to
-your data storage. You can do this by using:
+your data storage.
+You can do this by using:
 
  * symbolic links
  * bind mounts
@@ -1063,9 +1064,9 @@ RAUC calls this feature 'image variants'.
   :width: 300
 
 If you want to make use of image variants, you first of all need to say which
-variant your specific board is. You can do this in your ``system.conf`` by
-setting exactly one of the keys ``variant-dtb``, ``variant-file`` or
-``variant-name``.
+variant your specific board is.
+You can do this in your ``system.conf`` by setting exactly one of the keys
+``variant-dtb``, ``variant-file`` or ``variant-name``.
 
 .. code-block:: cfg
 
@@ -1140,8 +1141,9 @@ slot status etc. use:
 
   # rauc write-slot <slotname> <image>
 
-This uses the correct handler to write the image to the slot. It is useful for
-development scenarios as well as initial provisioning of embedded boards.
+This uses the correct handler to write the image to the slot.
+It is useful for development scenarios as well as initial provisioning of
+embedded boards.
 
 .. _sec-advanced-updating-bootloader:
 
@@ -1440,8 +1442,10 @@ rather use an approach like this:
   can be reduced by limiting which old versions are supported by an update.
 * Reboot into the new system.
 * On boot, before starting the application, check that the current slot
-  is 'sane'. Then check if the installed bootloader is older than the
-  version shipped in the (new) rootfs. In that case:
+  is 'sane'.
+  Then check if the installed bootloader is older than the version shipped in
+  the (new) rootfs.
+  In that case:
 
   * Disable the old rootfs slot and update the bootloader.
   * Reboot
@@ -1656,9 +1660,9 @@ Even if RAUC mainly focuses on logging information to stdout or into the
 journal (when using systemd), this might be insufficient for some purposes and
 especially for keeping long-term history of what RAUC changed on the system.
 
-A common problem for example can be journal rotation. Since storage is limited
-and the journal contains a lot of other information, it needs to be rotated at
-some point.
+A common problem for example can be journal rotation.
+Since storage is limited and the journal contains a lot of other information,
+it needs to be rotated at some point.
 However, one might want to preserve the history of what RAUC installed on the
 system or when the system rebooted, went into fallback, etc. for very long or
 even the full life time of the device.

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -168,8 +168,9 @@ Now, multiple slots of different classes can be grouped as a *slot group*.
 Such a group is the base for the slot selection algorithm of RAUC.
 
 Consider, for example, a system with two redundant rootfs slots and two
-redundant application slots. Then you group them together to have a fixed set
-of a rootfs and application slot each that will be used together.
+redundant application slots.
+Then you group them together to have a fixed set of a rootfs and application
+slot each that will be used together.
 
 .. image:: images/rauc-multi-image.svg
    :width: 500

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -94,8 +94,8 @@ Test Framework <https://developer.gnome.org/glib/stable/glib-Testing.html>`_.
 All tests reside in the ``test/`` folder and are named according to the module
 they test (``test/bundle.c`` contains tests for ``src/bundle.c``).
 
-The tests are built by default. To explicitly switch them on or off in meson,
-use ``-Dtest=`` option::
+The tests are built by default.
+To explicitly switch them on or off in meson, use ``-Dtest=`` option::
 
   meson setup -Dtests=true build
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,14 +7,15 @@ Full System Example
 This chapter aims to explain the basic concepts needed for RAUC using a simple
 but realistic scenario.
 
-The system is x86-based with 1GiB of disk space and 1GiB of RAM. GRUB_ was
-selected as the bootloader and we want to have two symmetric installations.
+The system is x86-based with 1GiB of disk space and 1GiB of RAM.
+GRUB_ was selected as the bootloader and we want to have two symmetric
+installations.
 Each installation consists of an ext4 root file system only (which contains the
 matching kernel image).
 
-We want to provide update bundles using a USB memory stick. We don't have a
-hardware watchdog, so we need to explicitly tell GRUB_ whether a boot was
-successful.
+We want to provide update bundles using a USB memory stick.
+We don't have a hardware watchdog, so we need to explicitly tell GRUB_ whether
+a boot was successful.
 
 This scenario can be easily reproduced using a QEMU_ virtual machine.
 
@@ -30,8 +31,9 @@ To create a simple key pair for testing, we can use ``openssl``::
   > openssl req -x509 -newkey rsa:4096 -nodes -keyout demo.key.pem -out demo.cert.pem -subj "/O=rauc Inc./CN=rauc-demo"
 
 For actual usage, setting up a real PKI (with a CA separate from the signing
-keys and a revocation infrastructure) is *strongly* recommended. OpenVPN's
-easy-rsa_ is a good first step. See :ref:`sec-security` for more details.
+keys and a revocation infrastructure) is *strongly* recommended.
+OpenVPN's easy-rsa_ is a good first step.
+See :ref:`sec-security` for more details.
 
 .. _easy-rsa: https://github.com/OpenVPN/easy-rsa
 
@@ -68,12 +70,14 @@ directory as the ``system.conf``, so that it is used by RAUC for verification.
 GRUB Configuration
 ~~~~~~~~~~~~~~~~~~
 
-GRUB itself is stored on ``/dev/sda1``, separate from the root file system. To
-access GRUB's environment file, this partition should be mounted to ``/boot``
+GRUB itself is stored on ``/dev/sda1``, separate from the root file system.
+To access GRUB's environment file, this partition should be mounted to
+``/boot``
 (which means that the environment file is found at ``/boot/grub/grubenv``).
 
 GRUB does not provide the boot target selection logic as needed by RAUC
-out of the box. Instead we use a script to implement it
+out of the box.
+Instead we use a script to implement it
 
 .. code-block:: sh
 
@@ -137,7 +141,8 @@ GRUB since 2.02-beta1 supports the ``eval`` command, which can be used
 to express the logic above more concisely.
 
 The ``grubenv`` file can be modified using ``grub-editenv``, which is shipped
-by GRUB. It can also be used to inspect the current contents::
+by GRUB.
+It can also be used to inspect the current contents::
 
   > grub-editenv /boot/grub/grubenv list
   ORDER="A B"
@@ -147,9 +152,9 @@ by GRUB. It can also be used to inspect the current contents::
   B_TRY=0
 
 The initial installation of the bootloader and rootfs on the system is out of
-scope for RAUC. A common approach is to generate a complete disk image
-(including the partition table) using a build system such as
-OpenEmbedded/Yocto, PTXdist or buildroot.
+scope for RAUC.
+A common approach is to generate a complete disk image (including the partition
+table) using a build system such as OpenEmbedded/Yocto, PTXdist or buildroot.
 
 .. _sec-example-bundle-generation:
 
@@ -196,12 +201,13 @@ Having copied ``update-2015.04-1.raucb`` onto the target, we only need to run RA
   > rauc install /mnt/usb/update-2015.04-1.raucb
 
 After cyptographically verifying the bundle, RAUC will now determine the
-active slots by looking at the ``rauc.slot`` variable. Then, it can select the
-target slot for the update image from the inactive slots.
+active slots by looking at the ``rauc.slot`` variable.
+Then, it can select the target slot for the update image from the inactive
+slots.
 
-When the update is installed completely, we just need to restart the system. GRUB
-will then try to boot the newly installed rootfs. Finally, if the boot was
-successful, we need to inform the bootloader::
+When the update is installed completely, we just need to restart the system.
+GRUB will then try to boot the newly installed rootfs.
+Finally, if the boot was successful, we need to inform the bootloader::
 
   > rauc status mark-good
 
@@ -211,9 +217,9 @@ process and declare dependencies on the main application(s).
 .. _systemd: http://www.freedesktop.org/wiki/Software/systemd/
 
 If the boot is not marked as successful, GRUB will try the other installation
-on the next boot. By configuring the kernel and systemd to reboot on
-critical errors and by using a (software) watchdog, hangs in a non-working
-installation can be avoided.
+on the next boot.
+By configuring the kernel and systemd to reboot on critical errors and by using
+a (software) watchdog, hangs in a non-working installation can be avoided.
 
 Write Slots Without Update Mechanics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -223,8 +229,8 @@ write can be performed by::
 
   > rauc write-slot rootfs.0 rootfs.ext4
 
-This will write the rootfs image ``rootfs.ext4`` to the slot ``rootfs.0``. Note
-that this bypasses all update mechanics like hooks, slot status etc.
+This will write the rootfs image ``rootfs.ext4`` to the slot ``rootfs.0``.
+Note that this bypasses all update mechanics like hooks, slot status etc.
 
 .. _sec-example-slot-configs:
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -22,8 +22,10 @@ to resize the installed filesystem to fully utilize the partitions' space.
 Is it possible to use RAUC without D-Bus (Client/Server mode)?
 --------------------------------------------------------------
 
-Yes. If you compile RAUC using the ``-Dservice=false`` configure option, you
-will be able to compile RAUC without service mode and without D-Bus support::
+Yes.
+If you compile RAUC using the ``-Dservice=false`` configure option,
+you will be able to compile RAUC without service mode and without D-Bus
+support::
 
   meson setup -Dservice=false build
 
@@ -33,11 +35,13 @@ being forwarded to the RAUC service process running on your machine.
 Why does RAUC not have an ext2 / ext3 file type?
 ------------------------------------------------
 
-ext4 is the successor of ext3. There is no advantage in using ext3 over ext4.
+ext4 is the successor of ext3.
+There is no advantage in using ext3 over ext4.
 
 Some people still tend to select ext2 when they want a file system without
-journaling. This is not necessary, as one can turn off journaling in ext4,
-either during creation::
+journaling.
+This is not necessary, as one can turn off journaling in ext4, either during
+creation::
 
   mkfs.ext4 -O ^has_journal
 
@@ -309,8 +313,8 @@ If this partition contains manufacturer-specific data (e.g., calibration data
 at the end), that data will be lost unless special precautions are taken.
 
 The recommended solution is to migrate this data to a safe location during the
-first boot of the device. This ensures future bootloader updates can proceed
-safely.
+first boot of the device.
+This ensures future bootloader updates can proceed safely.
 
 If migration is not feasible (for example, on already deployed devices) RAUC
 provides a ``size-limit`` :ref:`slot option <slot.slot-class.idx-section>` for

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,8 +72,9 @@ the different custom requirements and restrictions an update concept for a
 specific platform must deal with.
 
 When designing the RAUC update tool, all of these requirements were taken into
-consideration. In the following, we provide a short overview of basic concepts,
-principles and solutions RAUC provides for updating an embedded system.
+consideration.
+In the following, we provide a short overview of basic concepts, principles and
+solutions RAUC provides for updating an embedded system.
 
 And What Not?
 -------------

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -184,9 +184,9 @@ you should name your sections according to this example:
   [slot.rootfs.1]
   device = [...]
 
-RAUC does not have predefined class names. The only requirement is that the
-class names used in the system config match those you later use in the update
-manifests.
+RAUC does not have predefined class names.
+The only requirement is that the class names used in the system config match
+those you later use in the update manifests.
 
 The mandatory settings for each slot are:
 
@@ -419,7 +419,8 @@ target side is GLib (minimum version 2.45.8) as utility library and OpenSSL
    with libmount support (``--enable-libmount``) and at least be 2.49.5.
 
 For network support (enabled with ``--Dnetwork=true``), additionally `libcurl`
-is required. This is only useful for the target service.
+is required.
+This is only useful for the target service.
 
 For JSON-style support (enabled with ``-Djson=enabled``), additionally
 `libjson-glib` is required.
@@ -428,9 +429,9 @@ Kernel Configuration
 --------------------
 
 The kernel used on the target device must support both loop block devices and the
-SquashFS file system to allow installing RAUC bundles. For the recommended
-``verity`` :ref:`bundle format<sec_ref_formats>`, dm-verity must be supported as
-well.
+SquashFS file system to allow installing RAUC bundles.
+For the recommended ``verity`` :ref:`bundle format<sec_ref_formats>`, dm-verity
+must be supported as well.
 
 In kernel Kconfig you have to enable the following options as either built-in
 (``y``) or module (``m``):
@@ -748,8 +749,9 @@ Now, when Barebox is initialized it starts the bootchooser logic to select its
 real boot target.
 
 As a next step, we need to tell bootchooser which boot targets it should
-handle. These boot targets can have descriptive names which must not equal any of
-your existing boot targets, we will have a mapping for this later on.
+handle.
+These boot targets can have descriptive names which must not equal any of your
+existing boot targets, we will have a mapping for this later on.
 
 In this example we call the virtual bootchooser boot targets ``system0`` and
 ``system1``::
@@ -960,7 +962,8 @@ As detecting the currently booted rootfs slot from userspace and matching it to
 one of the slots defined in RAUC's ``system.conf`` is not always trivial and
 error-prone, Barebox provides an explicit information about which slot it
 selected for booting adding a `bootchooser.active` key to the commandline of
-the kernel it boots. This key has the virtual bootchooser boot target assigned.
+the kernel it boots.
+This key has the virtual bootchooser boot target assigned.
 In our case, if the bootchooser logic decided to boot `system0` the kernel
 commandline will contain::
 
@@ -1159,8 +1162,10 @@ For placing the content in partition 2 now, we must calculate the offset as
 ``offset=hex(n sector * 512 bytes/sector)``.
 With ``n=114688`` (start of /dev/mmcblk0p2 according to above partition table)
 we get an offset of ``0x3800000``.
-As size we pick ``0x4000`` (16kB) here. The offset of the redundant copy must
-be the offset of the first copy + size of first copy. This results in:
+As size we pick ``0x4000`` (16kB) here.
+The offset of the redundant copy must be the offset of the first copy + size of
+first copy.
+This results in:
 
 .. code-block:: cfg
 
@@ -1226,8 +1231,8 @@ EFI
 ~~~
 
 For x86 systems that directly boot via EFI/UEFI, RAUC supports interaction with
-EFI boot entries by using the `efibootmgr` tool. To enable EFI bootloader
-support in RAUC, write in your ``system.conf``:
+EFI boot entries by using the `efibootmgr` tool.
+To enable EFI bootloader support in RAUC, write in your ``system.conf``:
 
 .. code-block:: cfg
 
@@ -1380,9 +1385,9 @@ or non-zero if an error occurred.
 
 To get the current running slot, the handler must be called with the argument
 ``get-current``. The handler must output the current running slot's bootname on
-the `stdout`, and return ``0`` on exit, if no error occurred. Implementing this
-is only needed when the /proc/cmdline is not providing information about current
-booted slot.
+the `stdout`, and return ``0`` on exit, if no error occurred.
+Implementing this is only needed when the /proc/cmdline is not providing
+information about current booted slot.
 
 Init System and Service Startup
 -------------------------------
@@ -1414,7 +1419,8 @@ as successfully booted.
 In order to achieve this, a smart solution is to create a systemd service that calls
 ``rauc status mark-good`` and use systemd's dependency handling to assure this
 service will not be executed before all relevant other services came up
-successfully. It could look similar to this:
+successfully.
+It could look similar to this:
 
 .. code-block:: cfg
 
@@ -1577,16 +1583,18 @@ with the following content::
   FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 Write a ``system.conf`` for your board and place it in the folder you mentioned
-in the recipe (`meta-your-bsp/recipes-core/rauc/files`). This file must provide
-a system compatible string to identify your system type, as well as a
-definition of all slots in your system. By default, the system configuration
-will be placed in `/etc/rauc/system.conf` on your target rootfs.
+in the recipe (`meta-your-bsp/recipes-core/rauc/files`).
+This file must provide a system compatible string to identify your system type,
+as well as a definition of all slots in your system.
+By default, the system configuration will be placed in `/etc/rauc/system.conf`
+on your target rootfs.
 
 Also place the appropriate keyring file for your target into the directory
-added to ``FILESEXTRAPATHS`` above. Name it either ``ca.cert.pem`` or
-additionally specify the name of your custom file by setting
-``RAUC_KEYRING_FILE``. If multiple keyring certificates are required on a
-single system, create a keyring directory containing each certificate.
+added to ``FILESEXTRAPATHS`` above.
+Name it either ``ca.cert.pem`` or additionally specify the name of your custom
+file by setting ``RAUC_KEYRING_FILE``.
+If multiple keyring certificates are required on a single system, create a
+keyring directory containing each certificate.
 
 .. note::
   For information on how to create a testing / development
@@ -1613,7 +1621,8 @@ In order to compile RAUC for your host system, simply run:
   $ bitbake rauc-native
 
 This will place a copy of the RAUC binary in ``tmp/deploy/tools`` in your
-current build folder. To test it, try:
+current build folder.
+To test it, try:
 
 .. code-block:: console
 
@@ -1628,8 +1637,9 @@ Bundles can be created either manually by building and using RAUC as a native
 tool, or by using the ``bundle.bbclass`` that handles most of the basic steps,
 automatically.
 
-First, create a bundle recipe in your BSP layer. A possible location for this
-could be ``meta-your-bsp/recipes-core/bundles/update-bundle.bb``.
+First, create a bundle recipe in your BSP layer.
+A possible location for this could be
+``meta-your-bsp/recipes-core/bundles/update-bundle.bb``.
 
 To create your bundle you first have to inherit the bundle class::
 
@@ -1646,9 +1656,10 @@ For using the built-in bundle generation, you need to specify some variables:
   <https://github.com/rauc/meta-rauc/blob/master/classes-recipe/bundle.bbclass>`__.
 
 ``RAUC_BUNDLE_COMPATIBLE``
-  Sets the compatible string for the bundle. This should match the compatible
-  you specified in your ``system.conf`` or, more generally, the compatible of the
-  target platform you intend to install this bundle on.
+  Sets the compatible string for the bundle.
+  This should match the compatible you specified in your ``system.conf`` or,
+  more generally, the compatible of the target platform you intend to install
+  this bundle on.
 
 ``RAUC_BUNDLE_SLOTS``
   Use this to list all slot classes for which the bundle should contain images.
@@ -1666,8 +1677,8 @@ For using the built-in bundle generation, you need to specify some variables:
 
 ``RAUC_SLOT_<slotclass>[type]``
   For each slot class, set this to the *type* of image you intend to place in
-  this slot. Possible types are: ``image`` (default), ``kernel``,
-  ``boot``, or ``file``.
+  this slot.
+  Possible types are: ``image`` (default), ``kernel``, ``boot``, or ``file``.
 
 .. note::
   For a full list of supported variables, refer to `classes-recipe/bundle.bbclass` in
@@ -1689,8 +1700,9 @@ meta-rauc will look as follows::
 
 To be able to build a signed image of this, you also need to configure
 ``RAUC_KEY_FILE`` and ``RAUC_CERT_FILE`` to point to your key and certificate
-files you intend to use for signing. You may set them either from your bundle
-recipe or any global configuration (layer, site.conf, etc.), e.g.::
+files you intend to use for signing.
+You may set them either from your bundle recipe or any global configuration
+(layer, site.conf, etc.), e.g.::
 
   RAUC_KEY_FILE = "${COREBASE}/meta-<layername>/files/development-1.key.pem"
   RAUC_CERT_FILE = "${COREBASE}/meta-<layername>/files/development-1.cert.pem"

--- a/docs/man.rst
+++ b/docs/man.rst
@@ -41,9 +41,9 @@ and modify update files ("bundles") for the device.
 This manual page documents briefly the **rauc** command line utility.
 
 It was written for the Debian GNU/Linux distribution to satisfy the
-packaging requirements. Thus it should only serve as a summary, reading
-the comprehensive online manual (**https://rauc.readthedocs.io/**) is
-recommended.
+packaging requirements.
+Thus it should only serve as a summary, reading the comprehensive online manual
+(**https://rauc.readthedocs.io/**) is recommended.
 
 OPTIONS
 -------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -66,8 +66,9 @@ Example configuration:
 ``compatible`` (required)
   A user-defined compatible string that describes the target hardware as
   specific enough as required to prevent faulty updating systems with the wrong
-  firmware. It will be matched against the ``compatible`` string defined in the
-  update manifest.
+  firmware.
+  It will be matched against the ``compatible`` string defined in the update
+  manifest.
 
 ``min-bundle-version`` (optional)
   An optional user-defined version string that follows the
@@ -85,19 +86,20 @@ Example configuration:
   the caveat that cases where a rollback (due to a regression for example)
   would be required, could lead to scenarios where the bundle version would
   need to be incremented to pass the version-limit, but the rolled back system
-  version would end up at a number below the limit. E.g. 1.2.9 = good; update
-  to 1.3.0 with limit set to 1.3.0; problems!; update-bundle version:=1.3.1 but
-  with content=1.2.9.
+  version would end up at a number below the limit.
+  E.g. 1.2.9 = good; update to 1.3.0 with limit set to 1.3.0; problems!;
+  update-bundle version:=1.3.1 but with content=1.2.9.
 
   Also note that the implementation in RAUC relaxes the strict Major.Minor.Path
-  version-core format imposed by the semantic versioning scheme. To accommodate
-  versioning schemes that use YEAR.MONTH or similar, version-cores with just
-  Major or Major.Minor are also allowed.
+  version-core format imposed by the semantic versioning scheme.
+  To accommodate versioning schemes that use YEAR.MONTH or similar,
+  version-cores with just Major or Major.Minor are also allowed.
 
 ``bootloader`` (required)
   The bootloader implementation RAUC should use for its slot switching
-  mechanism. Currently supported values (and bootloaders) are ``barebox``,
-  ``grub``, ``uboot``, ``efi``, ``custom``, ``noop``.
+  mechanism.
+  Currently supported values (and bootloaders) are ``barebox``, ``grub``,
+  ``uboot``, ``efi``, ``custom``, ``noop``.
 
 .. _bundle-formats:
 
@@ -111,12 +113,13 @@ Example configuration:
 
   Alternatively, you can use format names prefixed by ``-`` or ``+`` (such as
   ``-plain``) to enable or disable formats relative to the default
-  configuration. This way, formats added in newer releases will be active
-  automatically.
+  configuration.
+  This way, formats added in newer releases will be active automatically.
 
 ``mountprefix`` (optional)
-  Prefix of the path where bundles and slots will be mounted. Can be overwritten
-  by the command line option ``--mount``. Defaults to ``/mnt/rauc/``.
+  Prefix of the path where bundles and slots will be mounted.
+  Can be overwritten by the command line option ``--mount``.
+  Defaults to ``/mnt/rauc/``.
 
 ``grubenv`` (optional)
   Only valid when ``bootloader`` is set to ``grub``.
@@ -124,9 +127,9 @@ Example configuration:
 
 ``barebox-statename`` (optional)
   Only valid when ``bootloader`` is set to ``barebox``.
-  Overwrites the default state ``state`` to a user-defined state name. If this
-  key not exists, the bootchooser framework searches per default for ``/state``
-  or ``/aliases/state``.
+  Overwrites the default state ``state`` to a user-defined state name.
+  If this key not exists, the bootchooser framework searches per default for
+  ``/state`` or ``/aliases/state``.
 
 ``barebox-dtbpath`` (optional)
   Only valid when ``bootloader`` is set to ``barebox``.
@@ -177,10 +180,11 @@ Example configuration:
 
 ``activate-installed`` (optional)
   This boolean value controls if a freshly installed slot is automatically
-  marked active with respect to the used bootloader. Its default value is
-  ``true`` which means that this slot is going to be started the next time the
-  system boots. If the value of this parameter is ``false`` the slot has to be
-  activated manually in order to be booted, see section :ref:`mark-active`.
+  marked active with respect to the used bootloader.
+  Its default value is ``true`` which means that this slot is going to be
+  started the next time the system boots.
+  If the value of this parameter is ``false`` the slot has to be activated
+  manually in order to be booted, see section :ref:`mark-active`.
 
 .. _statusfile:
 
@@ -285,8 +289,8 @@ desired, though only one or the other is necessary to verify the bundle
 signature.
 
 ``path`` (optional)
-  Path to the keyring file in PEM format. Either absolute or relative to the
-  system.conf file.
+  Path to the keyring file in PEM format.
+  Either absolute or relative to the system.conf file.
 
 ``directory`` (optional)
   Path to the keyring directory containing one or more certificates.
@@ -438,8 +442,8 @@ For more information about using the casync support of RAUC, refer to
 
 ``install-args`` (optional)
   Allows to specify additional arguments that will be passed to casync when
-  installing an update. For example it can be used to include additional
-  seeds or stores.
+  installing an update.
+  For example it can be used to include additional seeds or stores.
 
 ``storepath`` (optional)
   Allows to set the path to use as chunk store path for casync to a fixed one.
@@ -451,14 +455,16 @@ For more information about using the casync support of RAUC, refer to
 ``tmppath`` (optional)
   Allows to set the path to use as temporary directory for casync.
   The temporary directory used by casync can be specified using the TMPDIR
-  environment variable. It falls back to /var/tmp if unset.
+  environment variable.
+  It falls back to /var/tmp if unset.
   If ``tmppath`` is set then RAUC runs casync with TMPDIR sets to that path.
   By default, the temporary directory is left unset by RAUC and casync uses its
   internal default value ``/var/tmp``.
 
 ``use-desync=<true/false>`` (optional)
   If this boolean value is set to ``true``, RAUC will use desync instead of
-  casync. Desync support is still experimental, use with caution.
+  casync.
+  Desync support is still experimental, use with caution.
 
 ``[autoinstall]`` Section
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -482,9 +488,9 @@ performed from a dedicated (recovery) slot.
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Handlers allow to customize RAUC by placing scripts in the system that RAUC can
-call for different purposes. All parameters expect pathnames to the script to
-be executed. Pathnames are either absolute or relative to the system.conf file
-location.
+call for different purposes.
+All parameters expect pathnames to the script to be executed.
+Pathnames are either absolute or relative to the system.conf file location.
 
 RAUC passes a set of environment variables to handler scripts.
 See details about using handlers in `Custom Handlers (Interface)`_.
@@ -552,17 +558,19 @@ See details about using handlers in `Custom Handlers (Interface)`_.
 Each slot is identified by a section starting with ``slot.`` followed by
 the slot class name, and a slot number.
 The ``<slot-class>`` name is used in the *update manifest* to target the correct
-set of slots. It must not contain any ``.`` (dots) as these are used as
-hierarchical separator.
+set of slots.
+It must not contain any ``.`` (dots) as these are used as hierarchical
+separator.
 
 ``device=</path/to/dev>`` (required)
   The slot's device path.
 
 ``type=<type>`` (optional, recommended)
-  The type describing the slot. Currently supported ``<type>`` values are ``raw``,
-  ``nand``, ``nor``, ``ubivol``, ``ubifs``, ``ext4``, ``vfat``, ``jffs2`` for normal slots
-  and ``boot-emmc``, ``boot-mbr-switch``, ``boot-gpt-switch``, and ``boot-raw-fallback``
-  for atomically updatable bootloader slots.
+  The type describing the slot.
+  Currently supported ``<type>`` values are ``raw``, ``nand``, ``nor``,
+  ``ubivol``, ``ubifs``, ``ext4``, ``vfat``, ``jffs2`` for normal slots and
+  ``boot-emmc``, ``boot-mbr-switch``, ``boot-gpt-switch``, and
+  ``boot-raw-fallback`` for atomically updatable bootloader slots.
   See table :ref:`sec-slot-type` for a more detailed list of these different types.
   Defaults to ``raw`` if none given.
 
@@ -593,8 +601,9 @@ hierarchical separator.
   Such a slot can be updated only by a custom install hook.
 
 ``readonly=<true/false>`` (optional)
-  Marks the slot as existing but not updatable. May be used for sanity checking
-  or informative purpose. A ``readonly`` slot cannot be a target slot.
+  Marks the slot as existing but not updatable.
+  May be used for sanity checking or informative purpose.
+  A ``readonly`` slot cannot be a target slot.
 
 .. _install-same:
 
@@ -612,8 +621,9 @@ hierarchical separator.
 
 ``resize=<true/false>`` (optional)
   If set to ``true`` this will tell RAUC to resize the filesystem after having
-  written the image to this slot. This only has an effect when writing an ext4
-  file system to an ext4 slot, i.e. if the slot has``type=ext4`` set.
+  written the image to this slot.
+  This only has an effect when writing an ext4 file system to an ext4 slot,
+  i.e. if the slot has``type=ext4`` set.
 
 ``extra-mount-opts=<options>`` (optional)
   Allows to specify custom mount options that will be passed to the slot's
@@ -715,7 +725,8 @@ a look at :ref:`sec-advanced-event-log`.
   configuration error.
 
 ``events`` (optional)
-  Semicolon-separated list of events to log. Currently supported event types are:
+  Semicolon-separated list of events to log.
+  Currently supported event types are:
 
   * ``install`` - Logs start and end of installation
   * ``boot`` - Logs boot information
@@ -723,7 +734,8 @@ a look at :ref:`sec-advanced-event-log`.
   * ``all`` - Log all events (default, cannot be combined with other events)
 
 ``format`` (optional)
-  The output format used for the logger. Supported values are
+  The output format used for the logger.
+  Supported values are
 
   * ``readable``: readable multi-line output (default)
   * ``short``: Single-line readable output
@@ -797,7 +809,8 @@ This section contains some high-level information about the bundle.
 
 ``version`` (optional)
   A free version field that can be used to provide and track version
-  information. No checks will be performed on this version by RAUC itself,
+  information.
+  No checks will be performed on this version by RAUC itself,
   although a handler can use this information to reject updates.
 
 ``description`` (optional)
@@ -806,8 +819,8 @@ This section contains some high-level information about the bundle.
 
 ``build`` (optional)
   A build id that would typically hold the build date or some build
-  information provided by the bundle creation environment. This can help to
-  determine the date and origin of the built bundle.
+  information provided by the bundle creation environment.
+  This can help to determine the date and origin of the built bundle.
 
 ``min-rauc-version`` (optional)
   An optional version limit which causes the manifest to be rejected if the
@@ -966,11 +979,13 @@ The following fields are supported for image sections:
   :ref:`Supported Image Types <sec-ref-supported-image-types>` section.
 
 ``sha256`` (generated)
-  sha256 of image file. RAUC determines this value automatically when creating
+  sha256 of image file.
+  RAUC determines this value automatically when creating
   a bundle, thus it is not required to set this by hand.
 
 ``size`` (generated)
-  size of image file. RAUC determines this value automatically when creating a
+  size of image file.
+  RAUC determines this value automatically when creating a
   bundle, thus it is not required to set this by hand.
 
 ``hooks`` (optional)
@@ -1425,9 +1440,15 @@ section :ref:`Manifest <sec_ref_manifest>`.
 The ``status`` field records the status of each slot.
 It can have the following values:
 
-:ok: The latest update for this slot succeeded. Its content should be valid.
-:failed: The latest update for this slot failed. There is no valid content on it.
-:pending: The slot is currently being updated. There is no valid content on it, yet.
+:ok:
+  The latest update for this slot succeeded.
+  Its content should be valid.
+:failed:
+  The latest update for this slot failed.
+  There is no valid content on it.
+:pending:
+  The slot is currently being updated.
+  There is no valid content on it, yet.
 
 For a description of ``sha256`` and ``size`` keys see :ref:`this
 <image-section>` part of the section :ref:`Manifest
@@ -1457,7 +1478,8 @@ System Status File
 The system status is only available if a central status file is configured for
 RAUC (by setting :ref:`data-directory <data-directory>`).
 The system status is stored in the same file as the :ref:`slot status
-<slot-status>`. It uses a distinct ``[system]`` section.
+<slot-status>`.
+It uses a distinct ``[system]`` section.
 
 .. code-block:: cfg
 
@@ -1540,8 +1562,9 @@ variables.
   A deprecated alias for ``RAUC_BUNDLE_MOUNT_POINT``
 
 ``RAUC_TRANSACTION_ID``
-  A UUID of a particular installation. This is either generated by RAUC or
-  provided explicitly on command line or over the D-Bus :ref:`InstallBundle
+  A UUID of a particular installation.
+  This is either generated by RAUC or provided explicitly on command line or
+  over the D-Bus :ref:`InstallBundle
   <gdbus-method-de-pengutronix-rauc-Installer.InstallBundle>` method.
 
 ``RAUC_MOUNT_PREFIX``
@@ -1552,10 +1575,10 @@ variables.
   This uses the same format as ``rauc info --output-format=shell …``.
 
 ``RAUC_SLOTS``
-  An iterator list to loop over all existing slots. Each item in the list is
-  an integer referencing one of the slots. To get the slot parameters, you have to
-  resolve the per-slot variables (suffixed with <N> placeholder for the
-  respective slot number).
+  An iterator list to loop over all existing slots.
+  Each item in the list is an integer referencing one of the slots.
+  To get the slot parameters, you have to resolve the per-slot variables
+  (suffixed with <N> placeholder for the respective slot number).
 
 ``RAUC_TARGET_SLOTS``
   An iterator list similar to ``RAUC_SLOTS`` but only containing slots that
@@ -2110,7 +2133,8 @@ Refer :ref:`Processing Progress Data <sec_processing_progress>` section.
    :start-at: <property name="Compatible"
    :end-at: <property
 
-Represents the system's compatible. This can be used to check for usable bundles.
+Represents the system's compatible.
+This can be used to check for usable bundles.
 
 .. _gdbus-property-de-pengutronix-rauc-Installer.Variant:
 
@@ -2123,7 +2147,8 @@ Represents the system's compatible. This can be used to check for usable bundles
    :start-at: <property name="Variant"
    :end-at: <property
 
-Represents the system's variant. This can be used to select parts of an bundle.
+Represents the system's variant.
+This can be used to select parts of an bundle.
 
 .. _gdbus-property-de-pengutronix-rauc-Installer.BootSlot:
 
@@ -2136,11 +2161,12 @@ Represents the system's variant. This can be used to select parts of an bundle.
    :start-at: <property name="BootSlot"
    :end-at: <property
 
-Contains the information RAUC uses to identify the booted slot. It is derived
-from the kernel command line.
+Contains the information RAUC uses to identify the booted slot.
+It is derived from the kernel command line.
 This can either be the slot name (e.g. ``rauc.slot=rootfs.0``) or the root device
-path (e.g. ``root=PARTUUID=0815``). If the ``root=`` kernel command line option is
-used, the symlink is resolved to the block device (e.g. ``/dev/mmcblk0p1``).
+path (e.g. ``root=PARTUUID=0815``).
+If the ``root=`` kernel command line option is used,
+the symlink is resolved to the block device (e.g. ``/dev/mmcblk0p1``).
 
 
 RAUC's Basic Update Procedure
@@ -2210,8 +2236,8 @@ bootloader will not select it for booting anymore.
 As shown above this is either the case before an installation to make the
 update atomic from the bootloader's perspective, or optionally after the
 installation and a reboot into the new system, when a service detects that the
-system is in an unusable state. This potentially allows falling back to a
-working system.
+system is in an unusable state.
+This potentially allows falling back to a working system.
 
 The aim of setting a slot 'primary' is to let the bootloader select this slot
 upon next reboot in case of having completed the installation successfully.

--- a/docs/updating.rst
+++ b/docs/updating.rst
@@ -85,17 +85,19 @@ Interfacing with your Bootloader
 --------------------------------
 
 The bootloader is the final instance that controls which partition on your
-rootfs device will be booted. In order to switch partitions after an update,
-you have to have an interface to the bootloader that allows you to set the boot
-order, boot priority and other possible parameters.
+rootfs device will be booted.
+In order to switch partitions after an update, you have to have an interface to
+the bootloader that allows you to set the boot order, boot priority and other
+possible parameters.
 
 Some bootloaders, such as U-Boot, allow access to their environment storage
 where you can freely create and modify variables the bootloader may read.
 Boot logic often can be implemented by a simple boot script.
 
 Some others have distinct redundancy boot interfaces with redundant state
-storage. These often provide more features than simply switching boot
-partitions and are less prone to errors when used.
+storage.
+These often provide more features than simply switching boot partitions and are
+less prone to errors when used.
 The Barebox bootloader with its bootchooser framework is a good example for
 this.
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -160,8 +160,9 @@ which then, for example, resets a boot attempt counter.
   # rauc status mark-bad
 
 If the current boot failed in some kind, this command can be used to communicate
-that to the underlying bootloader implementation. In most cases this will
-disable the currently booted slot or at least switch to a different one.
+that to the underlying bootloader implementation.
+In most cases this will disable the currently booted slot or at least switch to
+a different one.
 
 Although not very useful in the field, both commands recognize an optional
 argument to explicitly identify the slot to act on:
@@ -200,15 +201,18 @@ To do so, RAUC offers the subcommand
   # rauc status mark-active [booted | other | <SLOT_NAME>]
 
 where the optional argument decides which slot to (re-)activate at the expense
-of the remaining slots. Choosing ``other`` switches to the next bootable slot
-that is not the one that is currently booted. In a two-slot-setup this is
-just... the other one. If one wants to explicitly address a known slot, one can
-do so by using its slot name which has the form ``<slot-class>.<idx>`` (e.g.
-``rootfs.1``), see :ref:`this <slot.slot-class.idx-section>` part of section
-:ref:`System Configuration File <sec_ref_slot_config>`. Last but not least,
-after switching to a different slot by mistake, before having rebooted this can
-be remedied by choosing ``booted`` as the argument which is, by the way, the
-default if the optional argument has been omitted.
+of the remaining slots.
+Choosing ``other`` switches to the next bootable slot that is not the one that
+is currently booted.
+In a two-slot-setup this is just... the other one.
+If one wants to explicitly address a known slot, one can do so by using its
+slot name which has the form ``<slot-class>.<idx>`` (e.g. ``rootfs.1``), see
+:ref:`this <slot.slot-class.idx-section>` part of section :ref:`System
+Configuration File <sec_ref_slot_config>`.
+Last but not least, after switching to a different slot by mistake,
+before having rebooted this can be remedied by choosing ``booted`` as the
+argument which is, by the way, the default if the optional argument has been
+omitted.
 The date and time of activation as well as the number of activations is part of
 the slot's metadata which is stored in the slot status file, see section
 :ref:`slot-status`.
@@ -216,9 +220,9 @@ the slot's metadata which is stored in the slot status file, see section
 Customizing the Update
 ----------------------
 
-RAUC provides several ways to customize the update process. Some allow adding
-and extending details more fine-grainedly, some allow replacing major parts of
-the default behavior of RAUC.
+RAUC provides several ways to customize the update process.
+Some allow adding and extending details more fine-grainedly,
+some allow replacing major parts of the default behavior of RAUC.
 
 In general, there exist three major types of customization:
 
@@ -230,19 +234,21 @@ The first type, configuration parameters, allow controlling parameters of the
 update in a predefined way.
 
 The second type, using `handlers`, allows extending or replacing the
-installation process. They are executables (most likely shell scripts) located
-in the root filesystem and configured in the system's configuration file. They
-control static behavior of the system that should remain the same over future
-updates.
+installation process.
+They are executables (most likely shell scripts) located in the root filesystem
+and configured in the system's configuration file.
+They control static behavior of the system that should remain the same over
+future updates.
 
-The last type are `hooks`. They are similar to `handlers`, except that they are
-contained in the update bundle. Thus they allow to flexibly extend or customize
-one or more updates by some special behavior.
+The last type are `hooks`.
+They are similar to `handlers`, except that they are contained in the update
+bundle.
+Thus they allow to flexibly extend or customize one or more updates by some
+special behavior.
 A common example would be using a per-slot post-install hook that handles
-configuration migration for a new software version. Hooks are especially useful
-to handle details of installing an update which were not considered in the
-previously deployed version.
-
+configuration migration for a new software version.
+Hooks are especially useful to handle details of installing an update which
+were not considered in the previously deployed version.
 
 In the following, configuration parameters, handlers and hooks will be
 explained in more detail.
@@ -275,7 +281,8 @@ scripts, see the :ref:`sec-handler-interface` section.
 
 RAUC will call the pre-install handler (if given) during the bundle
 installation process, right before calling the default or custom installation
-process. At this stage, the bundle is mounted, its content is accessible and the
+process.
+At this stage, the bundle is mounted, its content is accessible and the
 target group has been determined successfully.
 
 If calling the handler fails or the handler returns a non-zero exit code, RAUC
@@ -291,8 +298,9 @@ will abort installation with an error.
   post-install=/usr/lib/rauc/post-install
 
 The post-install handler will be called right after RAUC successfully performed
-a system update. If any error occurred during installation, the post-install
-handler will not be called.
+a system update.
+If any error occurred during installation, the post-install handler will not be
+called.
 
 Note that a failed call of the post-install handler or a non-zero exit code
 will cause a notification about the error but will not change the result of the
@@ -308,9 +316,9 @@ restart of the system.
   [handlers]
   system-info=/usr/lib/rauc/system-info
 
-The system-info handler is called after loading the configuration file. This
-way it can collect additional variables from the system, like the system's
-serial number.
+The system-info handler is called after loading the configuration file.
+This way it can collect additional variables from the system,
+like the system's serial number.
 
 The handler script can return variables by echoing ``<VARIABLE-NAME>=<value>``
 to stdout, like ``RAUC_SYSTEM_SERIAL`` or ``RAUC_SYSTEM_VARIANT``.
@@ -349,9 +357,9 @@ For each invoked hook, the common hook executable will be called with a
 specific argument indicating the name of the invoked hook.
 The executable is responsible for multiplexing the different hook calls.
 
-In the following the available hooks are listed. Depending on their purpose,
-some are image-specific, i.e. they will be executed for the installation of a
-specific image only, while some other are global.
+In the following the available hooks are listed.
+Depending on their purpose, some are image-specific, i.e. they will be executed
+for the installation of a specific image only, while some other are global.
 
 .. _sec-install-hooks:
 
@@ -407,13 +415,14 @@ the hook executable as the rejection reason message and provide it to the user:
 Slot Hooks
 ^^^^^^^^^^
 
-Slot hooks are called for each slot an image will be installed to. In order to
-enable them, you have to specify them in the ``hooks`` key under the respective
-``image`` section.
+Slot hooks are called for each slot an image will be installed to.
+In order to enable them, you have to specify them in the ``hooks`` key under
+the respective ``image`` section.
 
 Note that hook slot operations will be passed to the executable with the prefix
-``slot-``. Thus if you intend to check for the pre-install hook, you have to
-check for the argument to be ``slot-pre-install``.
+``slot-``.
+Thus if you intend to check for the pre-install hook, you have to check for the
+argument to be ``slot-pre-install``.
 
 For a detailed list of all environment variables exported for the hooks
 executable, see the :ref:`sec-slot-hook-interface` section.
@@ -442,10 +451,11 @@ installation to be aborted with an error.
 .. rubric:: Post-Install Hook
 
 The post-install hook will be called right after the update procedure for the
-respective slot was finished successfully. For slot types that represent a
-mountable file system, the hook will be executed with having the file system
-mounted. This allows to write some post-install information to the slot. It is
-also useful to copy files from the currently active system to the newly
+respective slot was finished successfully.
+For slot types that represent a mountable file system, the hook will be
+executed with having the file system mounted.
+This allows to write some post-install information to the slot.
+It is also useful to copy files from the currently active system to the newly
 installed slot, for example to preserve application configuration data.
 
 .. code-block:: cfg
@@ -483,13 +493,14 @@ An example on how to use a post-install hook:
 .. rubric:: Install Hook
 
 The install hook will replace the entire default installation process for the
-target slot of the image it was specified for. Note that when having the install
-hook enabled, pre- and post-install hooks will *not* be executed and having
-an image (i.e. ``filename`` set) is optional, too!
-The install hook allows to fully customize the way a slot is updated. This
-allows performing special installation methods that are not natively supported
-by RAUC, for example to upgrade the bootloader to a new version while also
-migrating configuration settings.
+target slot of the image it was specified for.
+Note that when having the install hook enabled, pre- and post-install hooks
+will *not* be executed and having an image (i.e. ``filename`` set) is optional,
+too!
+The install hook allows to fully customize the way a slot is updated.
+This allows performing special installation methods that are not natively
+supported by RAUC, for example to upgrade the bootloader to a new version while
+also migrating configuration settings.
 
 .. code-block:: cfg
 
@@ -770,7 +781,8 @@ service file).
 
 For more fine grained and advanced debugging options, use the
 ``G_MESSAGES_DEBUG`` environment variable.
-This allows enabling different log domains. Currently available are:
+This allows enabling different log domains.
+Currently available are:
 
 :all: enable all log domains
 


### PR DESCRIPTION
This only changes whitespace (checked with `git show --word-diff`).