### PR TITLE
src/utils: rename value_check_tab_whitespace and check for any whitespace

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -288,13 +288,16 @@ gchar * key_file_consume_string(
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
- * Ensure that the input string contains neither whitespace nor tab.
+ * Ensure that the input string contains no whitespace.
+ *
+ * Whitespace is checked using g_ascii_isspace (i.e. space, tab, CR, LF,
+ * VT, FF).
  *
  * @param str string to check.
  *
- * @return TRUE if str contains neither whitespace nor tab, FALSE otherwise
+ * @return TRUE if str contains no whitespace, FALSE otherwise
  */
-gboolean value_check_tab_whitespace(const gchar *str, GError **error)
+gboolean value_check_whitespace(const gchar *str, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1011,8 +1011,8 @@ static GHashTable *parse_slots(const char *filename, RaucConfig *c, GKeyFile *ke
 
 			slot->bootname = value;
 			if (slot->bootname) {
-				/* Ensure that the bootname does not contain whitespace or tab */
-				if (!value_check_tab_whitespace(value, &ierror)) {
+				/* Ensure that the bootname does not contain whitespace */
+				if (!value_check_whitespace(value, &ierror)) {
 					g_propagate_prefixed_error(error, ierror,
 							"Invalid bootname for slot %s: ", slot->name);
 					return NULL;

--- a/src/utils.c
+++ b/src/utils.c
@@ -408,17 +408,18 @@ gchar * key_file_consume_string(
 	return result;
 }
 
-gboolean value_check_tab_whitespace(const gchar *str, GError **error)
+gboolean value_check_whitespace(const gchar *str, GError **error)
 {
 	g_return_val_if_fail(str != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (strchr(str, '\t') || strchr(str, ' ')) {
-		g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
-				"The value '%s' can not contain tab or whitespace characters",
-				str
-				);
-		return FALSE;
+	for (const gchar *p = str; *p; p++) {
+		if (g_ascii_isspace(*p)) {
+			g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE,
+					"The value '%s' must not contain whitespace characters",
+					str);
+			return FALSE;
+		}
 	}
 
 	return TRUE;

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -701,7 +701,7 @@ bootname=the\tslot\n";
 
 	g_assert_false(load_config(pathname, &config, &ierror));
 	g_assert_error(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_PARSE);
-	g_assert_cmpstr(ierror->message, ==, "Invalid bootname for slot rootfs.0: The value 'the\tslot' can not contain tab or whitespace characters");
+	g_assert_cmpstr(ierror->message, ==, "Invalid bootname for slot rootfs.0: The value 'the\tslot' must not contain whitespace characters");
 	g_clear_error(&ierror);
 }
 


### PR DESCRIPTION
Rename the helper to value_check_whitespace and reject any character matched by g_ascii_isspace (space, tab, CR, LF, VT, FF) instead of just space and tab. This makes the helper safe to reuse for fields where any embedded whitespace is unsafe (such as device paths emitted as shell environment variables or space-joined output).

It is currently only used to check the bootname and any of the previously unchecked characters would already have caused problems, so this should not cause compatibility problems.