### PR TITLE
test/config_file: use proper bootloader slot name

### DIFF
--- a/test/config_file.c
+++ b/test/config_file.c
@@ -716,7 +716,7 @@ static void config_file_boot_emmc_with_bootpart(ConfigFileFixture *fixture, gcon
 compatible=FooCorp Super BarBazzer\n\
 bootloader=barebox\n\
 \n\
-[slot.rootfs.0]\n\
+[slot.bootloader.0]\n\
 device=/dev/mmcblk0boot0\n\
 type=boot-emmc\n";
 
@@ -725,7 +725,7 @@ type=boot-emmc\n";
 
 	g_assert_false(load_config(pathname, &config, &ierror));
 	g_assert_error(ierror, R_CONFIG_ERROR, R_CONFIG_ERROR_INVALID_DEVICE);
-	g_assert_cmpstr(ierror->message, ==, "slot.rootfs.0: 'device' must refer to the eMMC base device, not the boot partition");
+	g_assert_cmpstr(ierror->message, ==, "slot.bootloader.0: 'device' must refer to the eMMC base device, not the boot partition");
 	g_clear_error(&ierror);
 }
 


### PR DESCRIPTION
'rootfs.0' does not fit well for a bootloader slot.

Fixes: da2e0f824 ("src/config_file: prevent device misconfiguration for boot-emmc type")

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
