### PR TITLE
data/rauc.service.in: configure Restart and RestartSec

### DIFF
--- a/data/rauc.service.in
+++ b/data/rauc.service.in
@@ -9,3 +9,5 @@ BusName=de.pengutronix.rauc
 ExecStart=@bindir@/rauc --mount=/run/rauc/mnt service
 RuntimeDirectory=rauc/mnt
 MountFlags=slave
+Restart=on-failure
+RestartSec=5min


### PR DESCRIPTION
If the RAUC systemd service ran and then crashed for some reason, it should be restarted.

While this might not strictly be necessary if D-Bus activation is used, it is useful if not.
With the added polling support, having a running RAUC service also becomes more relevant (even though it is still stateless across restarts).

Wait at least 5 seconds to not restart too often.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
