### PR TITLE
enable testing on Ubuntu 26.04 and fix new compiler warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,11 +135,14 @@ jobs:
         release:
         - "ubuntu:22.04"
         - "ubuntu:24.04"
+        - "ubuntu:26.04"
         - "debian:bookworm"
         - "debian:trixie"
         - "debian:testing"
         include:
         - release: "ubuntu:24.04"
+          test: true
+        - release: "ubuntu:26.04"
           test: true
         - release: "debian:bookworm"
           test: true

--- a/src/utils.c
+++ b/src/utils.c
@@ -86,7 +86,7 @@ gchar *r_ptr_array_env_to_shell(const GPtrArray *ptrarray)
 
 	for (guint i = 0; i < ptrarray->len; i++) {
 		const gchar *element = g_ptr_array_index(ptrarray, i);
-		gchar *eq = strchr(element, '=');
+		const gchar *eq = strchr(element, '=');
 
 		if (!eq) {
 			g_error("missing '=' in '%s'", element);
@@ -113,7 +113,7 @@ gchar **r_environ_setenv_ptr_array(gchar **envp, const GPtrArray *ptrarray, gboo
 
 	for (guint i = 0; i < ptrarray->len; i++) {
 		const gchar *element = g_ptr_array_index(ptrarray, i);
-		gchar *eq = strchr(element, '=');
+		const gchar *eq = strchr(element, '=');
 
 		if (!eq) {
 			g_error("missing '=' in '%s'", element);
@@ -135,7 +135,7 @@ void r_subprocess_launcher_setenv_ptr_array(GSubprocessLauncher *launcher, const
 
 	for (guint i = 0; i < ptrarray->len; i++) {
 		const gchar *element = g_ptr_array_index(ptrarray, i);
-		gchar *eq = strchr(element, '=');
+		const gchar *eq = strchr(element, '=');
 
 		if (!eq) {
 			g_error("missing '=' in '%s'", element);


### PR DESCRIPTION
The new warning is generated since GCC 15.