### PR TITLE
 fix overflow for extremely large hash indices

### DIFF
--- a/src/hash_index.c
+++ b/src/hash_index.c
@@ -11,6 +11,8 @@
 #include "utils.h"
 
 #define SHA256_LEN 32
+#define MAX_CHUNK_COUNT 0x7ffffff /* limit index size to below 4 GiB */
+G_STATIC_ASSERT(MAX_CHUNK_COUNT <= (G_MAXUINT32/SHA256_LEN));
 
 GQuark r_hash_index_error_quark(void)
 {
@@ -54,12 +56,14 @@ static void hash_chunk(RaucHashIndexChunk *chunk)
 static GBytes *hash_file(int data_fd, guint32 count, GError **error)
 {
 	GError *ierror = NULL;
-	g_autoptr(GByteArray) hashes = g_byte_array_set_size(g_byte_array_new(), ((guint)count)*SHA256_LEN);
+	g_autoptr(GByteArray) hashes = g_byte_array_new();
 	g_autofree RaucHashIndexChunk *chunk = g_new0(RaucHashIndexChunk, 1);
 
 	g_return_val_if_fail(data_fd >= 0, NULL);
-	g_return_val_if_fail(count > 0, NULL);
+	g_return_val_if_fail(count > 0 && count <= MAX_CHUNK_COUNT, NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	g_byte_array_set_size(hashes, ((guint)count)*SHA256_LEN);
 
 	if (lseek(data_fd, 0, SEEK_SET) != 0) {
 		int err = errno;
@@ -143,6 +147,7 @@ static guint32 *build_lookup(GBytes *hashes)
 	g_return_val_if_fail(hashes != NULL, NULL);
 
 	count = g_bytes_get_size(hashes) / SHA256_LEN;
+	g_assert(count <= MAX_CHUNK_COUNT);
 	lookup = g_new(guint32, count);
 
 	for (guint32 i = 0; i < count; i++) {
@@ -199,7 +204,7 @@ static guint32 get_chunk_count(int data_fd, GError **error)
 				R_HASH_INDEX_ERROR_SIZE,
 				"image/partition is empty");
 		return 0;
-	} else if ((size / 4096) > (off_t)G_MAXUINT32) {
+	} else if ((size / 4096) > (off_t)MAX_CHUNK_COUNT) {
 		g_set_error(error,
 				R_HASH_INDEX_ERROR,
 				R_HASH_INDEX_ERROR_SIZE,

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -96,6 +96,33 @@ def test_install_env(rauc_dbus_service_with_system_adaptive, tmp_path):
     assert post_lines == pre_lines
 
 
+def test_install_hash_index_too_large(tmp_path, create_system_files, system, capfd):
+    system.prepare_minimal_config()
+    system.write_config()
+
+    assert (tmp_path / "images/appfs-1").is_file()
+    assert (tmp_path / "images/appfs-1").stat().st_size == 0
+    # create a slot "device" which would need a too large block-hash-index
+    with (tmp_path / "images/appfs-1").open("wb") as f:
+        f.truncate(2**32 // 32 * 4096)
+
+    bundle_name = "good-adaptive-meta-bundle.raucb"
+
+    # copy to tmp path for safe ownership check
+    shutil.copyfile(bundle_name, tmp_path / bundle_name)
+
+    with system.running_service("A"):
+        out, err, exitcode = run(f"rauc install {tmp_path}/{bundle_name}")
+
+        assert exitcode == 0
+
+    captured = capfd.readouterr()
+    assert (
+        "Continuing after adaptive mode error: failed to open target slot hash index for appfs.1: image/partition size (549755813888) is too large"
+        in captured.err
+    )
+
+
 @have_casync
 def test_install_plain_casync_local(rauc_dbus_service_with_system, tmp_path):
     assert os.path.exists(tmp_path / "images/rootfs-1")


### PR DESCRIPTION
When using block-hash-index adaptive updates with images or slot devices
of 512 GiB or larger, the resulting hash index reaches 4 GiB, which
exceedes what can be represented in the guint length parameter for
`g_byte_array_set_size()`.

Fix this by ensuring that only at most 0x7ffffff hash chunks are used.

While this can lead to an out-of-bounds write of SHA256 hashes, this is
not a security issue. During bundle creation, the user is responsible
for ensuring that the input image files are authentic as otherwise
malicious data would be signed. On the target, the system must be
configured to protect the raw slot devices and RAUC's configuration
against modification anyway. An attacker with access to either of these
would already have at least the same privileges as RAUC.

Reported-by: Junmin Zhu <junmin@ucsb.edu>