### PR TITLE
Clarify implications and scope of use-bundle-signing-time and avoid NULL pointer dereferences

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -302,6 +302,22 @@ signature.
   If this boolean value is set to ``true`` then the bundle signing time
   is used instead of the current system time for certificate validation.
 
+  This means that an expired certificate is still considered valid if the time
+  used for the signature timestamp is set to a point within the certificate's
+  validity period.
+  Accordingly, certificate expiry no longer limits how long a compromised key
+  can be used by an attacker.
+
+  As certificate revocation (using a CRL) is independent of validity times and
+  the current time, it is not affected by this option.
+
+  Only enable this option if you are required to do so and fully understand the
+  consequences.
+
+  .. note:: If you use short validity periods for certificates in the keyring
+    and rotate them often, re-signing old bundles to make them installable again
+    is usually a better approach.
+
 .. _allow-partial-chain:
 
 ``allow-partial-chain=<true/false>`` (optional)

--- a/src/signature.c
+++ b/src/signature.c
@@ -1435,12 +1435,54 @@ gboolean cms_verify_bytes(GBytes *content, GBytes *sig, X509_STORE *store, CMS_C
 		X509_VERIFY_PARAM *param = X509_STORE_get0_param(store);
 		struct tm tm;
 		time_t signingtime;
+		int signingtime_idx;
 
 		/* Extract signing time from pkcs9 attributes */
 		sinfos = CMS_get0_SignerInfos(icms);
+		if (sinfos == NULL) {
+			g_set_error(
+					error,
+					R_SIGNATURE_ERROR,
+					R_SIGNATURE_ERROR_INVALID,
+					"Failed to obtain signer infos for bundle signing time");
+			goto out;
+		}
+		if (sk_CMS_SignerInfo_num(sinfos) != 1) {
+			g_set_error(
+					error,
+					R_SIGNATURE_ERROR,
+					R_SIGNATURE_ERROR_INVALID,
+					"multiple signerInfos are not supported with 'use-bundle-signing-time'");
+			goto out;
+		}
 		si = sk_CMS_SignerInfo_value(sinfos, 0);
+		signingtime_idx = CMS_signed_get_attr_by_NID(si, NID_pkcs9_signingTime, -1);
+		if (signingtime_idx < 0) {
+			g_set_error(
+					error,
+					R_SIGNATURE_ERROR,
+					R_SIGNATURE_ERROR_INVALID,
+					"Bundle signing time attribute not found in signature");
+			goto out;
+		}
 		xa = CMS_signed_get_attr(si, CMS_signed_get_attr_by_NID(si, NID_pkcs9_signingTime, -1));
+		if (xa == NULL) {
+			g_set_error(
+					error,
+					R_SIGNATURE_ERROR,
+					R_SIGNATURE_ERROR_INVALID,
+					"Failed to obtain bundle signing time attribute");
+			goto out;
+		}
 		so = X509_ATTRIBUTE_get0_type(xa, 0);
+		if (so == NULL) {
+			g_set_error(
+					error,
+					R_SIGNATURE_ERROR,
+					R_SIGNATURE_ERROR_INVALID,
+					"Failed to obtain bundle signing time value");
+			goto out;
+		}
 
 		/* convert to time_t to make it usable for setting verify parameter */
 		if (!so->value.utctime || !ASN1_TIME_to_tm(so->value.utctime, &tm)) {

--- a/src/signature.c
+++ b/src/signature.c
@@ -1495,6 +1495,10 @@ gboolean cms_verify_bytes(GBytes *content, GBytes *sig, X509_STORE *store, CMS_C
 		}
 		signingtime = timegm(&tm);
 
+		g_autoptr(GDateTime) signingtime_gdate = g_date_time_new_from_unix_utc((gint64)signingtime);
+		g_autofree gchar *siginingtime_str = g_date_time_format(signingtime_gdate, "%b %d %H:%M:%S %Y GMT"); // OpenSSL-style formatting
+		g_message("Using bundle signing time (%s) for certificate verification.", siginingtime_str);
+
 		/* use signing time for verification */
 		X509_VERIFY_PARAM_set_time(param, signingtime);
 	}

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -97,3 +97,41 @@ def test_info_no_check_time(tmp_path):
     )
 
     assert exitcode == 0
+
+
+def test_verify_with_use_bundle_signing_time_no_signing_time(tmp_path):
+    shutil.copytree("install-content", tmp_path / "install-content")
+    prepare_signing_time_conf(tmp_path)
+
+    # create a signed bundle
+    out, err, exitcode = run(
+        "rauc "
+        "--cert openssl-ca/rel/release-1.cert.pem "
+        "--key openssl-ca/rel/private/release-1.pem "
+        f" bundle {tmp_path}/install-content {tmp_path}/out.raucb"
+    )
+
+    assert exitcode == 0
+    assert (tmp_path / "out.raucb").exists()
+
+    # sign the same manifest with '-noattr' again
+    out, err, exitcode = run(
+        f"openssl cms -sign -noattr  -signer openssl-ca/rel/release-1.cert.pem -inkey openssl-ca/rel/private/release-1.pem -nodetach -in {tmp_path}/install-content/manifest.raucm -outform der -out {tmp_path}/new-signature.cms"
+    )
+    assert exitcode == 0
+    assert (tmp_path / "new-signature.cms").exists()
+
+    # replace original signature
+    out, err, exitcode = run(
+        f"rauc --keyring openssl-ca/rel-ca.pem replace-signature {tmp_path}/out.raucb {tmp_path}/new-signature.cms {tmp_path}/invalid-bundle.raucb"
+    )
+    assert exitcode == 0
+    assert (tmp_path / "invalid-bundle.raucb").exists()
+
+    # test verification with missing signing time
+    out, err, exitcode = run(
+        f"rauc --conf {tmp_path}/use-bundle-signing-time.conf info {tmp_path}/invalid-bundle.raucb"
+    )
+
+    assert exitcode == 1
+    assert "Bundle signing time attribute not found in signature" in err


### PR DESCRIPTION
Clarify the impact of the `use-bundle-signing-time` option to better guide potential users.
This also documents aspects discussed in #496 already.

Also add explicit NULL checks to intermediate results in the signing time code path.
This prevents a NULL pointer dereference and early crash of RAUC for bundles that have lack a signing time attribute or have an unexpected CMS structure.