### PR TITLE
test: use Path objects to simplify path operations in pytest tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,7 +31,7 @@ shutil._USE_CP_SENDFILE = False
 meson_build = os.environ.get("MESON_BUILD_DIR")
 if not meson_build:
     raise Exception("Please set MESON_BUILD_DIR to point to the meson build directory.")
-if not os.path.isabs(meson_build):
+if not Path(meson_build).is_absolute():
     meson_build = os.path.abspath(meson_build)
 
 
@@ -48,12 +48,12 @@ def env_setup(monkeysession):
     monkeysession.setenv("TZ", "UTC")
     monkeysession.setenv("DBUS_STARTER_BUS_TYPE", "session")
 
-    os.chdir(f"{os.path.dirname(os.path.abspath(__file__))}")
+    os.chdir(Path(__file__).resolve().parent)
 
 
 @cache
 def meson_buildoptions():
-    with open(os.path.join(meson_build, "meson-info/intro-buildoptions.json")) as f:
+    with open(Path(meson_build) / "meson-info/intro-buildoptions.json") as f:
         data = json.loads(f.read())
 
     return {o["name"]: o for o in data}
@@ -61,7 +61,7 @@ def meson_buildoptions():
 
 @cache
 def string_in_config_h(findstring):
-    with open(os.path.join(meson_build, "config.h")) as f:
+    with open(Path(meson_build) / "config.h") as f:
         if findstring in f.read():
             return True
     return False
@@ -326,11 +326,11 @@ def prepare_softhsm2(tmp_path, softhsm2_mod):
 
 @pytest.fixture(scope="session")
 def pkcs11(tmp_path_factory):
-    if os.path.exists("/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so"):
+    if Path("/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so").exists():
         softhsm2_mod = "/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so"
     else:
         softhsm2_mod = "/usr/lib/softhsm/libsofthsm2.so"
-    if not os.path.exists(softhsm2_mod):
+    if not Path(softhsm2_mod).exists():
         pytest.skip("libsofthsm2.so not available on system")
 
     prepare_softhsm2(tmp_path_factory.mktemp("blub"), softhsm2_mod)
@@ -374,15 +374,15 @@ def dbus_session_bus(tmp_path_factory):
 
 @pytest.fixture
 def create_system_files(env_setup, tmp_path):
-    os.mkdir(tmp_path / "images")
-    open(tmp_path / "images/rootfs-0", mode="w").close()
-    open(tmp_path / "images/rootfs-1", mode="w").close()
-    open(tmp_path / "images/appfs-0", mode="w").close()
-    open(tmp_path / "images/appfs-1", mode="w").close()
-    os.mkdir(tmp_path / "repos")
-    os.mkdir(tmp_path / "repos/files")
-    os.mkdir(tmp_path / "repos/trees")
-    os.mkdir(tmp_path / "repos/composefs")
+    (tmp_path / "images").mkdir()
+    (tmp_path / "images/rootfs-0").touch()
+    (tmp_path / "images/rootfs-1").touch()
+    (tmp_path / "images/appfs-0").touch()
+    (tmp_path / "images/appfs-1").touch()
+    (tmp_path / "repos").mkdir()
+    (tmp_path / "repos/files").mkdir()
+    (tmp_path / "repos/trees").mkdir()
+    (tmp_path / "repos/composefs").mkdir()
     os.symlink(os.path.abspath("bin"), tmp_path / "bin")
     os.symlink(os.path.abspath("openssl-ca"), tmp_path / "openssl-ca")
     os.symlink(os.path.abspath("openssl-enc"), tmp_path / "openssl-enc")
@@ -604,8 +604,8 @@ class System:
             "parent": "rootfs.2",
         }
         # create target devices for third slot group
-        open(self.tmp_path / "images/rootfs-2", mode="w").close()
-        open(self.tmp_path / "images/appfs-2", mode="w").close()
+        (self.tmp_path / "images/rootfs-2").touch()
+        (self.tmp_path / "images/appfs-2").touch()
         # prepare grub env for 3 slots
         run(
             f'grub-editenv {self.tmp_path}/grubenv.test set ORDER="A B C" A_TRY="0" B_TRY="0" C_TRY="0" A_OK="1" B_OK="1" C_OK="1"'

--- a/test/helper.py
+++ b/test/helper.py
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: 2021-2022 Bastian Krause <bst@pengutronix.de>, Pengutronix
 
 import logging
-import os
 import shlex
 import subprocess
+from pathlib import Path
 
 
 def logger_from_command(command):
@@ -14,7 +14,7 @@ def logger_from_command(command):
     python module,
     """
     cmd_parts = command.split()
-    base_cmd = os.path.basename(cmd_parts[0])
+    base_cmd = Path(cmd_parts[0]).name
     try:
         if base_cmd.startswith("python") and cmd_parts[1] == "-m":
             base_cmd = command.split()[2]

--- a/test/test_bundle.py
+++ b/test/test_bundle.py
@@ -17,7 +17,7 @@ def test_bundle(tmp_path):
     assert exitcode == 0
     assert "Creating 'verity' format bundle" in out
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()
 
     out, err, exitcode = run(f"rauc -c test.conf info {tmp_path}/out.raucb")
     assert exitcode == 0
@@ -39,7 +39,7 @@ def test_bundle_args_compat(tmp_path):
     assert exitcode == 0
     assert "Creating 'verity' format bundle" in out
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()
 
     out, err, exitcode = run(f"rauc -c test.conf info {tmp_path}/out.raucb")
     assert exitcode == 0
@@ -60,7 +60,7 @@ def test_bundle_mksquashfs_extra_args(tmp_path):
     assert exitcode == 0
     assert "Creating 'verity' format bundle" in out
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()
 
     out, err, exitcode = run(f"rauc -c test.conf info {tmp_path}/out.raucb")
     assert exitcode == 0
@@ -81,7 +81,7 @@ def test_bundle_pkcs11_key1(tmp_path, pkcs11):
     assert exitcode == 0
     assert "Creating 'verity' format bundle" in out
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()
 
     out, err, exitcode = run(f"rauc -c test.conf info {tmp_path}/out.raucb")
     assert exitcode == 0
@@ -102,7 +102,7 @@ def test_bundle_pkcs11_key2_revoked(tmp_path, pkcs11):
     assert exitcode == 0
     assert "Creating 'verity' format bundle" in out
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()
 
     out, err, exitcode = run(f"rauc -c test.conf info {tmp_path}/out.raucb")
     assert exitcode == 1
@@ -125,7 +125,7 @@ def test_bundle_pkcs11_key_mismatch(tmp_path, pkcs11):
     assert "Creating 'verity' format bundle" in out
     assert "key values mismatch" in err
 
-    assert not os.path.exists(f"{tmp_path}/out.raucb")
+    assert not (tmp_path / "out.raucb").exists()
 
 
 def test_bundle_crypt(tmp_path):
@@ -143,7 +143,7 @@ def test_bundle_crypt(tmp_path):
     assert exitcode == 0
     assert "Creating 'crypt' format bundle" in out
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()
 
     out, err, exitcode = run(f"rauc -c test.conf info {tmp_path}/out.raucb")
     assert exitcode == 0

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 
 from conftest import have_casync, have_desync
@@ -20,7 +19,7 @@ def test_convert(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/casync.raucb")
+    assert (tmp_path / "casync.raucb").exists()
 
 
 @have_casync
@@ -40,7 +39,7 @@ def test_convert_ignore_image(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/casync.raucb")
+    assert (tmp_path / "casync.raucb").exists()
 
 
 @have_casync
@@ -48,7 +47,7 @@ def test_convert_output_exists(tmp_path):
     # copy to tmp path for safe ownership check
     shutil.copyfile("good-bundle.raucb", tmp_path / "good-bundle.raucb")
 
-    open(f"{tmp_path}/casync.raucb", "a").close()
+    (tmp_path / "casync.raucb").touch()
 
     out, err, exitcode = run(
         "rauc"
@@ -61,7 +60,7 @@ def test_convert_output_exists(tmp_path):
     assert exitcode == 1
     assert "already exists" in err
 
-    assert os.path.exists(f"{tmp_path}/casync.raucb")
+    assert (tmp_path / "casync.raucb").exists()
 
 
 @have_casync
@@ -79,7 +78,7 @@ def test_convert_error(tmp_path):
 
     assert exitcode == 1
 
-    assert not os.path.exists(f"{tmp_path}/casync.raucb")
+    assert not (tmp_path / "casync.raucb").exists()
 
 
 @have_casync
@@ -99,8 +98,8 @@ def test_convert_casync_extra_args(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/casync-extra-args.raucb")
-    assert os.path.isdir(f"{tmp_path}/casync-extra-args.castr")
+    assert (tmp_path / "casync-extra-args.raucb").exists()
+    assert (tmp_path / "casync-extra-args.castr").is_dir()
 
 
 @have_casync
@@ -124,8 +123,8 @@ def test_convert_verity(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/casync-verity.raucb")
-    assert os.path.isdir(f"{tmp_path}/casync-verity.castr")
+    assert (tmp_path / "casync-verity.raucb").exists()
+    assert (tmp_path / "casync-verity.castr").is_dir()
 
 
 @have_desync
@@ -148,8 +147,8 @@ def test_convert_desync(tmp_path, system):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/desync.raucb")
-    assert os.path.isdir(f"{tmp_path}/desync.castr")
+    assert (tmp_path / "desync.raucb").exists()
+    assert (tmp_path / "desync.castr").is_dir()
 
 
 @have_desync
@@ -157,7 +156,7 @@ def test_convert_desync_output_exists(tmp_path, system):
     # copy to tmp path for safe ownership check
     shutil.copyfile("good-bundle.raucb", tmp_path / "good-bundle.raucb")
 
-    open(f"{tmp_path}/desync.raucb", "a").close()
+    (tmp_path / "desync.raucb").touch()
 
     system.config["casync"] = {
         "use-desync": "true",
@@ -175,7 +174,7 @@ def test_convert_desync_output_exists(tmp_path, system):
     assert exitcode == 1
     assert "already exists" in err
 
-    assert os.path.exists(f"{tmp_path}/desync.raucb")
+    assert (tmp_path / "desync.raucb").exists()
 
 
 @have_desync
@@ -198,7 +197,7 @@ def test_convert_desync_error(tmp_path, system):
 
     assert exitcode == 1
 
-    assert not os.path.exists(f"{tmp_path}/desync.raucb")
+    assert not (tmp_path / "desync.raucb").exists()
 
 
 @have_desync
@@ -223,4 +222,4 @@ def test_convert_desync_extra_args(tmp_path, system):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/desync-extra-args.raucb")
+    assert (tmp_path / "desync-extra-args.raucb").exists()

--- a/test/test_encrypt.py
+++ b/test/test_encrypt.py
@@ -1,5 +1,3 @@
-import os
-
 from helper import run
 
 
@@ -14,7 +12,7 @@ def test_encrypt_multi_single_cert_pem(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/encrypted.raucb")
+    assert (tmp_path / "encrypted.raucb").exists()
 
 
 def test_encrypt_single_multi_cert_pem(tmp_path):
@@ -27,7 +25,7 @@ def test_encrypt_single_multi_cert_pem(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/encrypted.raucb")
+    assert (tmp_path / "encrypted.raucb").exists()
 
 
 def test_encrypt_single_multi_cert_pem_rsa_ecc_mixed(tmp_path):
@@ -41,12 +39,12 @@ def test_encrypt_single_multi_cert_pem_rsa_ecc_mixed(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/encrypted.raucb")
+    assert (tmp_path / "encrypted.raucb").exists()
 
 
 def test_encrypt_broken_multi_cert_pem(tmp_path):
     with open("openssl-enc/keys/rsa-4096/certs.pem") as infile:
-        with open(f"{tmp_path}/certs.pem", "a") as outfile:
+        with (tmp_path / "certs.pem").open("a") as outfile:
             outfile.writelines(infile.readlines()[:-5])
 
     out, err, exitcode = run(
@@ -58,7 +56,7 @@ def test_encrypt_broken_multi_cert_pem(tmp_path):
 
     assert exitcode == 1
 
-    assert not os.path.exists(f"{tmp_path}/encrypted.raucb")
+    assert not (tmp_path / "encrypted.raucb").exists()
 
 
 def test_encrypt_missing_cert_in_file(tmp_path):
@@ -72,7 +70,7 @@ def test_encrypt_missing_cert_in_file(tmp_path):
     assert exitcode == 1
     assert "Expecting: CERTIFICATE" in err
 
-    assert not os.path.exists(f"{tmp_path}/encrypted.raucb")
+    assert not (tmp_path / "encrypted.raucb").exists()
 
 
 def test_encrypt_verity_bundle(tmp_path):
@@ -86,4 +84,4 @@ def test_encrypt_verity_bundle(tmp_path):
     assert exitcode == 1
     assert "Refused to encrypt input bundle" in err
 
-    assert not os.path.exists(f"{tmp_path}/encrypted.raucb")
+    assert not (tmp_path / "encrypted.raucb").exists()

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 
 from conftest import have_openssl
@@ -16,7 +15,7 @@ def test_extract_signature(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/bundle.sig")
+    assert (tmp_path / "bundle.sig").exists()
 
     out, err, exitcode = run(f"openssl asn1parse -inform DER -in {tmp_path}/bundle.sig -noout")
     assert exitcode == 0
@@ -32,7 +31,7 @@ def test_extract_signature_crypt(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/bundle.sig")
+    assert (tmp_path / "bundle.sig").exists()
 
     out, err, exitcode = run(f"openssl asn1parse -inform DER -in {tmp_path}/bundle.sig -noout")
     assert exitcode == 0
@@ -49,11 +48,11 @@ def test_extract(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/bundle-extract/appfs.img")
-    assert os.path.exists(f"{tmp_path}/bundle-extract/custom_handler.sh")
-    assert os.path.exists(f"{tmp_path}/bundle-extract/hook.sh")
-    assert os.path.exists(f"{tmp_path}/bundle-extract/manifest.raucm")
-    assert os.path.exists(f"{tmp_path}/bundle-extract/rootfs.img")
+    assert (tmp_path / "bundle-extract/appfs.img").exists()
+    assert (tmp_path / "bundle-extract/custom_handler.sh").exists()
+    assert (tmp_path / "bundle-extract/hook.sh").exists()
+    assert (tmp_path / "bundle-extract/manifest.raucm").exists()
+    assert (tmp_path / "bundle-extract/rootfs.img").exists()
 
 
 @have_openssl
@@ -69,8 +68,8 @@ def test_extract_crypt(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/bundle-extract/appfs.img")
-    assert os.path.exists(f"{tmp_path}/bundle-extract/custom_handler.sh")
-    assert os.path.exists(f"{tmp_path}/bundle-extract/hook.sh")
-    assert os.path.exists(f"{tmp_path}/bundle-extract/manifest.raucm")
-    assert os.path.exists(f"{tmp_path}/bundle-extract/rootfs.img")
+    assert (tmp_path / "bundle-extract/appfs.img").exists()
+    assert (tmp_path / "bundle-extract/custom_handler.sh").exists()
+    assert (tmp_path / "bundle-extract/hook.sh").exists()
+    assert (tmp_path / "bundle-extract/manifest.raucm").exists()
+    assert (tmp_path / "bundle-extract/rootfs.img").exists()

--- a/test/test_mount.py
+++ b/test/test_mount.py
@@ -1,5 +1,5 @@
-import os
 import shutil
+from pathlib import Path
 
 from conftest import root
 from helper import run
@@ -15,8 +15,8 @@ def test_mount(tmp_path):
         assert exitcode == 0
         assert "Mounted bundle at /mnt/rauc/bundle" in out
 
-        assert os.path.exists("/mnt/rauc/bundle/manifest.raucm")
-        assert os.path.exists("/mnt/rauc/bundle/rootfs.img")
+        assert Path("/mnt/rauc/bundle/manifest.raucm").exists()
+        assert Path("/mnt/rauc/bundle/rootfs.img").exists()
 
     finally:
         out, err, exitcode = run("umount /mnt/rauc/bundle")

--- a/test/test_replace_signature.py
+++ b/test/test_replace_signature.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 
 from conftest import have_openssl
@@ -20,13 +19,13 @@ def test_replace_signature_plain(tmp_path):
     )
 
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/out1.raucb")
+    assert (tmp_path / "out1.raucb").exists()
 
     out, err, exitcode = run(
         f"rauc --keyring openssl-ca/dev-only-ca.pem extract-signature {tmp_path}/out1.raucb {tmp_path}/bundle.sig"
     )
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/bundle.sig")
+    assert (tmp_path / "bundle.sig").exists()
 
     out, err, exitcode = run(f"openssl asn1parse -inform DER -in {tmp_path}/bundle.sig -noout")
     assert exitcode == 0
@@ -39,7 +38,7 @@ def test_replace_signature_plain(tmp_path):
         "--signing-keyring openssl-ca/dev-only-ca.pem"
     )
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/out2.raucb")
+    assert (tmp_path / "out2.raucb").exists()
 
 
 @have_openssl
@@ -57,13 +56,13 @@ def test_replace_signature_verity(tmp_path):
     )
 
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/out1.raucb")
+    assert (tmp_path / "out1.raucb").exists()
 
     out, err, exitcode = run(
         f"rauc --keyring openssl-ca/dev-only-ca.pem extract-signature {tmp_path}/out1.raucb {tmp_path}/bundle.sig"
     )
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/bundle.sig")
+    assert (tmp_path / "bundle.sig").exists()
 
     out, err, exitcode = run(f"openssl asn1parse -inform DER -in {tmp_path}/bundle.sig -noout")
     assert exitcode == 0
@@ -76,7 +75,7 @@ def test_replace_signature_verity(tmp_path):
         "--signing-keyring openssl-ca/dev-only-ca.pem"
     )
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/out2.raucb")
+    assert (tmp_path / "out2.raucb").exists()
 
 
 @have_openssl
@@ -94,13 +93,13 @@ def test_replace_signature_crypt(tmp_path):
     )
 
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/out1.raucb")
+    assert (tmp_path / "out1.raucb").exists()
 
     out, err, exitcode = run(
         f"rauc --keyring openssl-ca/dev-only-ca.pem extract-signature {tmp_path}/out1.raucb {tmp_path}/bundle.sig"
     )
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/bundle.sig")
+    assert (tmp_path / "bundle.sig").exists()
 
     out, err, exitcode = run(f"openssl asn1parse -inform DER -in {tmp_path}/bundle.sig -noout")
     assert exitcode == 0
@@ -113,7 +112,7 @@ def test_replace_signature_crypt(tmp_path):
         "--signing-keyring openssl-ca/dev-only-ca.pem"
     )
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/out2.raucb")
+    assert (tmp_path / "out2.raucb").exists()
 
 
 @have_openssl
@@ -121,7 +120,7 @@ def test_replace_signature_output_exists(tmp_path):
     # copy to tmp path for safe ownership check
     shutil.copyfile("good-bundle.raucb", tmp_path / "good-bundle.raucb")
 
-    open(f"{tmp_path}/out2.raucb", "a").close()
+    (tmp_path / "out2.raucb").touch()
 
     out, err, exitcode = run(
         "rauc "
@@ -133,13 +132,13 @@ def test_replace_signature_output_exists(tmp_path):
     )
 
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/out1.raucb")
+    assert (tmp_path / "out1.raucb").exists()
 
     out, err, exitcode = run(
         f"rauc --keyring openssl-ca/dev-only-ca.pem extract-signature {tmp_path}/out1.raucb {tmp_path}/bundle.sig"
     )
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/bundle.sig")
+    assert (tmp_path / "bundle.sig").exists()
 
     out, err, exitcode = run(f"openssl asn1parse -inform DER -in {tmp_path}/bundle.sig -noout")
     assert exitcode == 0
@@ -152,7 +151,7 @@ def test_replace_signature_output_exists(tmp_path):
         "--signing-keyring openssl-ca/dev-only-ca.pem"
     )
     assert exitcode == 1
-    assert os.path.exists(f"{tmp_path}/out2.raucb")
+    assert (tmp_path / "out2.raucb").exists()
 
 
 @have_openssl
@@ -170,13 +169,13 @@ def test_replace_signature_bad_keyring(tmp_path):
     )
 
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/out1.raucb")
+    assert (tmp_path / "out1.raucb").exists()
 
     out, err, exitcode = run(
         f"rauc --keyring openssl-ca/dev-only-ca.pem extract-signature {tmp_path}/out1.raucb {tmp_path}/bundle.sig"
     )
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/bundle.sig")
+    assert (tmp_path / "bundle.sig").exists()
 
     out, err, exitcode = run(f"openssl asn1parse -inform DER -in {tmp_path}/bundle.sig -noout")
     assert exitcode == 0
@@ -189,7 +188,7 @@ def test_replace_signature_bad_keyring(tmp_path):
         "--signing-keyring openssl-ca/dev-only-ca.pem"
     )
     assert exitcode == 1
-    assert not os.path.exists(f"{tmp_path}/out2.raucb")
+    assert not (tmp_path / "out2.raucb").exists()
 
 
 @have_openssl
@@ -207,13 +206,13 @@ def test_replace_signature_no_verify(tmp_path):
     )
 
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/out1.raucb")
+    assert (tmp_path / "out1.raucb").exists()
 
     out, err, exitcode = run(
         f"rauc --keyring openssl-ca/dev-only-ca.pem extract-signature {tmp_path}/out1.raucb {tmp_path}/bundle.sig"
     )
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/bundle.sig")
+    assert (tmp_path / "bundle.sig").exists()
 
     out, err, exitcode = run(f"openssl asn1parse -inform DER -in {tmp_path}/bundle.sig -noout")
     assert exitcode == 0
@@ -227,7 +226,7 @@ def test_replace_signature_no_verify(tmp_path):
         "--signing-keyring openssl-ca/dev-only-ca.pem"
     )
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/out2.raucb")
+    assert (tmp_path / "out2.raucb").exists()
 
 
 @have_openssl
@@ -235,14 +234,14 @@ def test_replace_signature_invalid_bundle_signature_output(tmp_path):
     # copy to tmp path for safe ownership check
     shutil.copyfile("good-bundle.raucb", tmp_path / "good-bundle.raucb")
 
-    open(f"{tmp_path}/invalid.raucb", "a").close()
-    open(f"{tmp_path}/invalid.sig", "a").close()
+    (tmp_path / "invalid.raucb").touch()
+    (tmp_path / "invalid.sig").touch()
 
     out, err, exitcode = run(
         f"rauc --keyring openssl-ca/dev-ca.pem extract-signature {tmp_path}/good-bundle.raucb {tmp_path}/bundle.sig"
     )
     assert exitcode == 0
-    assert os.path.exists(f"{tmp_path}/bundle.sig")
+    assert (tmp_path / "bundle.sig").exists()
 
     out, err, exitcode = run(f"openssl asn1parse -inform DER -in {tmp_path}/bundle.sig -noout")
     assert exitcode == 0
@@ -255,7 +254,7 @@ def test_replace_signature_invalid_bundle_signature_output(tmp_path):
         "--signing-keyring openssl-ca/dev-ca.pem"
     )
     assert exitcode == 1
-    assert not os.path.exists(f"{tmp_path}/out.raucb")
+    assert not (tmp_path / "out.raucb").exists()
 
     out, err, exitcode = run(
         "rauc "
@@ -265,7 +264,7 @@ def test_replace_signature_invalid_bundle_signature_output(tmp_path):
         "--signing-keyring openssl-ca/dev-ca.pem"
     )
     assert exitcode == 1
-    assert not os.path.exists(f"{tmp_path}/out.raucb")
+    assert not (tmp_path / "out.raucb").exists()
 
     out, err, exitcode = run(
         "rauc "
@@ -275,7 +274,7 @@ def test_replace_signature_invalid_bundle_signature_output(tmp_path):
         "--signing-keyring openssl-ca/dev-ca.pem"
     )
     assert exitcode == 1
-    assert not os.path.exists(f"{tmp_path}/notexisting/out.raucb")
+    assert not (tmp_path / "notexisting/out.raucb").exists()
 
     out, err, exitcode = run(
         "rauc "
@@ -285,4 +284,4 @@ def test_replace_signature_invalid_bundle_signature_output(tmp_path):
         "--signing-keyring openssl-ca/dev-ca.pem"
     )
     assert exitcode == 1
-    assert os.path.exists(f"{tmp_path}/good-bundle.raucb")
+    assert (tmp_path / "good-bundle.raucb").exists()

--- a/test/test_sign.py
+++ b/test/test_sign.py
@@ -1,5 +1,3 @@
-import os
-
 from conftest import have_faketime
 from helper import run
 
@@ -18,7 +16,7 @@ def test_sign_bundle_expired_cert(tmp_path):
     assert exitcode == 1
     assert "certificate has expired" in err
 
-    assert not os.path.exists(f"{tmp_path}/out.raucb")
+    assert not (tmp_path / "out.raucb").exists()
 
 
 @have_faketime
@@ -35,7 +33,7 @@ def test_sign_bundle_not_yet_valid_cert(tmp_path):
     assert exitcode == 1
     assert "certificate is not yet valid" in err
 
-    assert not os.path.exists(f"{tmp_path}/out.raucb")
+    assert not (tmp_path / "out.raucb").exists()
 
 
 @have_faketime
@@ -51,7 +49,7 @@ def test_sign_bundle_almost_expired_cert(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()
 
 
 @have_faketime
@@ -67,7 +65,7 @@ def test_sign_bundle_valid_cert(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()
 
 
 @have_faketime
@@ -84,4 +82,4 @@ def test_sign_bundle_valid_cert_encrypted_key(tmp_path, monkeypatch):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 
 from conftest import have_faketime
@@ -10,7 +9,7 @@ pytestmark = have_faketime
 
 def prepare_signing_time_conf(tmp_path):
     shutil.copyfile("openssl-ca/dev-ca.pem", tmp_path / "test-ca.pem")
-    with open(f"{tmp_path}/use-bundle-signing-time.conf", "a") as f:
+    with (tmp_path / "use-bundle-signing-time.conf").open("a") as f:
         f.write("""
 [system]
 compatible=Test Config
@@ -38,7 +37,7 @@ def test_verify_with_use_bundle_signing_time_valid_signing_invalid_current(tmp_p
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()
 
     out, err, exitcode = run(
         f'faketime "2022-01-01" rauc --conf {tmp_path}/use-bundle-signing-time.conf info {tmp_path}/out.raucb'
@@ -61,7 +60,7 @@ def test_verify_with_use_bundle_signing_time_invalid_signing_valid_current(tmp_p
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()
 
     out, err, exitcode = run(
         f'faketime "2018-01-01" rauc --conf {tmp_path}/use-bundle-signing-time.conf info {tmp_path}/out.raucb'
@@ -83,7 +82,7 @@ def test_info_no_check_time(tmp_path):
 
     assert exitcode == 0
 
-    assert os.path.exists(f"{tmp_path}/out.raucb")
+    assert (tmp_path / "out.raucb").exists()
 
     out, err, exitcode = run(f'faketime "2018-01-01" rauc --keyring openssl-ca/rel-ca.pem info {tmp_path}/out.raucb')
 


### PR DESCRIPTION
Replace string-based path operations with equivalent `pathlib.Path` methods where the behavior is unchanged:

- `os.path.exists(f"{tmp_path}/file")` → `(tmp_path / "file").exists()`
- `os.path.isdir(f"{tmp_path}/dir")` → `(tmp_path / "dir").is_dir()`
- `open(f"{tmp_path}/file", "a").close()` → `(tmp_path / "file").touch()`
- `open(tmp_path / "file", mode="w").close()` → `(tmp_path / "file").touch()`
- `os.mkdir(tmp_path / "dir")` → `(tmp_path / "dir").mkdir()`
- `os.path.join(base, "file")` → `Path(base) / "file"`
- `os.path.isabs(path)` → `Path(path).is_absolute()`
- `os.path.basename(path)` → `Path(path).name`
- `os.chdir(os.path.dirname(os.path.abspath(__file__)))` → `os.chdir(Path(__file__).resolve().parent)`
- `open(f"{tmp_path}/conf", "a") as f` → `(tmp_path / "conf").open("a") as f`

Remove now-unused `import os` from files where `os` is no longer referenced.

Further cleanup to reduce repeated construction of the same path can be done in a follow-up commit.