### PR TITLE
.github/workflows: restrict permissions to read contents

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "23 8 * * 5"
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -5,6 +5,9 @@ on:
   schedule:
   - cron: "30 12 */2 * *"
 
+permissions:
+  contents: read
+
 jobs:
   coverity:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,9 @@ name: documentation
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -2,6 +2,9 @@ name: sanitizers
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   address:
     runs-on: ubuntu-latest

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -2,6 +2,9 @@ name: scan-build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -2,6 +2,9 @@ name: style check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   style:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
       - 'docs/**'
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This removes unnecessary permissions from our GitHub actions workflows.

Skip the container workflow for now. It will be updated in a separate commit.