### PR TITLE
Add optional password prompting for Basic Auth and mask credentials in log output

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -499,7 +499,8 @@ Authentication
 ~~~~~~~~~~~~~~
 
 To use Basic Authentication, you can add the username and password to the bundle
-URL (``rauc install https//user:password@example.com/update.raucb``).
+URL (``rauc install https://user:password@example.com/update.raucb``).
+The password is masked as ``******`` in log output to avoid leaking credentials.
 
 To pass HTTP headers for authentication, use the ``--http-header='HEADER:
 VALUE'`` option of ``rauc install`` or set them via the ``http-headers`` options

--- a/include/utils.h
+++ b/include/utils.h
@@ -549,6 +549,32 @@ gchar *r_regex_match_simple(const gchar *pattern, const gchar *string)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Injects HTTP Basic Auth credentials into a URL.
+ *
+ * Produces a URL of the form ``scheme://user:password@host/path`` suitable for
+ * use with libcurl.  Two calling patterns are supported:
+ *
+ * - URL already contains a username (``scheme://user@host/path``): @user must
+ *   be NULL or match the username in the URL; the password is inserted before
+ *   the ``@``.
+ * - URL has no userinfo (``scheme://host/path``): @user must be provided; both
+ *   username and password are inserted after ``://``.
+ *
+ * Returns NULL and sets @error if the URL already contains a password, if
+ * @user conflicts with the username already in the URL, or if no username is
+ * available.
+ *
+ * @param url the base URL
+ * @param user the HTTP username, or NULL if already embedded in @url
+ * @param password the HTTP password to inject
+ * @param error return location for a GError, or NULL
+ *
+ * @return newly-allocated URL string with credentials embedded, or NULL on error
+ */
+gchar *r_url_inject_password(const gchar *url, const gchar *user, const gchar *password, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
  * Returns a copy of a URL with any embedded password replaced by '******'.
  *
  * This is intended for use in log messages to avoid leaking credentials.

--- a/include/utils.h
+++ b/include/utils.h
@@ -549,6 +549,21 @@ gchar *r_regex_match_simple(const gchar *pattern, const gchar *string)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Returns a copy of a URL with any embedded password replaced by '******'.
+ *
+ * This is intended for use in log messages to avoid leaking credentials.
+ * URLs of the form ``scheme://user:password@host/path`` are handled; URLs
+ * without a password are returned unchanged.
+ *
+ * @param url the URL to censor
+ *
+ * @return newly-allocated string with the password replaced, or a copy of the
+ *         original URL if it contained no embedded password
+ */
+gchar *r_censor_url(const gchar *url)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
  * Reads CLOCK_BOOTTIME via clock_gettime().
  *
  * @return the time value in microseconds

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -2343,7 +2343,8 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleP
 			ibundle->nbd_srv->tls_ca = g_strdup(r_context()->config->streaming_tls_ca);
 		res = r_nbd_start_server(ibundle->nbd_srv, &ierror);
 		if (!res) {
-			g_propagate_prefixed_error(error, ierror, "Failed to stream bundle %s: ", ibundle->path);
+			g_autofree gchar *censored = r_censor_url(ibundle->path);
+			g_propagate_prefixed_error(error, ierror, "Failed to stream bundle %s: ", censored);
 			goto out;
 		}
 #elif ENABLE_NETWORK
@@ -2360,7 +2361,8 @@ gboolean check_bundle(const gchar *bundlename, RaucBundle **bundle, CheckBundleP
 		g_message("Remote URI detected, downloading bundle to %s...", ibundle->path);
 		res = download_file(ibundle->path, ibundle->origpath, r_context()->config->max_bundle_download_size, &ierror);
 		if (!res) {
-			g_propagate_prefixed_error(error, ierror, "Failed to download bundle %s: ", ibundle->origpath);
+			g_autofree gchar *censored = r_censor_url(ibundle->origpath);
+			g_propagate_prefixed_error(error, ierror, "Failed to download bundle %s: ", censored);
 			goto out;
 		}
 		g_debug("Downloaded temp bundle to %s", ibundle->path);

--- a/src/main.c
+++ b/src/main.c
@@ -58,6 +58,8 @@ gchar *require_manifest_hash = NULL;
 gchar *write_slot_image_type = NULL;
 gboolean utf8_supported = FALSE;
 RaucBundleAccessArgs access_args = {0};
+static gchar *http_user = NULL;
+static gboolean ask_password = FALSE;
 
 static gchar* make_progress_line(gint percentage)
 {
@@ -237,6 +239,33 @@ static gboolean on_sigint_noop(gpointer user_data)
 	return G_SOURCE_CONTINUE;
 }
 
+/* Prompts for an HTTP password and rewrites *url with credentials embedded.
+ * Does nothing and returns TRUE if --ask-password was not given.
+ * The original *url is freed and replaced on success. */
+static gboolean apply_http_password(gchar **url, GError **error)
+{
+	g_return_val_if_fail(url && *url, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (!ask_password)
+		return TRUE;
+
+	const gchar *password = getpass("HTTP password: ");
+	if (!password) {
+		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED,
+				"Failed to read password (is a terminal available?)");
+		return FALSE;
+	}
+
+	g_autofree gchar *new_url = r_url_inject_password(*url, http_user, password, error);
+	if (!new_url)
+		return FALSE;
+
+	g_free(*url);
+	*url = g_steal_pointer(&new_url);
+	return TRUE;
+}
+
 static gboolean install_start(int argc, char **argv)
 {
 	GBusType bus_type = (!g_strcmp0(g_getenv("DBUS_STARTER_BUS_TYPE"), "session"))
@@ -272,6 +301,11 @@ static gboolean install_start(int argc, char **argv)
 	bundlelocation = resolve_bundle_path(argv[2]);
 	if (bundlelocation == NULL)
 		goto out;
+	if (!apply_http_password(&bundlelocation, &error)) {
+		g_printerr("%s\n", error->message);
+		g_clear_error(&error);
+		goto out;
+	}
 	{
 		g_autofree gchar *censored = r_censor_url(bundlelocation);
 		g_debug("input bundle: %s", censored);
@@ -1360,6 +1394,11 @@ static gboolean info_start(int argc, char **argv)
 	bundlelocation = resolve_bundle_path(argv[2]);
 	if (bundlelocation == NULL)
 		goto out;
+	if (!apply_http_password(&bundlelocation, &error)) {
+		g_printerr("%s\n", error->message);
+		g_clear_error(&error);
+		goto out;
+	}
 	{
 		g_autofree gchar *censored = r_censor_url(bundlelocation);
 		g_debug("input bundle: %s", censored);
@@ -2692,6 +2731,8 @@ static GOptionEntry entries_bundle_access[] = {
 	{"tls-ca", '\0', 0, G_OPTION_ARG_FILENAME, &access_args.tls_ca, "TLS CA file", "PEMFILE"},
 	{"tls-no-verify", '\0', 0, G_OPTION_ARG_NONE, &access_args.tls_no_verify, "do not verify TLS server certificate", NULL},
 	{"http-header", 'H', 0, G_OPTION_ARG_STRING_ARRAY, &access_args.http_headers, "HTTP request header (multiple uses supported)", "'HEADER: VALUE'"},
+	{"http-user", '\0', 0, G_OPTION_ARG_STRING, &http_user, "HTTP username (for Basic Auth)", "USER"},
+	{"ask-password", '\0', 0, G_OPTION_ARG_NONE, &ask_password, "prompt for HTTP password (for Basic Auth)", NULL},
 	{0}
 };
 

--- a/src/main.c
+++ b/src/main.c
@@ -272,7 +272,10 @@ static gboolean install_start(int argc, char **argv)
 	bundlelocation = resolve_bundle_path(argv[2]);
 	if (bundlelocation == NULL)
 		goto out;
-	g_debug("input bundle: %s", bundlelocation);
+	{
+		g_autofree gchar *censored = r_censor_url(bundlelocation);
+		g_debug("input bundle: %s", censored);
+	}
 
 	args = install_args_new();
 	args->name = g_steal_pointer(&bundlelocation);
@@ -1357,7 +1360,10 @@ static gboolean info_start(int argc, char **argv)
 	bundlelocation = resolve_bundle_path(argv[2]);
 	if (bundlelocation == NULL)
 		goto out;
-	g_debug("input bundle: %s", bundlelocation);
+	{
+		g_autofree gchar *censored = r_censor_url(bundlelocation);
+		g_debug("input bundle: %s", censored);
+	}
 
 	if (verification_disabled)
 		check_bundle_params |= CHECK_BUNDLE_NO_VERIFY;
@@ -2509,7 +2515,10 @@ static gboolean mount_start(int argc, char **argv)
 	bundlelocation = resolve_bundle_path(argv[2]);
 	if (bundlelocation == NULL)
 		goto out; /* an error message was already printed by resolve_bundle_path */
-	g_debug("input bundle: %s", bundlelocation);
+	{
+		g_autofree gchar *censored = r_censor_url(bundlelocation);
+		g_debug("input bundle: %s", censored);
+	}
 
 	res = check_bundle(bundlelocation, &bundle, CHECK_BUNDLE_DEFAULT, NULL, &error);
 	if (!res) {

--- a/src/nbd.c
+++ b/src/nbd.c
@@ -628,7 +628,8 @@ static void start_configure(struct RaucNBDContext *ctx, struct RaucNBDTransfer *
 		g_assert_nonnull(v);
 		{
 			g_autofree gchar *tmp = g_variant_print(v, TRUE);
-			g_message("nbd server received configuration: %s", tmp);
+			g_autofree gchar *censored = r_censor_url(tmp);
+			g_message("nbd server received configuration: %s", censored);
 		}
 
 		g_variant_dict_init(&dict, v);
@@ -650,7 +651,10 @@ static void start_configure(struct RaucNBDContext *ctx, struct RaucNBDTransfer *
 		}
 	}
 
-	g_message("nbd server configuring for URL: %s", ctx->url);
+	{
+		g_autofree gchar *censored = r_censor_url(ctx->url);
+		g_message("nbd server configuring for URL: %s", censored);
+	}
 
 	prepare_curl(xfer);
 	if (ctx->initial_headers_slist) {
@@ -807,8 +811,11 @@ static gboolean finish_configure(struct RaucNBDContext *ctx, struct RaucNBDTrans
 
 	code = curl_easy_getinfo(xfer->easy, CURLINFO_EFFECTIVE_URL, &effective_url);
 	if (code == CURLE_OK) {
-		if (!g_str_equal(ctx->url, effective_url))
-			g_message("redirected from %s to %s", ctx->url, effective_url);
+		if (!g_str_equal(ctx->url, effective_url)) {
+			g_autofree gchar *censored_from = r_censor_url(ctx->url);
+			g_autofree gchar *censored_to = r_censor_url(effective_url);
+			g_message("redirected from %s to %s", censored_from, censored_to);
+		}
 		g_free(ctx->url);
 		ctx->url = g_strdup(effective_url);
 	}

--- a/src/polling.c
+++ b/src/polling.c
@@ -274,10 +274,13 @@ static gboolean polling_install_cleanup(gpointer data)
 	polling_context->installation_running = FALSE;
 
 	g_mutex_lock(&args->status_mutex);
-	if (args->status_result == 0) {
-		g_message("polling: installation of `%s` succeeded", args->name);
-	} else {
-		g_message("polling: installation of `%s` failed: %d", args->name, args->status_result);
+	{
+		g_autofree gchar *censored = r_censor_url(args->name);
+		if (args->status_result == 0) {
+			g_message("polling: installation of `%s` succeeded", censored);
+		} else {
+			g_message("polling: installation of `%s` failed: %d", censored, args->status_result);
+		}
 	}
 	/* TODO expose error via d-bus? */
 	r_installer_emit_completed(r_installer, args->status_result);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1162,6 +1162,72 @@ gchar *r_censor_url(const gchar *url)
 	return g_regex_replace(regex, url, -1, 0, "\\1******\\2", 0, NULL);
 }
 
+gchar *r_url_inject_password(const gchar *url, const gchar *user, const gchar *password, GError **error)
+{
+	g_return_val_if_fail(url, NULL);
+	g_return_val_if_fail(password, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	/* Locate the authority section (after "://") */
+	const gchar *authority = strstr(url, "://");
+	if (!authority) {
+		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+				"URL has no scheme: %s", url);
+		return NULL;
+	}
+	authority += 3;
+
+	/* Find the end of the authority (first '/' or end of string) */
+	const gchar *path_start = strchr(authority, '/');
+	if (!path_start)
+		path_start = authority + strlen(authority);
+
+	/* Find the last '@' within the authority — indicates existing userinfo */
+	const gchar *at = NULL;
+	for (const gchar *p = authority; p < path_start; p++) {
+		if (*p == '@')
+			at = p;
+	}
+
+	if (at) {
+		/* URL already has userinfo before '@' */
+		for (const gchar *p = authority; p < at; p++) {
+			if (*p == ':') {
+				g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+						"URL already contains a password");
+				return NULL;
+			}
+		}
+		if (user) {
+			g_autofree gchar *url_user = g_strndup(authority, at - authority);
+			if (!g_str_equal(url_user, user)) {
+				g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+						"--http-user '%s' conflicts with username '%s' in URL",
+						user, url_user);
+				return NULL;
+			}
+		}
+		/* inject ":password" before the '@' */
+		return g_strdup_printf("%.*s:%s%s",
+				(int)(at - url), url,
+				password,
+				at);
+	} else {
+		/* no userinfo in URL — user must be supplied via --http-user */
+		if (!user) {
+			g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+					"URL contains no username; use --http-user to provide one");
+			return NULL;
+		}
+		/* inject "user:password@" after "://" */
+		return g_strdup_printf("%.*s%s:%s@%s",
+				(int)(authority - url), url,
+				user,
+				password,
+				authority);
+	}
+}
+
 gint64 r_get_boottime(void)
 {
 	struct timespec ts = {0};

--- a/src/utils.c
+++ b/src/utils.c
@@ -1154,6 +1154,14 @@ gchar *r_regex_match_simple(const gchar *pattern, const gchar *string)
 	return NULL;
 }
 
+gchar *r_censor_url(const gchar *url)
+{
+	g_return_val_if_fail(url, NULL);
+
+	g_autoptr(GRegex) regex = g_regex_new("(https?://[^:@/]+:)[^/]*(@)", 0, 0, NULL);
+	return g_regex_replace(regex, url, -1, 0, "\\1******\\2", 0, NULL);
+}
+
 gint64 r_get_boottime(void)
 {
 	struct timespec ts = {0};

--- a/test/utils.c
+++ b/test/utils.c
@@ -555,6 +555,49 @@ static void boottime_test(void)
 	g_assert_cmpint(diff, <=, 110000);
 }
 
+static void censor_url_test(void)
+{
+	/* password is masked */
+	{
+		g_autofree gchar *out = r_censor_url("http://user:secret@example.com/bundle.raucb");
+		g_assert_cmpstr(out, ==, "http://user:******@example.com/bundle.raucb");
+	}
+	{
+		g_autofree gchar *out = r_censor_url("https://user:secret@example.com/bundle.raucb");
+		g_assert_cmpstr(out, ==, "https://user:******@example.com/bundle.raucb");
+	}
+
+	/* password containing '@' is masked up to the last '@' */
+	{
+		g_autofree gchar *out = r_censor_url("https://alice:p@ssw0rd@server.local/update.raucb");
+		g_assert_cmpstr(out, ==, "https://alice:******@server.local/update.raucb");
+	}
+
+	/* percent-encoded '@' in password */
+	{
+		g_autofree gchar *out = r_censor_url("https://alice:p%40ssw0rd@server.local/update.raucb");
+		g_assert_cmpstr(out, ==, "https://alice:******@server.local/update.raucb");
+	}
+
+	/* no credentials — returned unchanged */
+	{
+		g_autofree gchar *out = r_censor_url("https://example.com/bundle.raucb");
+		g_assert_cmpstr(out, ==, "https://example.com/bundle.raucb");
+	}
+
+	/* username only, no password — returned unchanged */
+	{
+		g_autofree gchar *out = r_censor_url("http://user@example.com/bundle.raucb");
+		g_assert_cmpstr(out, ==, "http://user@example.com/bundle.raucb");
+	}
+
+	/* URL embedded in a GVariant dict string (as logged by the nbd server) */
+	{
+		g_autofree gchar *out = r_censor_url("{'url': <'https://admin:topsecret@rauc.example.com/bundle.raucb'>, 'cert': <''>}");
+		g_assert_cmpstr(out, ==, "{'url': <'https://admin:******@rauc.example.com/bundle.raucb'>, 'cert': <''>}");
+	}
+}
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -574,6 +617,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/utils/semver_less_equal_test", semver_less_equal_test);
 	g_test_add_func("/utils/format_duration", format_duration_test);
 	g_test_add_func("/utils/regex_match", regex_match_test);
+	g_test_add_func("/utils/censor_url", censor_url_test);
 	g_test_add_func("/utils/tempfile_cleanup", tempfile_cleanup_test);
 	g_test_add_func("/utils/boottime", boottime_test);
 

--- a/test/utils.c
+++ b/test/utils.c
@@ -555,6 +555,63 @@ static void boottime_test(void)
 	g_assert_cmpint(diff, <=, 110000);
 }
 
+static void inject_password_test(void)
+{
+	GError *error = NULL;
+
+	/* username in URL, no --http-user */
+	{
+		g_autofree gchar *out = r_url_inject_password("https://alice@server.local/bundle.raucb", NULL, "s3cr3t", &error);
+		g_assert_no_error(error);
+		g_assert_cmpstr(out, ==, "https://alice:s3cr3t@server.local/bundle.raucb");
+	}
+
+	/* no userinfo in URL, username via argument */
+	{
+		g_autofree gchar *out = r_url_inject_password("https://server.local/bundle.raucb", "alice", "s3cr3t", &error);
+		g_assert_no_error(error);
+		g_assert_cmpstr(out, ==, "https://alice:s3cr3t@server.local/bundle.raucb");
+	}
+
+	/* username in URL matches --http-user */
+	{
+		g_autofree gchar *out = r_url_inject_password("https://alice@server.local/bundle.raucb", "alice", "s3cr3t", &error);
+		g_assert_no_error(error);
+		g_assert_cmpstr(out, ==, "https://alice:s3cr3t@server.local/bundle.raucb");
+	}
+
+	/* password with '@' in it */
+	{
+		g_autofree gchar *out = r_url_inject_password("https://alice@server.local/bundle.raucb", NULL, "p@ss", &error);
+		g_assert_no_error(error);
+		g_assert_cmpstr(out, ==, "https://alice:p@ss@server.local/bundle.raucb");
+	}
+
+	/* error: URL already has a password */
+	{
+		g_autofree gchar *out = r_url_inject_password("https://alice:existing@server.local/bundle.raucb", NULL, "s3cr3t", &error);
+		g_assert_null(out);
+		g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT);
+		g_clear_error(&error);
+	}
+
+	/* error: no username in URL and no --http-user */
+	{
+		g_autofree gchar *out = r_url_inject_password("https://server.local/bundle.raucb", NULL, "s3cr3t", &error);
+		g_assert_null(out);
+		g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT);
+		g_clear_error(&error);
+	}
+
+	/* error: --http-user conflicts with username in URL */
+	{
+		g_autofree gchar *out = r_url_inject_password("https://alice@server.local/bundle.raucb", "bob", "s3cr3t", &error);
+		g_assert_null(out);
+		g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT);
+		g_clear_error(&error);
+	}
+}
+
 static void censor_url_test(void)
 {
 	/* password is masked */
@@ -617,6 +674,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/utils/semver_less_equal_test", semver_less_equal_test);
 	g_test_add_func("/utils/format_duration", format_duration_test);
 	g_test_add_func("/utils/regex_match", regex_match_test);
+	g_test_add_func("/utils/inject_password", inject_password_test);
 	g_test_add_func("/utils/censor_url", censor_url_test);
 	g_test_add_func("/utils/tempfile_cleanup", tempfile_cleanup_test);
 	g_test_add_func("/utils/boottime", boottime_test);


### PR DESCRIPTION
This PR improves handling of HTTP Basic Authentication for remote bundle access to avoid leaking credentials in logs and also provides a secure way for users to supply passwords interactively with `rauc status` and `rauc info` instead of embedding them in the URL in cmdline arguments which may be logged and thus leak.


Draft as I haven't fully checked all code paths yet. Please let me know if you don't think this is useful and I will close it.