### PR TITLE
test/Dockerfile: add gpg as a test environment dependency

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -68,6 +68,7 @@ RUN apt-get install -q -y --no-install-recommends \
   sudo \
   python3-pip \
   git \
+  gpg \
   curl && \
   curl -sLo /usr/bin/codecov https://codecov.io/bash && \
   chmod +x /usr/bin/codecov


### PR DESCRIPTION
This is needed for newer versions of codecov/codecov-action.