### PR TITLE
.github/workflows/container: avoid top-level write permission

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -12,11 +12,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      # needed for container push
+      packages: write
     steps:
     - name: Install QEMU
       run: |


### PR DESCRIPTION
The Scorecard "Token-Permissions" check actually requires write permissions to be set at the job level:
https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

Fixes: 51391e47f928 (".github/workflows/container: restrict permissions")