### PR TITLE
.github/workflows/tests: install dbus-daemon

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,7 +172,7 @@ jobs:
     - name: Install test dependencies
       if: ${{ matrix.test }}
       run: |
-        podman exec -e DEBIAN_FRONTEND='noninteractive' -i -u root stable apt-get install -qy python3-pytest python3-dasbus python3-aiohttp python3-requests python3-pyasn1 python3-pyasn1-modules openssl e2fsprogs grub-common faketime
+        podman exec -e DEBIAN_FRONTEND='noninteractive' -i -u root stable apt-get install -qy python3-pytest python3-dasbus python3-aiohttp python3-requests python3-pyasn1 python3-pyasn1-modules openssl e2fsprogs grub-common faketime dbus-daemon
 
     - name: Configure
       run: |

--- a/README.rst
+++ b/README.rst
@@ -223,7 +223,7 @@ Running the Test Suite
 
     sudo apt-get install qemu-system-x86 time squashfs-tools e2fsprogs python3-pytest python3-dasbus python3-aiohttp python3-requests python3-pyasn1 python3-pyasn1-modules
     # Optional to run all tests:
-    # sudo apt-get install faketime casync grub-common openssl softhsm2 opensc opensc-pkcs11 libengine-pkcs11-openssl mtd-utils nginx-light tree
+    # sudo apt-get install faketime dbus-daemon casync grub-common openssl softhsm2 opensc opensc-pkcs11 libengine-pkcs11-openssl mtd-utils nginx-light tree
     ./qemu-test
 
 Creating a Bundle (Host)


### PR DESCRIPTION
Testing requires dbus-daemon to be available.
In CI, some tests fail due to missing dbus-daemon in Debian testing.

Just make sure we have it installed.

Note: The Dockerfile already install 'dbus' which depends on 'dbus-daemon', anyway. So no explicit install is necessary.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
