### PR TITLE
require OpenSSL 3.0 or newer

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,7 @@ c_flags = [
 
 giodep = dependency('gio-2.0', version : '>=2.64')
 giounixdep = dependency('gio-unix-2.0', version : '>=2.64')
-openssldep = dependency('openssl', version : '>=1.1.1')
+openssldep = dependency('openssl', version : '>=3.0')
 jsonglibdep = dependency('json-glib-1.0', required : get_option('json'))
 dbusdep = dependency('dbus-1', required : get_option('service'))
 fdiskdep = dependency('fdisk', version : '>=2.29', required : get_option('gpt'))

--- a/src/signature.c
+++ b/src/signature.c
@@ -37,11 +37,7 @@ static const gchar *get_openssl_err_string(void)
 	const gchar *data = NULL;
 	int errflags = 0;
 
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
-	err = ERR_get_error_line_data(NULL, NULL, &data, &errflags);
-#else
 	err = ERR_get_error_all(NULL, NULL, NULL, &data, &errflags);
-#endif
 
 	return (errflags & ERR_TXT_STRING) ? data : ERR_error_string(err, NULL);
 }

--- a/src/signature.c
+++ b/src/signature.c
@@ -1205,33 +1205,6 @@ gboolean cms_get_cert_chain(CMS_ContentInfo *cms, X509_STORE *store, STACK_OF(X5
 	return TRUE;
 }
 
-/* while OpenSSL 1.1.x provides a function for converting ASN1_TIME to tm,
- * OpenSSL 1.0.x does not.
- * Instead of coding an own conversion routine which might introduce bugs
- * unnecessarily, we use the existing conversion capabilities of
- * ASN1_TIME_print() and strptime() by taking the string representation as
- * intermediate format. */
-static gboolean asn1_time_to_tm(const ASN1_TIME *intime, struct tm *tm)
-{
-	BIO *mem = BIO_new(BIO_s_mem());
-
-	ASN1_TIME_print(mem, intime);
-
-	gchar *data = NULL;
-	long size = BIO_get_mem_data(mem, &data);
-	g_autofree gchar *ret = g_strndup(data, size);
-
-	g_debug("Obtained signing time: %s", ret);
-
-	if (!strptime(ret, "%b %d %H:%M:%S %Y GMT", tm))
-		return FALSE;
-
-	g_assert(BIO_set_close(mem, BIO_CLOSE));
-	BIO_free(mem);
-
-	return TRUE;
-}
-
 static void debug_cms_ci(CMS_ContentInfo *cms)
 {
 	const gchar *domains = g_getenv("G_MESSAGES_DEBUG");
@@ -1470,7 +1443,7 @@ gboolean cms_verify_bytes(GBytes *content, GBytes *sig, X509_STORE *store, CMS_C
 		so = X509_ATTRIBUTE_get0_type(xa, 0);
 
 		/* convert to time_t to make it usable for setting verify parameter */
-		if (!asn1_time_to_tm(so->value.utctime, &tm)) {
+		if (!so->value.utctime || !ASN1_TIME_to_tm(so->value.utctime, &tm)) {
 			g_set_error(
 					error,
 					R_SIGNATURE_ERROR,


### PR DESCRIPTION
This will allow us to use the OSSL_STORE APIs which are needed for transparent provider support. Also, we can get rid of some compatibility code.

OpenSSL 1.1.1 is out of standard LTS support since 2023-09-11. OpenSSL 3.0 is a LTS release supported until 2026-09-07.

Versions 3.0 or newer are used by supported releases of major distributions.
- Debian bookworm (LTS until 2028-06-30): 3.0.19 bullseye (LTS until 2026-08-31): 1.1.1w
- Ubuntu: jammy 22.04 (LTS Security Support until 2027-04-01): 3.0.2 focal 20.04 (out of Security Support since 2025-03-31): 1.1.1f
- Yocto: scarthgap (LTS until April 2028): 3.5.6 kirkstone (out of support since April 2026): 3.0.19

Although bullseye with 1.1.1 is still in LTS for a few months, it's very unlikely that someone would update RAUC without also updating to bookworm at least.