### PR TITLE
 src/main: extract: strip trailing output bundle slash

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -225,20 +225,30 @@ G_GNUC_WARN_UNUSED_RESULT;
  * Resolve path based on directory of `basefile` argument or current working dir.
  *
  * This is useful for parsing paths from config files where the path locations
- * may depend on the config files location. In this case `path` would be the
+ * may depend on the config file’s location. In this case `path` would be the
  * pathname set in the config file, and `basefile` would be the path to the
  * config file itself.
  *
- * If given path itself is absolute, this will be returned.
- * If `basefile` is given and absolute, its location (with the pathname
- * stripped) will be used as the prefix path for `path`.
- * If `basefile` is not an absolute path, the current workding dir will be used
- * as the prefix path for `path` instead.
+ * The function behaves as follows:
  *
- * @param basefile Reference path to resolve `path` to
- * @param path The path to resolve an absolute path for
+ * - If `path` is NULL, NULL is returned.
+ * - If `path` starts with the "pkcs11:" URI scheme, it is returned unchanged.
+ * - If `path` is absolute, it is returned unchanged.
+ * - If `path` is relative and `basefile` is NULL, it is resolved relative to
+ *   the current working directory.
+ * - If `path` is relative and `basefile` is given:
+ *   - If the directory part of `basefile` is absolute, `path` is resolved
+ *     relative to that directory.
+ *   - If the directory part of `basefile` is relative, `path` is resolved
+ *     relative to the current working directory followed by the directory
+ *     part of `basefile`.
  *
- * @return An absolute path name, determined as described above, NULL if undeterminable
+ * @param basefile Reference path used to resolve `path`, or NULL to use the
+ *                 current working directory.
+ * @param path The path to resolve.
+ *
+ * @return A newly allocated string containing the resolved path, or NULL if
+ *         `path` is NULL.
  *         [transfer full]
  */
 gchar *resolve_path(const gchar *basefile, const gchar *path)

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2770,7 +2770,7 @@ gboolean extract_bundle(RaucBundle *bundle, const gchar *outputdir, GError **err
 
 	if (g_file_test(outputdir, G_FILE_TEST_EXISTS)) {
 		res = FALSE;
-		g_set_error(error, G_FILE_ERROR, G_FILE_ERROR_EXIST, "output directory %s exists already", outputdir);
+		g_set_error(error, G_FILE_ERROR, G_FILE_ERROR_EXIST, "output directory '%s' exists already", outputdir);
 		goto out;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -769,20 +769,28 @@ static gboolean extract_start(int argc, char **argv)
 		return TRUE;
 	}
 
-	g_debug("input bundle: %s", argv[2]);
-	g_debug("output dir: %s", argv[3]);
+	g_autofree gchar* inbundle = g_strdup(argv[2]);
+	g_autofree gchar* outdir = g_strdup(argv[3]);
+
+	/* strip trailing slash for later path existence check */
+	if (g_str_has_suffix(outdir, "/")) {
+		outdir[strlen(outdir)-1] = '\0';
+	}
+
+	g_debug("input bundle: %s", inbundle);
+	g_debug("output dir: %s", outdir);
 
 	if (trust_environment)
 		check_bundle_params |= CHECK_BUNDLE_TRUST_ENV;
 
-	if (!check_bundle(argv[2], &bundle, check_bundle_params, NULL, &ierror)) {
+	if (!check_bundle(inbundle, &bundle, check_bundle_params, NULL, &ierror)) {
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
 		return TRUE;
 	}
 
-	if (!extract_bundle(bundle, argv[3], &ierror)) {
+	if (!extract_bundle(bundle, outdir, &ierror)) {
 		g_printerr("Failed to extract bundle: %s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;

--- a/src/main.c
+++ b/src/main.c
@@ -754,19 +754,19 @@ static gboolean extract_start(int argc, char **argv)
 	if (argc < 3) {
 		g_printerr("An input bundle must be provided\n");
 		r_exit_status = 1;
-		goto out;
+		return TRUE;
 	}
 
 	if (argc < 4) {
 		g_printerr("An output directory must be provided\n");
 		r_exit_status = 1;
-		goto out;
+		return TRUE;
 	}
 
 	if (argc > 4) {
 		g_printerr("Excess argument: %s\n", argv[4]);
 		r_exit_status = 1;
-		goto out;
+		return TRUE;
 	}
 
 	g_debug("input bundle: %s", argv[2]);
@@ -779,17 +779,16 @@ static gboolean extract_start(int argc, char **argv)
 		g_printerr("%s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
-		goto out;
+		return TRUE;
 	}
 
 	if (!extract_bundle(bundle, argv[3], &ierror)) {
 		g_printerr("Failed to extract bundle: %s\n", ierror->message);
 		g_clear_error(&ierror);
 		r_exit_status = 1;
-		goto out;
+		return TRUE;
 	}
 
-out:
 	return TRUE;
 }
 


### PR DESCRIPTION
Calling `rauc extract` with a trailing slash as output directory can lead to:

> % rauc extract […] out.raucb out/
> […]
> rauc-Message: 13:27:30.107: Verifying bundle payload...
>
> FATAL ERROR: dir_scan: failed to change permissions for directory out/, because Not a directory
> Failed to extract bundle: Failed to run unsquashfs: Child process exited with code 1

This will be the case when 'out' is an existing file since `g_file_test("out/")` will not return `TRUE` for a file. Fix this by simply stripping a trailing slash.

 src/main: extract: strip trailing output bundle slash

While at it, also fix the `resolve_path()` documentation (which caught my eye while thinking about whether to handle the slash there or in main).