### PR TITLE
qemu-test: add SSH access support for the test VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@
 /.qemu_gdb_history
 /qemu-test-ok
 /qemu-test-emmc.img
+/.qemu-test-ssh-key
+/.qemu-test-ssh-key.pub
+/.qemu-test-ssh-host-key
+/.qemu-test-ssh-host-key.pub
+/.qemu-test-qmp
+/.qemu-test-pid
+/qemu-test-log
 app.info
 /bzImage
 .ccls-cache

--- a/.qemu-test-sshd-config
+++ b/.qemu-test-sshd-config
@@ -1,0 +1,10 @@
+Port 22
+HostKey /etc/ssh/ssh_host_ed25519_key
+AuthorizedKeysFile /root/.ssh/authorized_keys
+PermitRootLogin prohibit-password
+PermitUserEnvironment yes
+StrictModes no
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+UsePAM no
+Subsystem sftp /usr/lib/openssh/sftp-server

--- a/qemu-ssh
+++ b/qemu-ssh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Helper script to connect via SSH to a running qemu-test VM
+#
+# Usage: ./qemu-ssh [ssh-arguments...]
+#
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+exec ssh \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o LogLevel=ERROR \
+  -o IdentitiesOnly=yes \
+  -i "$SCRIPT_DIR/.qemu-test-ssh-key" \
+  -p 2222 \
+  root@127.0.0.1 \
+  "$@"

--- a/qemu-test
+++ b/qemu-test
@@ -17,6 +17,8 @@
 #   system            Setup qemu dummy system that behaves like a target (without reboot!)
 #   service-backtrace Run service under gdb and show backtrace on error (requires 'system')
 #   asan              Set environment variables to support address sanitizer
+#   ssh               Enable SSH access to the VM (port 2222)
+#   background        Run the VM in the background (implies ssh, use qemu-test-stop to stop)
 #   test=<test>       Run specified test (for use with git bisect)
 #
 # When no argument is given, the default test suite will be executed
@@ -57,11 +59,18 @@ fi
 
 QEMU_ARGS=""
 BOOTNAME="system0"
+SSH=0
+BACKGROUND=0
 for x in "$@"; do
   if [ "$x" = "passthrough" ]; then
     QEMU_ARGS="$QEMU_ARGS -cpu host"
   elif [ "$x" = "system" ]; then
     BOOTNAME="A"
+  elif [ "$x" = "ssh" ]; then
+    SSH=1
+  elif [ "$x" = "background" ]; then
+    BACKGROUND=1
+    SSH=1
   fi
 done
 
@@ -84,16 +93,41 @@ if "$QEMU_BIN" -device help | grep -q 'name "emmc"'; then
   QEMU_ARGS="$QEMU_ARGS -device emmc,id=emmc0,drive=emmc-drive,boot-partition-size=1048576"
 fi
 
+NIC_ARGS="-nic user,model=virtio-net-pci"
+if [ "$SSH" = "1" ]; then
+  # When QEMU v10.2.0 is widely available, we could use -hostfwd=unix: instead.
+  NIC_ARGS="-nic user,model=virtio-net-pci,hostfwd=tcp:127.0.0.1:2222-:22"
+  if [ ! -f .qemu-test-ssh-key ]; then
+    ssh-keygen -t ed25519 -f .qemu-test-ssh-key -N "" -C "qemu-test"
+  fi
+  if [ ! -f .qemu-test-ssh-host-key ]; then
+    ssh-keygen -t ed25519 -f .qemu-test-ssh-host-key -N ""
+  fi
+fi
+
+QEMU_ARGS="$QEMU_ARGS -qmp unix:.qemu-test-qmp,server,nowait"
+
+if [ "$BACKGROUND" = "1" ]; then
+  QEMU_ARGS="$QEMU_ARGS -display none -serial file:qemu-test-log -daemonize -pidfile .qemu-test-pid"
+else
+  QEMU_ARGS="$QEMU_ARGS -nographic -serial mon:stdio"
+fi
+
 $QEMU_BIN \
   $QEMU_ARGS \
   -machine q35 \
   -m 1G \
   -smp 2 \
   -kernel bzImage \
-  -nographic -serial mon:stdio \
   -no-reboot \
   -virtfs local,id=rootfs,path=/,security_model=none,mount_tag=/dev/root,multidevs=remap \
-  -nic user,model=virtio-net-pci \
+  $NIC_ARGS \
   -append "loglevel=6 console=ttyS0 nandsim.id_bytes=0x20,0xa2,0x00,0x15 nandsim.parts=0x100 mtdram.total_size=32768 root=/dev/root rootfstype=9p rootflags=msize=16777216 rw init=$(pwd)/qemu-test-init rauc.slot=$BOOTNAME $*"
 
-test -f qemu-test-ok
+if [ "$BACKGROUND" = "1" ]; then
+  echo "QEMU started in background (PID $(cat .qemu-test-pid))"
+  echo "  Stop VM: ./qemu-test-stop"
+  echo "  Log file: qemu-test-log"
+else
+  test -f qemu-test-ok
+fi

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -257,12 +257,12 @@ if [ -n "$SERVICE" ]; then
 fi
 
 echo "alias ll='ls -l'" > /root/.bashrc
+ln -s "$(pwd)/.qemu_bash_history" /root/.bash_history
 if [ -n "$INTERACTIVE_SHELL" ]; then
   BASH_CMD="exec bash"
   if type resize; then
     BASH_CMD="eval \$(resize); $BASH_CMD"
   fi
-  HISTFILE="$(pwd)/.qemu_bash_history" \
   setsid bash -c "$BASH_CMD" </dev/ttyS0 >/dev/ttyS0 2>&1 || echo exit-code=$?
   if [ -n "$GCOV_PREFIX" ]; then
     save_gcov_data

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -17,6 +17,10 @@ mount -t tmpfs none /tmp
 mkdir /dev/shm
 mount -t tmpfs none /dev/shm
 
+# create /dev/pts for ssh
+mkdir /dev/pts
+mount -t devpts none /dev/pts
+
 # create overlay for /etc
 mkdir /tmp/etc-overlay /tmp/etc-work
 mount -t overlay overlay -o lowerdir=/etc,upperdir=/tmp/etc-overlay,workdir=/tmp/etc-work /etc
@@ -43,6 +47,12 @@ for x in "$@"; do
     export SERVICE_BACKTRACE=1
   elif [ "$x" = "service-poll" ]; then
     export SERVICE_POLL=1
+  elif [ "$x" = "ssh" ]; then
+    SSH=1
+  elif [ "$x" = "background" ]; then
+    INTERACTIVE_SHELL=1
+    BACKGROUND=1
+    SSH=1
   fi
 done
 
@@ -63,6 +73,36 @@ rm -f /etc/resolv.conf
 echo "nameserver 10.0.2.3" > /etc/resolv.conf
 
 export HOME="/root"
+
+# setup SSH server if requested
+if [ -n "$SSH" ]; then
+  # clean up motd
+  echo "= RAUC qemu-test VM =" > /etc/motd
+
+  # make shadow readable in the guest and add root entry
+  echo 'root:*:::::::' > /etc/shadow
+
+  # setup login for root
+  mkdir -p /root/.ssh
+  chmod 700 /root/.ssh
+  cp "$(pwd)/.qemu-test-ssh-key.pub" /root/.ssh/authorized_keys
+  chmod 600 /root/.ssh/authorized_keys
+
+  # prepare sshd config
+  cp "$(pwd)/.qemu-test-sshd-config" /etc/ssh/sshd_config
+
+  # generate host key (remove any existing key from the host overlay)
+  rm -f /etc/ssh/ssh_host_*_key /etc/ssh/ssh_host_*_key.pub
+  cp "$(pwd)/.qemu-test-ssh-host-key" /etc/ssh/ssh_host_ed25519_key
+  cp "$(pwd)/.qemu-test-ssh-host-key.pub" /etc/ssh/ssh_host_ed25519_key.pub
+
+  # ensure privilege separation directory exists
+  mkdir -p /run/sshd
+
+  # start sshd
+  /usr/sbin/sshd
+  echo "SSH server started on port 22 (host port 2222)"
+fi
 
 # allow git access to our repo
 git config --system --add safe.directory "$(pwd)"
@@ -258,7 +298,10 @@ fi
 
 echo "alias ll='ls -l'" > /root/.bashrc
 ln -s "$(pwd)/.qemu_bash_history" /root/.bash_history
-if [ -n "$INTERACTIVE_SHELL" ]; then
+if [ -n "$BACKGROUND" ]; then
+  # in background mode, just wait (VM is controlled via SSH/QMP)
+  while true; do sleep 3600; done
+elif [ -n "$INTERACTIVE_SHELL" ]; then
   BASH_CMD="exec bash"
   if type resize; then
     BASH_CMD="eval \$(resize); $BASH_CMD"

--- a/qemu-test-init
+++ b/qemu-test-init
@@ -256,9 +256,9 @@ if [ -n "$SERVICE" ]; then
   rauc status mark-good
 fi
 
+echo "alias ll='ls -l'" > /root/.bashrc
 if [ -n "$INTERACTIVE_SHELL" ]; then
-  echo "alias ll='ls -l'" >> /tmp/bashrc
-  BASH_CMD="exec bash --rcfile /tmp/bashrc"
+  BASH_CMD="exec bash"
   if type resize; then
     BASH_CMD="eval \$(resize); $BASH_CMD"
   fi

--- a/qemu-test-stop
+++ b/qemu-test-stop
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Helper script to stop a running qemu-test VM via QMP
+#
+# Usage: ./qemu-test-stop
+#
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+QMP_SOCK="$SCRIPT_DIR/.qemu-test-qmp"
+
+if [ ! -S "$QMP_SOCK" ]; then
+  echo "error: QMP socket not found at $QMP_SOCK" >&2
+  echo "Is the VM running?" >&2
+  exit 1
+fi
+
+# QMP requires a capabilities negotiation handshake before sending commands.
+# We send qmp_capabilities first, then quit.
+printf '{"execute": "qmp_capabilities"}\n{"execute": "quit"}\n' | \
+  socat - UNIX-CONNECT:"$QMP_SOCK"


### PR DESCRIPTION
Add an `ssh` option to `qemu-test` that enables SSH access into the running QEMU VM on port 2222. When used, this:

- Generates an ed25519 keypairs (host and user) on first use
- Forwards host port 2222 to guest port 22
- Configures and starts `sshd` inside the guest
- Sets up authorized_keys for root in the guest

A `qemu-ssh` helper script is provided to connect with all necessary options pre-configured.

Also add a `background` option that starts the VM as a daemon with serial output redirected to `qemu-test-log`. This also implies starting the ssh daemon. A QMP unix socket (`.qemu-test-qmp`) is always set up to allow VM control.

The `qemu-test-stop` helper script sends the QMP quit command via `socat` to gracefully shut down the VM.

Usage:
```
  ./qemu-test shell ssh   # start VM with SSH enabled
  ./qemu-test background  # start VM in background with SSH enabled
  ./qemu-ssh              # connect to the running VM
  tail -f qemu-test-log   # watch serial output (background mode)
  ./qemu-test-stop        # stop the VM (background mode)
```