### PR TITLE
.github/workflows: pin GitHub Actions to exact commits 

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@f94c9befffa4412c356fb5463a959ab7821dd57e # v3.31.3
         with:
           languages: cpp
           queries: +security-and-quality
@@ -38,14 +38,14 @@ jobs:
           meson compile -C build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@f94c9befffa4412c356fb5463a959ab7821dd57e # v3.31.3
         with:
           category: "/language:cpp"
           upload: false
           output: sarif-results
 
       - name: Filter out meson-internal test files
-        uses: advanced-security/filter-sarif@v1
+        uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1
         with:
           patterns: |
             -build/meson-private/**/testfile.c
@@ -53,7 +53,7 @@ jobs:
           output: sarif-results/cpp.sarif
 
       - name: Upload CodeQL results to code scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@f94c9befffa4412c356fb5463a959ab7821dd57e # v3.31.3
         with:
           sarif_file: sarif-results/cpp.sarif
           category: "/language:cpp"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -18,10 +18,10 @@ jobs:
       run: |
         sudo apt-get update
         DEBIAN_FRONTEND='noninteractive' sudo apt-get install -qy qemu-user-static
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Build Images
       id: build-image
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
       with:
         image: rauc-ci
         tags: latest
@@ -41,7 +41,7 @@ jobs:
         buildah manifest inspect "${{ steps.build-image.outputs.image-with-tag }}"
     - name: Push Images
       id: push-to-github
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
       with:
         image: ${{ steps.build-image.outputs.image }}
         tags: ${{ steps.build-image.outputs.tags }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ jobs:
       image: ghcr.io/rauc/rauc/rauc-ci:latest
       options: --user=root
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - run: |
         PLATFORM=`uname`
         export TOOL_BASE="/tmp/coverity-scan-analysis"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         gcc --version
         ls -l /dev/kvm || true
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Build documentation
       run: |
         rm -rf build/

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -16,7 +16,7 @@ jobs:
         gcc --version
         ls -l /dev/kvm || true
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Run meson
       run: |

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -20,7 +20,7 @@ jobs:
         gcc --version
         ls -la /usr/bin/clang*
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Run meson
       run: |
@@ -32,7 +32,7 @@ jobs:
 
     - name: Upload scan-build report
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: scan-build-report
         path: build/meson-logs/scanbuild/*

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,7 +6,7 @@ jobs:
   style:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Install codespell
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         gcc --version
         ls -l /dev/kvm || true
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Test with service, gpt and composefs
       run: |
@@ -32,7 +32,7 @@ jobs:
         lcov --directory . --capture --output-file "service.info"
         
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         files: service.info
         flags: "service=true"
@@ -49,7 +49,7 @@ jobs:
         lcov --directory . --capture --output-file "noservice.info"
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         files: noservice.info
         flags: "service=false"
@@ -99,7 +99,7 @@ jobs:
         - "arm64/v8"
         - "386"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Install QEMU
       run: |
@@ -151,7 +151,7 @@ jobs:
         - release: "debian:testing"
           test: true
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Prepare ${{ matrix.release }} container for meson build
       run: |


### PR DESCRIPTION
This prepares for updating them via Dependabot and improves protection against unwanted changes.