### PR TITLE
test: support running CLI commands with customized environment

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -535,6 +535,22 @@ class System:
         self.service = None
         self.proxy = None
 
+        self.env_kernel_cmdline = None
+
+    @property
+    def env(self):
+        env = {
+            "RAUC_TEST_RUNTIME_DIRECTORY": str(self.run_dir),
+        }
+
+        if self.env_kernel_cmdline:
+            env["RAUC_TEST_CMDLINE"] = str(self.env_kernel_cmdline)
+
+        return env
+
+    def run(self, command, *, timeout=30):
+        return run(f"{self.prefix} {command}", timeout=timeout, extra_env=self.env)
+
     def prepare_minimal_config(self):
         self.config["system"] = {
             "compatible": "Test Config",
@@ -633,8 +649,8 @@ class System:
         assert self.proxy is None
 
         env = os.environ.copy()
+        env.update(self.env)
         env["RAUC_PYTEST_TMP"] = str(self.tmp_path)
-        env["RAUC_TEST_RUNTIME_DIRECTORY"] = str(self.run_dir)
         if polling_speedup:
             env["RAUC_TEST_POLLING_SPEEDUP"] = f"{polling_speedup}"
         if extra_env:

--- a/test/helper.py
+++ b/test/helper.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2021-2022 Bastian Krause <bst@pengutronix.de>, Pengutronix
 
 import logging
+import os
 import shlex
 import subprocess
 from pathlib import Path
@@ -24,7 +25,7 @@ def logger_from_command(command):
     return logging.getLogger(base_cmd)
 
 
-def run(command, *, timeout=30):
+def run(command, *, timeout=30, extra_env=None):
     """
     Runs given command as subprocess with DBUS_STARTER_BUS_TYPE=session and PATH+=./build. Blocks
     until command terminates. Logs command and its stdout/stderr/exit code (use
@@ -34,7 +35,11 @@ def run(command, *, timeout=30):
     logger = logger_from_command(command)
     logger.info("running: %s", command)
 
-    proc = subprocess.run(shlex.split(command), capture_output=True, text=True, check=False, timeout=timeout)
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+
+    proc = subprocess.run(shlex.split(command), capture_output=True, text=True, check=False, timeout=timeout, env=env)
 
     for line in proc.stdout.splitlines():
         if line:


### PR DESCRIPTION
When using the system fixture, it would be useful if we could run commands with a configuration matching the one used by the service. Support that by adding a run() helper function and an env property which computes the environment on demand.

While we're there, also add support for overriding the kernel commandline from tests.