### PR TITLE
tests/doc: use spec-conform UKI profile invocation parameter

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -1321,8 +1321,8 @@ partition.
    ``efi-cmdline`` or efibootmgr's ``--unicode``) can point to a
    `UKI profile
    <https://uapi-group.org/specifications/specs/unified_kernel_image/#multi-profile-ukis>`_
-   (e.g. ``@1``) defining the corresponding ``root=`` and ``rauc.slot=`` kernel
-   command line parameters.
+   (e.g. ``@1\s`` in RAUC's system configuration) defining the corresponding
+   ``root=`` and ``rauc.slot=`` kernel command line parameters.
 
 You can inspect and verify your settings by running:
 

--- a/test/test_mark.py
+++ b/test/test_mark.py
@@ -275,9 +275,9 @@ def create_efi_system_config(system, blk_dev_partitions, *, configure_efi_entry=
 
     if configure_efi_entry:
         system.config["slot.rootfs.0"]["efi-loader"] = r"\\EFI\\BOOT\\BOOTX64.EFI"
-        system.config["slot.rootfs.0"]["efi-cmdline"] = "@1"
+        system.config["slot.rootfs.0"]["efi-cmdline"] = r"@1\s"
         system.config["slot.rootfs.1"]["efi-loader"] = r"\\EFI\\BOOT\\BOOTX64.EFI"
-        system.config["slot.rootfs.1"]["efi-cmdline"] = "@2"
+        system.config["slot.rootfs.1"]["efi-cmdline"] = r"@2\s"
 
     system.write_config()
 


### PR DESCRIPTION
The "UAPI.5 Unified Kernel Images (UKI)" [1] reads:

> A profile is (optionally) selected by prefixing the EFI stub’s invocation parameters (“command line”) with `@0 `, `@1 `, `@2 `, (i.e. an `@` character, the numeric profile index, and a space character) in order to select the desired profile."

While at least the systemd-stub implementation works without a trailing space, document and test the spec-conform invocation.

Note that neither `efi-loader` nor `efi-cmdline` are currently persisted/printed in the `test/bin/efibootmgr` mock, so the change in the tests has no direct effect and is only made for the sake of correctness.

[1] https://uapi-group.org/specifications/specs/unified_kernel_image/#multi-profile-ukis