### PR TITLE
service: reload polling config on SIGHUP

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -637,6 +637,42 @@ As long as any of the file listed in ``inhibit-files`` exist, no polling or
 installation is started.
 Note that a running poll or installation is not aborted.
 
+.. _sec-polling-runtime-reload:
+
+Runtime Reload with SIGHUP
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When RAUC runs in service mode and polling was enabled when the service
+started, sending ``SIGHUP`` to the service requests a polling-only reload of
+``system.conf``.
+This can be used to update polling policy without restarting the service.
+It is only active for polling-enabled service mode; it does not provide a
+general configuration reload and does not enable polling on a service that
+started without it.
+
+The reloadable ``[polling]`` keys are ``url``, ``interval-sec``,
+``max-interval-sec``, ``inhibit-files``, ``candidate-criteria``,
+``install-criteria``, ``reboot-criteria`` and ``reboot-cmd``.
+Adding or removing the ``[polling]`` section, or adding or removing the
+required ``polling.url``, is rejected.
+Any change outside ``[polling]`` is also rejected fail-closed; this may include
+comment-only edits or section/key reordering outside ``[polling]``.
+
+If RAUC is installing when ``SIGHUP`` is received, the reload is deferred until
+the service is idle.
+An accepted reload clears cached polling bundle/status/error/backoff state and
+schedules a new initial poll with the updated interval settings.
+It does not cancel an installation and does not clear an automatic-install
+reboot that was already pending.
+
+Reload accept/reject decisions are written to the service log.
+Rejected reloads also update the shared
+:ref:`Installer.LastError <gdbus-property-de-pengutronix-rauc-Installer.LastError>`
+D-Bus property with the rejection reason, while accepted reloads clear it.
+Polling attempt errors are reported separately in
+:ref:`Poller.Status <gdbus-property-de-pengutronix-rauc-Poller.Status>` and are
+cleared by an accepted reload.
+
 To support different use-cases, the polling functionality can be used with or
 without automatic installation.
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -503,6 +503,21 @@ For more information about using the streaming support of RAUC, refer to
 ``reboot-cmd`` (optional, defaults to ``reboot``)
   Command to execute for rebooting the system after an update.
 
+Runtime Reload with SIGHUP
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When RAUC runs in service mode and polling was enabled at service startup,
+sending ``SIGHUP`` to the service reloads only the ``[polling]`` section.
+The reloadable keys are ``url``, ``interval-sec``, ``max-interval-sec``,
+``inhibit-files``, ``candidate-criteria``, ``install-criteria``,
+``reboot-criteria`` and ``reboot-cmd``.
+
+This is not a general ``system.conf`` reload: adding or removing polling at
+runtime is rejected, and any change outside the ``[polling]`` section is
+rejected fail-closed. This can include comment-only edits or reordering outside
+``[polling]``.
+See :ref:`sec-polling-runtime-reload` for the full operator contract.
+
 ``[encryption]`` Section
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/config_file.h
+++ b/include/config_file.h
@@ -116,6 +116,8 @@ typedef struct {
 	/* flag to ensure slot states were determined */
 	gboolean slot_states_determined;
 	gchar *file_checksum;
+	gchar *non_polling_file_checksum;
+	gboolean polling_enabled_at_startup;
 
 	GHashTable *artifact_repos;
 } RaucConfig;
@@ -219,3 +221,17 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(RaucConfig, free_config);
  * recorded during config parsing.
  */
 void r_config_file_modified_check(void);
+
+/**
+ * Reloads only the [polling] system configuration in-place.
+ *
+ * This rejects all non-polling changes and polling enable/disable changes,
+ * then moves only the parsed polling fields into the live configuration.
+ *
+ * @param error a GError, or NULL
+ *
+ * @return TRUE if polling configuration was reloaded. FALSE if there were
+ * errors or the reload was rejected.
+ */
+gboolean r_config_reload_polling_only(GError **error)
+G_GNUC_WARN_UNUSED_RESULT;

--- a/include/context.h
+++ b/include/context.h
@@ -217,6 +217,13 @@ void r_context_set_busy(gboolean busy);
 RaucContext *r_context_conf(void);
 
 /**
+ * Returns config file overrides without changing context pending state.
+ *
+ * @return override list, or NULL
+ */
+GList *r_context_config_overrides(void);
+
+/**
  * Returns read-only (const) reference to context object.
  *
  * Use this to access context information regularly.

--- a/include/polling.h
+++ b/include/polling.h
@@ -30,6 +30,14 @@ gboolean r_polling_setup(GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
 
 /**
+ * Clear stale polling request/cache/error state after an accepted config reload.
+ *
+ * This preserves reboot and installation state and reschedules the next poll
+ * using the current polling interval settings.
+ */
+void r_polling_reload(void);
+
+/**
  * Names of supported and default criteria for the configuration.
  */
 extern const gchar * const r_polling_supported_candidate_criteria[];

--- a/include/service.h
+++ b/include/service.h
@@ -24,6 +24,11 @@ G_GNUC_WARN_UNUSED_RESULT;
 
 void set_last_error(const gchar *message);
 
+/**
+ * Schedule draining of a pending polling-only reload once the service is idle.
+ */
+void r_service_polling_reload_deferred(void);
+
 /* used by poll.c */
 extern RInstaller *r_installer;
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1288,6 +1288,36 @@ static gboolean check_unique_slotclasses(RaucConfig *config, GError **error)
 	return TRUE;
 }
 
+static gchar *compute_non_polling_file_checksum(const gchar *data, gsize length, GError **error)
+{
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(data, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	g_autoptr(GKeyFile) key_file = g_key_file_new();
+	if (!g_key_file_load_from_data(key_file, data, length, G_KEY_FILE_KEEP_COMMENTS, &ierror)) {
+		g_propagate_error(error, ierror);
+		return NULL;
+	}
+
+	/* process overrides */
+	for (GList *l = r_context_config_overrides(); l != NULL; l = l->next) {
+		ConfigFileOverride *override = (ConfigFileOverride *)l->data;
+		g_key_file_set_value(key_file, override->section, override->name, override->value);
+	}
+
+	g_key_file_remove_group(key_file, "polling", NULL);
+
+	g_autofree gchar *non_polling_data = g_key_file_to_data(key_file, NULL, &ierror);
+	if (!non_polling_data) {
+		g_propagate_error(error, ierror);
+		return NULL;
+	}
+
+	return g_compute_checksum_for_string(G_CHECKSUM_SHA256, non_polling_data, -1);
+}
+
 void r_config_file_modified_check(void)
 {
 	g_autoptr(GError) ierror = NULL;
@@ -1331,6 +1361,11 @@ static RaucConfig *parse_config(const gchar *filename, const gchar *data, gsize 
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	c->file_checksum = g_compute_checksum_for_data(G_CHECKSUM_SHA256, (guchar*) data, length);
+	c->non_polling_file_checksum = compute_non_polling_file_checksum(data, length, &ierror);
+	if (!c->non_polling_file_checksum) {
+		g_propagate_error(error, ierror);
+		return NULL;
+	}
 
 	g_autoptr(GKeyFile) key_file = g_key_file_new();
 	if (!g_key_file_load_from_data(key_file, data, length, G_KEY_FILE_NONE, &ierror)) {
@@ -1339,7 +1374,7 @@ static RaucConfig *parse_config(const gchar *filename, const gchar *data, gsize 
 	}
 
 	/* process overrides */
-	for (GList *l = r_context_conf()->configoverride; l != NULL; l = l->next) {
+	for (GList *l = r_context_config_overrides(); l != NULL; l = l->next) {
 		ConfigFileOverride *override = (ConfigFileOverride *)l->data;
 		g_key_file_set_value(key_file, override->section, override->name, override->value);
 	}
@@ -1373,6 +1408,7 @@ static RaucConfig *parse_config(const gchar *filename, const gchar *data, gsize 
 		g_propagate_error(error, ierror);
 		return NULL;
 	}
+	c->polling_enabled_at_startup = (c->polling_url != NULL);
 
 	/* parse [encryption] section */
 	if (!parse_encryption_section(filename, key_file, c, &ierror)) {
@@ -1526,6 +1562,80 @@ gboolean check_config_target(const RaucConfig *config, GError **error)
 	return TRUE;
 }
 
+static void clear_config_polling(RaucConfig *config)
+{
+	g_return_if_fail(config);
+
+	g_clear_pointer(&config->polling_url, g_free);
+	g_clear_pointer(&config->polling_inhibit_files, g_strfreev);
+	g_clear_pointer(&config->polling_candidate_criteria, g_strfreev);
+	g_clear_pointer(&config->polling_install_criteria, g_strfreev);
+	g_clear_pointer(&config->polling_reboot_criteria, g_strfreev);
+	g_clear_pointer(&config->polling_reboot_cmd, g_free);
+	config->polling_interval_ms = 0;
+	config->polling_max_interval_ms = 0;
+}
+
+gboolean r_config_reload_polling_only(GError **error)
+{
+	GError *ierror = NULL;
+	RaucConfig *config = r_context()->config;
+	g_autoptr(RaucConfig) reload = NULL;
+	gboolean reload_polling_enabled;
+
+	g_return_val_if_fail(config, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (!r_context()->configpath) {
+		g_set_error_literal(error, R_CONFIG_ERROR, R_CONFIG_ERROR_POLLING,
+				"Cannot reload polling configuration without a system config path");
+		return FALSE;
+	}
+
+	if (!config->polling_enabled_at_startup) {
+		g_set_error_literal(error, R_CONFIG_ERROR, R_CONFIG_ERROR_POLLING,
+				"Rejected polling reload: polling was not enabled at startup");
+		return FALSE;
+	}
+
+	if (!load_config(r_context()->configpath, &reload, &ierror)) {
+		g_propagate_prefixed_error(error, ierror,
+				"Failed to load system config for polling reload: ");
+		return FALSE;
+	}
+
+	reload_polling_enabled = (reload->polling_url != NULL);
+	if (config->polling_enabled_at_startup != reload_polling_enabled) {
+		g_set_error(error, R_CONFIG_ERROR, R_CONFIG_ERROR_POLLING,
+				"Rejected polling reload: runtime %s of [polling] or polling.url is not supported",
+				"removal");
+		return FALSE;
+	}
+
+	if (g_strcmp0(config->non_polling_file_checksum, reload->non_polling_file_checksum) != 0) {
+		g_set_error_literal(error, R_CONFIG_ERROR, R_CONFIG_ERROR_POLLING,
+				"Rejected polling reload: non-polling system configuration changed");
+		return FALSE;
+	}
+
+	clear_config_polling(config);
+	/* Move all trusted [polling] keys in-place. This intentionally includes
+	 * reboot-cmd because it is part of root-owned system.conf polling policy.
+	 */
+	config->polling_url = g_steal_pointer(&reload->polling_url);
+	config->polling_inhibit_files = g_steal_pointer(&reload->polling_inhibit_files);
+	config->polling_candidate_criteria = g_steal_pointer(&reload->polling_candidate_criteria);
+	config->polling_install_criteria = g_steal_pointer(&reload->polling_install_criteria);
+	config->polling_reboot_criteria = g_steal_pointer(&reload->polling_reboot_criteria);
+	config->polling_interval_ms = reload->polling_interval_ms;
+	config->polling_max_interval_ms = reload->polling_max_interval_ms;
+	config->polling_reboot_cmd = g_steal_pointer(&reload->polling_reboot_cmd);
+
+	r_replace_strdup(&config->file_checksum, reload->file_checksum);
+
+	return TRUE;
+}
+
 RaucSlot *find_config_slot_by_device(RaucConfig *config, const gchar *device)
 {
 	g_return_val_if_fail(config, NULL);
@@ -1576,15 +1686,11 @@ void free_config(RaucConfig *config)
 	g_free(config->encryption_key);
 	g_free(config->encryption_cert);
 	g_list_free_full(config->loggers, (GDestroyNotify)r_event_log_free_logger);
-	g_free(config->polling_url);
-	g_strfreev(config->polling_inhibit_files);
-	g_strfreev(config->polling_candidate_criteria);
-	g_strfreev(config->polling_install_criteria);
-	g_strfreev(config->polling_reboot_criteria);
-	g_free(config->polling_reboot_cmd);
+	clear_config_polling(config);
 	g_clear_pointer(&config->slots, g_hash_table_destroy);
 	g_free(config->custom_bootloader_backend);
 	g_free(config->file_checksum);
+	g_free(config->non_polling_file_checksum);
 	g_clear_pointer(&config->artifact_repos, g_hash_table_destroy);
 	g_free(config);
 }

--- a/src/context.c
+++ b/src/context.c
@@ -861,6 +861,14 @@ RaucContext *r_context_conf(void)
 	return context;
 }
 
+GList *r_context_config_overrides(void)
+{
+	if (!context)
+		return NULL;
+
+	return context->configoverride;
+}
+
 const RaucContext *r_context(void)
 {
 	GError *ierror = NULL;

--- a/src/polling.c
+++ b/src/polling.c
@@ -49,7 +49,9 @@ static void polling_context_clear_manifest(RPollingContext *polling_context)
 	g_return_if_fail(polling_context);
 
 	g_clear_pointer(&polling_context->manifest, free_manifest);
+	polling_context->bundle_size = 0;
 	g_clear_pointer(&polling_context->bundle_effective_url, g_free);
+	polling_context->bundle_modified_time = 0;
 	g_clear_pointer(&polling_context->bundle_etag, g_free);
 }
 
@@ -292,6 +294,7 @@ static gboolean polling_install_cleanup(gpointer data)
 
 	polling_reschedule(polling_context, POLLING_DELAY_SHORT);
 	g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_poller));
+	r_service_polling_reload_deferred();
 
 	return G_SOURCE_REMOVE;
 }
@@ -620,6 +623,28 @@ gboolean r_polling_setup(GError **error)
 
 	return TRUE;
 };
+
+void r_polling_reload(void)
+{
+	RPollingContext *polling_context = NULL;
+
+	if (!r_poller)
+		return;
+
+	polling_context = (RPollingContext *)g_object_get_data(G_OBJECT(r_poller), "r-poll");
+	g_return_if_fail(polling_context);
+
+	g_clear_pointer(&polling_context->last_error_message, g_free);
+	g_clear_pointer(&polling_context->summary, g_free);
+	g_clear_pointer(&polling_context->attempted_hash, g_free);
+	polling_context->recent_error_count = 0;
+	polling_context->update_available = FALSE;
+	polling_context_clear_manifest(polling_context);
+
+	polling_update_status(polling_context);
+	polling_reschedule(polling_context, POLLING_DELAY_INITIAL);
+	g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON(r_poller));
+}
 
 const gchar * const r_polling_supported_candidate_criteria[] = {
 	"higher-semver",

--- a/src/service.c
+++ b/src/service.c
@@ -23,6 +23,57 @@ GMainLoop *service_loop = NULL;
 RInstaller *r_installer = NULL;
 gboolean r_service_booted_slot_is_good = FALSE;
 guint r_bus_name_id = 0;
+static gboolean polling_reload_pending = FALSE;
+static guint polling_reload_idle_id = 0;
+
+static void service_reload_polling_config(void)
+{
+	g_autoptr(GError) ierror = NULL;
+
+	/* Do not use r_context_configure() for SIGHUP reloads. That path is
+	 * whole-system configuration: it frees/rebuilds slots, keyring,
+	 * bootloader, handlers, PKI, encryption, and target context state.
+	 * Runtime SIGHUP is intentionally scoped to in-place [polling] fields.
+	 */
+	if (!r_config_reload_polling_only(&ierror)) {
+		g_warning("polling configuration reload rejected: %s", ierror->message);
+		/* SIGHUP has no reply channel, so expose the rejection via the
+		 * shared installer LastError property in addition to the log.
+		 */
+		set_last_error(ierror->message);
+		return;
+	}
+
+	r_polling_reload();
+	set_last_error("");
+	g_message("polling configuration reloaded");
+}
+
+static gboolean service_polling_reload_idle(gpointer user_data)
+{
+	polling_reload_idle_id = 0;
+
+	if (!polling_reload_pending)
+		return G_SOURCE_REMOVE;
+
+	if (r_context_get_busy()) {
+		g_debug("polling configuration reload still deferred while service is busy");
+		return G_SOURCE_REMOVE;
+	}
+
+	polling_reload_pending = FALSE;
+	service_reload_polling_config();
+
+	return G_SOURCE_REMOVE;
+}
+
+void r_service_polling_reload_deferred(void)
+{
+	if (!polling_reload_pending || polling_reload_idle_id)
+		return;
+
+	polling_reload_idle_id = g_idle_add(service_polling_reload_idle, NULL);
+}
 
 static gboolean service_install_notify(gpointer data)
 {
@@ -54,6 +105,7 @@ static gboolean service_install_cleanup(gpointer data)
 	g_mutex_unlock(&args->status_mutex);
 
 	install_args_free(args);
+	r_service_polling_reload_deferred();
 
 	return G_SOURCE_REMOVE;
 }
@@ -660,6 +712,20 @@ static gboolean r_on_signal(gpointer user_data)
 	return G_SOURCE_REMOVE;
 }
 
+static gboolean r_on_sighup(gpointer user_data)
+{
+	if (r_context_get_busy()) {
+		g_message("polling configuration reload deferred until service is idle");
+		polling_reload_pending = TRUE;
+		return G_SOURCE_CONTINUE;
+	}
+
+	polling_reload_pending = FALSE;
+	service_reload_polling_config();
+
+	return G_SOURCE_CONTINUE;
+}
+
 gboolean r_service_run(GError **error)
 {
 	GError *ierror = NULL;
@@ -671,6 +737,7 @@ gboolean r_service_run(GError **error)
 
 	service_loop = g_main_loop_new(NULL, FALSE);
 	g_unix_signal_add(SIGTERM, r_on_signal, NULL);
+	g_unix_signal_add(SIGHUP, r_on_sighup, NULL);
 
 	r_installer = r_installer_skeleton_new();
 

--- a/test/config_file.c
+++ b/test/config_file.c
@@ -1616,6 +1616,225 @@ bootloader=barebox\n\
 	g_assert_null(config);
 }
 
+#if ENABLE_STREAMING
+static gchar *polling_reload_config_full(const gchar *bootloader,
+		const gchar *system_extra,
+		const gchar *extra_sections,
+		const gchar *polling_section)
+{
+	return g_strdup_printf("\
+[system]\n\
+compatible=Test Config\n\
+bootloader=%s\n\
+%s\
+\n\
+[slot.rootfs.0]\n\
+device=images/rootfs-0\n\
+type=raw\n\
+bootname=A\n\
+\n\
+[slot.rootfs.1]\n\
+device=images/rootfs-1\n\
+type=raw\n\
+bootname=B\n\
+%s\
+%s",
+			bootloader,
+			system_extra ?: "",
+			extra_sections ?: "",
+			polling_section ?: "");
+}
+
+static gchar *polling_reload_config(const gchar *system_extra,
+		const gchar *extra_sections,
+		const gchar *polling_section)
+{
+	return polling_reload_config_full("noop", system_extra, extra_sections, polling_section);
+}
+
+static const gchar *polling_reload_base_section = "\
+\n\
+[polling]\n\
+url=http://example.com/one\n\
+interval-sec=60\n\
+max-interval-sec=120\n\
+reboot-cmd=reboot\n\
+";
+
+static gchar *polling_reload_start_context(ConfigFileFixture *fixture,
+		const gchar *config)
+{
+	g_autoptr(GError) ierror = NULL;
+	g_autofree gchar *pathname = NULL;
+
+	r_context_clean();
+
+	pathname = write_tmp_file(fixture->tmpdir, "polling-reload.conf", config, NULL);
+	g_assert_nonnull(pathname);
+
+	r_context_conf()->configpath = g_strdup(pathname);
+	r_context_conf()->configmode = R_CONTEXT_CONFIG_MODE_REQUIRED;
+	r_context_conf()->mock.proc_cmdline = "quiet rauc.slot=A rootwait";
+	g_assert_true(r_context_configure(&ierror));
+	g_assert_no_error(ierror);
+
+	return g_steal_pointer(&pathname);
+}
+
+static void polling_reload_replace_config(const gchar *pathname,
+		const gchar *config)
+{
+	g_autoptr(GError) ierror = NULL;
+
+	g_assert_true(g_file_set_contents(pathname, config, -1, &ierror));
+	g_assert_no_error(ierror);
+}
+
+static void config_file_polling_reload_accepted(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	g_autoptr(GError) ierror = NULL;
+	g_autofree gchar *startup = polling_reload_config(NULL, NULL, polling_reload_base_section);
+	g_autofree gchar *reload_config = polling_reload_config(NULL, NULL, "\
+\n\
+[polling]\n\
+url=http://example.com/two\n\
+interval-sec=120\n\
+max-interval-sec=240\n\
+inhibit-files=/tmp/inhibit-a;/tmp/inhibit-b\n\
+candidate-criteria=different-version\n\
+install-criteria=always\n\
+reboot-criteria=updated-slots\n\
+reboot-cmd=touch /tmp/reboot-requested\n\
+");
+	g_autofree gchar *pathname = polling_reload_start_context(fixture, startup);
+	RaucConfig *config = r_context()->config;
+	GHashTable *slots = config->slots;
+	g_autofree gchar *old_checksum = g_strdup(config->file_checksum);
+	g_autofree gchar *old_non_polling_checksum = g_strdup(config->non_polling_file_checksum);
+
+	polling_reload_replace_config(pathname, reload_config);
+
+	g_assert_true(r_config_reload_polling_only(&ierror));
+	g_assert_no_error(ierror);
+
+	g_assert_true(r_context()->config == config);
+	g_assert_true(config->slots == slots);
+	g_assert_cmpstr(config->polling_url, ==, "http://example.com/two");
+	g_assert_cmpint(config->polling_interval_ms, ==, 120 * 1000);
+	g_assert_cmpint(config->polling_max_interval_ms, ==, 240 * 1000);
+	g_assert_cmpstr(config->polling_inhibit_files[0], ==, "/tmp/inhibit-a");
+	g_assert_cmpstr(config->polling_inhibit_files[1], ==, "/tmp/inhibit-b");
+	g_assert_null(config->polling_inhibit_files[2]);
+	g_assert_cmpstr(config->polling_candidate_criteria[0], ==, "different-version");
+	g_assert_null(config->polling_candidate_criteria[1]);
+	g_assert_cmpstr(config->polling_install_criteria[0], ==, "always");
+	g_assert_null(config->polling_install_criteria[1]);
+	g_assert_cmpstr(config->polling_reboot_criteria[0], ==, "updated-slots");
+	g_assert_null(config->polling_reboot_criteria[1]);
+	g_assert_cmpstr(config->polling_reboot_cmd, ==, "touch /tmp/reboot-requested");
+	g_assert_cmpstr(config->non_polling_file_checksum, ==, old_non_polling_checksum);
+	g_assert_cmpstr(config->file_checksum, !=, old_checksum);
+	g_assert_true(config->polling_enabled_at_startup);
+}
+
+static void assert_polling_reload_rejected(ConfigFileFixture *fixture,
+		const gchar *startup,
+		const gchar *reload_config,
+		const gchar *message_part)
+{
+	g_autoptr(GError) ierror = NULL;
+	g_autofree gchar *pathname = polling_reload_start_context(fixture, startup);
+	RaucConfig *config = r_context()->config;
+	GHashTable *slots = config->slots;
+	g_autofree gchar *old_checksum = g_strdup(config->file_checksum);
+	g_autofree gchar *old_non_polling_checksum = g_strdup(config->non_polling_file_checksum);
+
+	polling_reload_replace_config(pathname, reload_config);
+
+	g_assert_false(r_config_reload_polling_only(&ierror));
+	g_assert_error(ierror, R_CONFIG_ERROR, R_CONFIG_ERROR_POLLING);
+	g_assert_nonnull(strstr(ierror->message, message_part));
+
+	g_assert_true(r_context()->config == config);
+	g_assert_true(config->slots == slots);
+	if (config->polling_enabled_at_startup) {
+		g_assert_cmpstr(config->polling_url, ==, "http://example.com/one");
+		g_assert_cmpint(config->polling_interval_ms, ==, 60 * 1000);
+		g_assert_cmpint(config->polling_max_interval_ms, ==, 120 * 1000);
+		g_assert_cmpstr(config->polling_reboot_cmd, ==, "reboot");
+	} else {
+		g_assert_null(config->polling_url);
+		g_assert_null(config->polling_reboot_cmd);
+	}
+	g_assert_cmpstr(config->file_checksum, ==, old_checksum);
+	g_assert_cmpstr(config->non_polling_file_checksum, ==, old_non_polling_checksum);
+
+	r_context_clean();
+}
+
+static void config_file_polling_reload_rejects_non_polling(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	g_autofree gchar *startup = polling_reload_config(NULL, NULL, polling_reload_base_section);
+	g_autofree gchar *reload_config = polling_reload_config("min-bundle-version=1.0\n", NULL, "\
+\n\
+[polling]\n\
+url=http://example.com/two\n\
+interval-sec=60\n\
+max-interval-sec=120\n\
+");
+
+	assert_polling_reload_rejected(fixture, startup, reload_config, "non-polling");
+}
+
+static void config_file_polling_reload_rejects_sensitive(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	typedef struct {
+		const gchar *name;
+		const gchar *bootloader;
+		const gchar *system_extra;
+		const gchar *extra_sections;
+	} SensitiveCase;
+	const SensitiveCase cases[] = {
+		{"bootloader", "grub", "grubenv=grubenv.test\n", NULL},
+		{"statusfile", NULL, "statusfile=/tmp/central.raucs\n", NULL},
+		{"keyring", NULL, NULL, "\n[keyring]\npath=/tmp/keyring.pem\n"},
+		{"handler", NULL, NULL, "\n[handlers]\npre-install=/bin/true\n"},
+		{"encryption", NULL, NULL, "\n[encryption]\nkey=/tmp/key.pem\ncert=/tmp/cert.pem\n"},
+		{"slot", NULL, NULL, "\n[slot.rescue.0]\ndevice=images/rescue-0\ntype=raw\nbootname=R\n"},
+		{NULL, NULL, NULL, NULL},
+	};
+
+	for (const SensitiveCase *test = cases; test->name; test++) {
+		g_autofree gchar *startup = polling_reload_config(NULL, NULL, polling_reload_base_section);
+		g_autofree gchar *reload_config = polling_reload_config_full(test->bootloader ?: "noop", test->system_extra, test->extra_sections, polling_reload_base_section);
+
+		g_test_message("checking sensitive rejection: %s", test->name);
+		assert_polling_reload_rejected(fixture, startup, reload_config, "non-polling");
+	}
+}
+
+static void config_file_polling_reload_rejects_polling_add_remove(ConfigFileFixture *fixture,
+		gconstpointer user_data)
+{
+	g_autofree gchar *startup_enabled = polling_reload_config(NULL, NULL, polling_reload_base_section);
+	g_autofree gchar *startup_disabled = polling_reload_config(NULL, NULL, NULL);
+	g_autofree gchar *reload_enabled = polling_reload_config(NULL, NULL, "\
+\n\
+[polling]\n\
+url=http://example.com/two\n\
+interval-sec=60\n\
+max-interval-sec=120\n\
+");
+	g_autofree gchar *reload_disabled = polling_reload_config(NULL, NULL, NULL);
+
+	assert_polling_reload_rejected(fixture, startup_disabled, reload_enabled, "not enabled");
+	assert_polling_reload_rejected(fixture, startup_enabled, reload_disabled, "removal");
+}
+#endif
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -1761,5 +1980,19 @@ int main(int argc, char *argv[])
 	g_test_add("/config-file/min-bundle-version/bad", ConfigFileFixture, NULL,
 			config_file_fixture_set_up, config_file_min_bundle_version_bad,
 			config_file_fixture_tear_down);
+#if ENABLE_STREAMING
+	g_test_add("/config-file/polling-reload/accepted", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_polling_reload_accepted,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/polling-reload/rejects-non-polling", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_polling_reload_rejects_non_polling,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/polling-reload/rejects-sensitive", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_polling_reload_rejects_sensitive,
+			config_file_fixture_tear_down);
+	g_test_add("/config-file/polling-reload/rejects-polling-add-remove", ConfigFileFixture, NULL,
+			config_file_fixture_set_up, config_file_polling_reload_rejects_polling_add_remove,
+			config_file_fixture_tear_down);
+#endif
 	return g_test_run();
 }

--- a/test/test_polling.py
+++ b/test/test_polling.py
@@ -1,3 +1,6 @@
+import os
+import signal
+import subprocess
 import time
 
 import pytest
@@ -16,6 +19,21 @@ def wait_one_poll(system, *, timeout=15.0):
         time.sleep(0.1)
         assert time.monotonic() < (start + timeout)
     return time.monotonic() - start
+
+
+def wait_until(condition, *, timeout=15.0):
+    start = time.monotonic()
+    while True:
+        result = condition()
+        if result:
+            return result
+        time.sleep(0.1)
+        assert time.monotonic() < (start + timeout)
+
+
+def status_without_manifest(system):
+    status = get_native(system.proxy.Status)
+    return status if "manifest" not in status else None
 
 
 def test_no_system_version(create_system_files, system, http_server):
@@ -225,6 +243,263 @@ def test_candidate_criteria(create_system_files, system, http_server, sys_ver, c
     assert status["summary"] == result
 
     assert slots_initial == slots_final
+
+
+def test_sighup_reload_accepted(create_system_files, system, http_server):
+    """Test if SIGHUP accepts polling-only changes and clears stale status."""
+    http_server.setup(
+        file_path="good-verity-bundle.raucb",
+    )
+
+    system.prepare_minimal_config()
+    system.config["handlers"] = {
+        "system-info": "bin/systeminfo.sh",
+    }
+    system.config["streaming"] = {
+        "send-headers": "system-version;transaction-id",
+    }
+    system.config["polling"] = {
+        "url": http_server.url,
+        "interval-sec": "60",
+        "candidate-criteria": "higher-semver",
+    }
+    system.write_config()
+
+    with system.running_service("A", polling_speedup=10):
+        system.proxy.Mark("good", "booted")
+
+        wait_one_poll(system)
+        status_1 = get_native(system.proxy.Status)
+        assert status_1["summary"] == "update candidate found: higher semantic version"
+        assert "manifest" in status_1
+
+        system.config["polling"]["candidate-criteria"] = "different-version"
+        system.write_config()
+        os.kill(system.service.pid, signal.SIGHUP)
+
+        status_2 = wait_until(lambda: status_without_manifest(system))
+        assert "summary" not in status_2
+        assert status_2["recent-error-count"] == 0
+
+        system.proxy.Poll()
+        wait_one_poll(system)
+        status_3 = get_native(system.proxy.Status)
+        last_error = system.proxy.LastError
+
+    assert status_3["summary"] == "update candidate found: different version"
+    assert "manifest" in status_3
+    assert last_error == ""
+
+
+def test_sighup_reload_rejected(create_system_files, system, http_server):
+    """Test if SIGHUP rejects non-polling changes and leaves old polling active."""
+    http_server.setup(
+        file_path="good-verity-bundle.raucb",
+    )
+
+    system.prepare_minimal_config()
+    system.config["handlers"] = {
+        "system-info": "bin/systeminfo.sh",
+    }
+    system.config["streaming"] = {
+        "send-headers": "system-version;transaction-id",
+    }
+    system.config["polling"] = {
+        "url": http_server.url,
+        "interval-sec": "60",
+        "candidate-criteria": "higher-semver",
+    }
+    system.write_config()
+
+    with system.running_service("A", polling_speedup=10):
+        system.proxy.Mark("good", "booted")
+
+        wait_one_poll(system)
+        status_1 = get_native(system.proxy.Status)
+        assert status_1["summary"] == "update candidate found: higher semantic version"
+
+        system.config["system"]["compatible"] = "Changed Config"
+        system.config["polling"]["candidate-criteria"] = "different-version"
+        system.write_config()
+        os.kill(system.service.pid, signal.SIGHUP)
+
+        wait_until(lambda: "non-polling" in system.proxy.LastError)
+        system.proxy.Poll()
+        wait_one_poll(system)
+        status_2 = get_native(system.proxy.Status)
+
+    assert status_2["summary"] == "update candidate found: higher semantic version"
+
+
+def test_sighup_reload_deferred(create_system_files, system, http_server, tmp_path):
+    """Test if SIGHUP during polling installation is deferred until idle."""
+    marker = tmp_path / "preinstall-started"
+    preinstall = tmp_path / "sleep-preinstall.sh"
+    preinstall.write_text(f"#!/bin/sh\ntouch {marker}\nsleep 3\n")
+    preinstall.chmod(0o755)
+
+    http_server.setup(
+        file_path="good-verity-bundle.raucb",
+    )
+
+    system.prepare_minimal_config()
+    system.config["handlers"] = {
+        "system-info": "bin/systeminfo.sh",
+        "pre-install": str(preinstall),
+    }
+    system.config["streaming"] = {
+        "send-headers": "system-version;transaction-id",
+    }
+    system.config["polling"] = {
+        "url": http_server.url,
+        "interval-sec": "60",
+        "candidate-criteria": "higher-semver",
+        "install-criteria": "always",
+    }
+    system.write_config()
+
+    with system.running_service("A", polling_speedup=10):
+        system.proxy.Mark("good", "booted")
+
+        wait_until(marker.exists, timeout=20.0)
+        assert system.proxy.Operation == "installing"
+
+        system.config["polling"] = {
+            "url": http_server.url,
+            "interval-sec": "60",
+            "candidate-criteria": "different-version",
+        }
+        system.write_config()
+        os.kill(system.service.pid, signal.SIGHUP)
+
+        wait_until(lambda: system.proxy.Operation == "idle", timeout=20.0)
+        status_1 = wait_until(lambda: status_without_manifest(system))
+
+        system.proxy.Poll()
+        wait_one_poll(system)
+        status_2 = get_native(system.proxy.Status)
+
+    assert "summary" not in status_1
+    assert status_2["summary"] == "update candidate found: different version"
+
+
+def test_sighup_reload_preserves_pending_reboot(create_system_files, system, http_server, tmp_path):
+    """Test if accepted SIGHUP reloads keep a pending polling reboot."""
+    marker = tmp_path / "preinstall-started"
+    preinstall = tmp_path / "sleep-preinstall.sh"
+    preinstall.write_text(f"#!/bin/sh\ntouch {marker}\nsleep 1\n")
+    preinstall.chmod(0o755)
+    reboot_flag = tmp_path / "reboot-flag"
+
+    http_server.setup(
+        file_path="good-verity-bundle.raucb",
+    )
+
+    system.prepare_minimal_config()
+    system.config["handlers"] = {
+        "system-info": "bin/systeminfo.sh",
+        "pre-install": str(preinstall),
+    }
+    system.config["streaming"] = {
+        "send-headers": "system-version;transaction-id",
+    }
+    system.config["polling"] = {
+        "url": http_server.url,
+        "interval-sec": "60",
+        "install-criteria": "always",
+        "reboot-criteria": "updated-slots",
+        "reboot-cmd": f"touch {reboot_flag}",
+    }
+    system.write_config()
+
+    env = {"RAUC_TEST_SYSTEM_VERSION": "2010.01-1"}
+
+    with system.running_service("A", polling_speedup=5, extra_env=env):
+        system.proxy.Mark("good", "booted")
+
+        wait_until(marker.exists, timeout=20.0)
+        wait_until(lambda: system.proxy.Operation == "idle", timeout=20.0)
+        assert not reboot_flag.exists()
+
+        system.config["polling"]["candidate-criteria"] = "different-version"
+        system.write_config()
+        os.kill(system.service.pid, signal.SIGHUP)
+
+        status_after_reload = wait_until(lambda: status_without_manifest(system), timeout=10.0)
+        wait_until(reboot_flag.exists, timeout=20.0)
+        last_error = system.proxy.LastError
+
+    assert "summary" not in status_after_reload
+    assert last_error == ""
+
+
+def test_sighup_reload_deferred_dbus_install(create_system_files, system, http_server, tmp_path):
+    """Test if SIGHUP during a D-Bus-triggered install is drained when idle."""
+    marker = tmp_path / "preinstall-started"
+    preinstall = tmp_path / "sleep-preinstall.sh"
+    preinstall.write_text(f"#!/bin/sh\ntouch {marker}\nsleep 3\n")
+    preinstall.chmod(0o755)
+
+    http_server.setup(
+        file_path="good-verity-bundle.raucb",
+    )
+
+    system.prepare_minimal_config()
+    system.config["handlers"] = {
+        "system-info": "bin/systeminfo.sh",
+        "pre-install": str(preinstall),
+    }
+    system.config["streaming"] = {
+        "send-headers": "system-version;transaction-id",
+    }
+    system.config["polling"] = {
+        "url": http_server.url,
+        "interval-sec": "60",
+        "candidate-criteria": "higher-semver",
+    }
+    system.write_config()
+
+    install = None
+    with system.running_service("A", polling_speedup=10):
+        system.proxy.Mark("good", "booted")
+
+        system.proxy.Poll()
+        wait_one_poll(system)
+        status_1 = get_native(system.proxy.Status)
+        assert status_1["summary"] == "update candidate found: higher semantic version"
+
+        install_env = os.environ.copy()
+        install_env["RAUC_PYTEST_TMP"] = str(system.tmp_path)
+        install = subprocess.Popen(
+            ["rauc", "-c", str(system.output), "install", os.path.abspath("good-verity-bundle.raucb")],
+            env=install_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            wait_until(marker.exists, timeout=20.0)
+            assert system.proxy.Operation == "installing"
+
+            system.config["polling"]["candidate-criteria"] = "different-version"
+            system.write_config()
+            os.kill(system.service.pid, signal.SIGHUP)
+
+            wait_until(lambda: system.proxy.Operation == "idle", timeout=20.0)
+            out, err = install.communicate(timeout=10.0)
+            assert install.returncode == 0, f"{out}\n{err}"
+            status_2 = wait_until(lambda: status_without_manifest(system), timeout=20.0)
+
+            system.proxy.Poll()
+            wait_one_poll(system)
+            status_3 = get_native(system.proxy.Status)
+        finally:
+            if install.poll() is None:
+                install.terminate()
+                install.wait(timeout=10.0)
+
+    assert "summary" not in status_2
+    assert status_3["summary"] == "update candidate found: different version"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1709.

## Summary

- Add service-mode `SIGHUP` handling for polling-only `system.conf` reloads.
- Reload only `[polling]` keys and reject polling enable/disable at runtime.
- Reject every non-polling config change instead of performing a general service config reload.
- Defer reload while RAUC is busy and drain it once the service is idle.
- Reset stale polling status/cache/error state while preserving pending automatic reboot and installation-running state.
- Document the SIGHUP polling reload operator contract.

## Notes

This intentionally does not call `r_context_configure()` on the reload path and does not replace the live config object wholesale.

Rejected reloads update the shared `Installer.LastError` property in addition to the service log because `SIGHUP` has no direct reply channel. Accepted reloads clear that property. Please confirm whether this D-Bus visibility is preferred over log-only behavior.

The non-polling rejection is fail-closed and may reject comment-only edits or reordering outside `[polling]`; this is documented so operators do not confuse it with a general config reload.

## Verification

- `git diff --check`
- `PYTHONPYCACHEPREFIX=/tmp/rauc-pycache python3 -m py_compile test/test_polling.py`

I could not run the full RAUC local suite in my environment because `meson`, `ninja`, `pytest`, `pkg-config`, `uncrustify`, `dasbus`, and required C headers were unavailable. The PR should be gated on upstream CI / a properly provisioned local RAUC environment for the C tests, polling pytest suite, service tests, docs build, and formatting.
