### PR TITLE
.github/workflows/tests: disable Debian bullseye and Ubuntu 20.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,10 +133,8 @@ jobs:
       fail-fast: false
       matrix:
         release:
-        - "ubuntu:20.04"
         - "ubuntu:22.04"
         - "ubuntu:24.04"
-        - "debian:bullseye"
         - "debian:bookworm"
         - "debian:trixie"
         - "debian:testing"


### PR DESCRIPTION
Ubuntu 20.04 (focal) is out of Security Support since 2025-03-31. Although Debian bullseye is in LTS until 2026-08-31, it's very unlikely that someone would update RAUC without also updating to bookworm at least.

We want to update our dependencies beyond what's supported by them, so remove both from the test matrix.