### PR TITLE
src/install: make RAUC_SYSTEM_COMPATIBLE available to system handlers

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1656,6 +1656,10 @@ variables.
   Path to the chosen system configuration file (e.g. ``/usr/lib/rauc/system.conf``
   if not overridden by a file in ``/etc`` or ``/run``)
 
+``RAUC_SYSTEM_COMPATIBLE``
+  The compatible value set in the system configuration file,
+  e.g. ``"My First Product"``
+
 ``RAUC_SYSTEM_VARIANT``
   The system's variant as obtained by the variant source
   (refer :ref:`sec-variants`)

--- a/src/install.c
+++ b/src/install.c
@@ -684,6 +684,7 @@ static gchar **add_system_environment(gchar **envp)
 	g_return_val_if_fail(envp, NULL);
 
 	envp = g_environ_setenv(envp, "RAUC_SYSTEM_CONFIG", r_context()->configpath, TRUE);
+	envp = g_environ_setenv(envp, "RAUC_SYSTEM_COMPATIBLE", r_context()->config->system_compatible ?: "", TRUE);
 	envp = g_environ_setenv(envp, "RAUC_SYSTEM_VARIANT", r_context()->config->system_variant ?: "", TRUE);
 	envp = g_environ_setenv(envp, "RAUC_CURRENT_BOOTNAME", r_context()->bootslot, TRUE);
 	envp = g_environ_setenv(envp, "RAUC_MOUNT_PREFIX", r_context()->config->mount_prefix, TRUE);


### PR DESCRIPTION
This commit adds the `RAUC_SYSTEM_COMPATIBLE` environment variable to system handlers.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
