### PR TITLE
.github/workflows/tests: always run for pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,7 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
+  pull_request: {}
 
 jobs:
   build:


### PR DESCRIPTION
We need the tests jobs to run for all pull requests to satisfy the branch protection checks.

See also https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks

Fixes: 29494ef4d41e (".github/workflows: use separate workflow for building docs")