### PR TITLE
src/manifest: check mandatory 'filename' option for 'convert' and 'adaptive'

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -177,13 +177,6 @@ static gboolean parse_image(GKeyFile *key_file, const gchar *group, RaucImage **
 		}
 	}
 
-	/* All requirements to check if a filename is necessary have been collected,
-	 * so we can now check if the current state is valid */
-	if (!validate_filename_requirements(iimage, &ierror)) {
-		g_propagate_error(error, ierror);
-		return FALSE;
-	}
-
 	g_key_file_remove_key(key_file, group, "version", NULL);
 	g_key_file_remove_key(key_file, group, "description", NULL);
 	g_key_file_remove_key(key_file, group, "build", NULL);
@@ -564,6 +557,17 @@ static gboolean check_manifest_common(const RaucManifest *mf, GError **error)
 	if (have_hooks && !mf->hook_name) {
 		g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_CHECK_ERROR, "Hooks used, but no hook 'filename' defined in [hooks] section");
 		return FALSE;
+	}
+
+	for (GList *l = mf->images; l != NULL; l = l->next) {
+		RaucImage *image = l->data;
+		GError *ierror = NULL;
+		/* All requirements to check if a filename is necessary have been collected,
+		 * so we can now check if the current state is valid */
+		if (!validate_filename_requirements(image, &ierror)) {
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
 	}
 
 	return TRUE;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -65,6 +65,16 @@ static gboolean validate_filename_requirements(RaucImage *image, GError **error)
 		}
 	}
 
+	if (image->adaptive && !image->filename) {
+		g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_PARSE_ERROR, "'adaptive' requires 'filename' to be set");
+		return FALSE;
+	}
+
+	if (image->convert && !image->filename) {
+		g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_PARSE_ERROR, "'convert' requires 'filename' to be set");
+		return FALSE;
+	}
+
 	return TRUE;
 }
 

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -483,7 +483,7 @@ static void test_manifest_load_types_emptyfs_with_imagename_invalid(void)
 	g_autoptr(RaucManifest) rm = NULL;
 	gchar* manifestpath = NULL;
 	gboolean res;
-	GError *error = NULL;
+	g_autoptr(GError) error = NULL;
 	const gchar *mffile = "\
 [update]\n\
 compatible=FooCorp Super BarBazzer\n\
@@ -507,11 +507,15 @@ filename=appfs.vfat\n\
 	g_free(tmpdir);
 
 	res = load_manifest_file(manifestpath, &rm, &error);
-	g_assert_error(error, R_MANIFEST_ERROR, R_MANIFEST_PARSE_ERROR);
-	g_assert_false(res);
+	g_assert_true(res);
+	g_assert_no_error(error);
 
-	g_clear_error(&error);
 	g_free(manifestpath);
+
+	res = check_manifest_input(rm, &error);
+	g_assert_error(error, R_MANIFEST_ERROR, R_MANIFEST_PARSE_ERROR);
+	g_assert_cmpstr("It is not supported setting 'filename' when 'type=emptyfs' is set", ==, error->message);
+	g_assert_false(res);
 }
 
 static void test_manifest_load_types_emptyfs_valid(void)

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -477,6 +477,36 @@ version=2025.10-1\n\
 	g_assert_false(res);
 }
 
+static void test_manifest_load_adaptive_missing_filename(void)
+{
+	const gchar *mffile = "\
+[update]\n\
+compatible=FooCorp Super BarBazzer\n\
+version=2015.04-1\n\
+\n\
+[image.rootfs]\n\
+type=emptyfs\n\
+adaptive=block-hash-index\n\
+";
+
+	g_autofree gchar *tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+	g_assert_nonnull(tmpdir);
+
+	g_autofree gchar* manifestpath = write_tmp_file(tmpdir, "manifest.raucm", mffile, NULL);
+	g_assert_nonnull(manifestpath);
+
+	g_autoptr(RaucManifest) rm = NULL;
+	g_autoptr(GError) error = NULL;
+	gboolean res = load_manifest_file(manifestpath, &rm, &error);
+	g_assert_true(res);
+	g_assert_no_error(error);
+
+	res = check_manifest_input(rm, &error);
+	g_assert_error(error, R_MANIFEST_ERROR, R_MANIFEST_PARSE_ERROR);
+	g_assert_cmpstr("'adaptive' requires 'filename' to be set", ==, error->message);
+	g_assert_false(res);
+}
+
 static void test_manifest_load_types_emptyfs_with_imagename_invalid(void)
 {
 	gchar *tmpdir;
@@ -987,6 +1017,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/manifest/load_types_filenext_not_mapped", test_manifest_load_types_fileext_not_mapped);
 	g_test_add_func("/manifest/missing_type_and_filename", test_manifest_load_missing_type_and_filename);
 	g_test_add_func("/manifest/load_types_emptyfs_valid", test_manifest_load_types_emptyfs_valid);
+	g_test_add_func("/manifest/load_adaptive_missing_filename", test_manifest_load_adaptive_missing_filename);
 	g_test_add_func("/manifest/load_types_emptyfs_with_filename_invalid", test_manifest_load_types_emptyfs_with_imagename_invalid);
 	g_test_add_func("/manifest/load_adaptive", test_manifest_load_adaptive);
 	g_test_add_func("/manifest/load_meta", test_manifest_load_meta);


### PR DESCRIPTION
The 'convert' methods and adaptive updates require having a 'filename' set.

Extend validate_filename_requirements() by a check that ensures that.

Otherwise manifests that e.g. use `type=emptyfs` together with `convert=keep` will crash rauc during bundle creation:

> (rauc:126245): rauc-DEBUG: 10:42:05.337: keeping input artifact image '(null)' | **
> rauc:ERROR:../src/bundle.c:631:convert_images: assertion failed: (converted_filename != NULL)

Or, when combining with 'adaptive=block-hash-index', with

> (rauc:129541): rauc-CRITICAL **: 10:56:51.633: image_is_archive: assertion 'image->filename' failed

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
