### PR TITLE
src/update_handler: avoid redundant flash_erase call

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -1185,9 +1185,10 @@ static gboolean nor_write_slot(const gchar *image, const gchar *device, GError *
 {
 	GError *ierror = NULL;
 	gboolean res = FALSE;
-	g_autoptr(GPtrArray) args = g_ptr_array_new_full(5, g_free);
+	g_autoptr(GPtrArray) args = g_ptr_array_new_full(6, g_free);
 
 	g_ptr_array_add(args, g_strdup("flashcp"));
+	g_ptr_array_add(args, g_strdup("--erase-all"));
 	g_ptr_array_add(args, g_strdup(image));
 	g_ptr_array_add(args, g_strdup(device));
 	g_ptr_array_add(args, NULL);
@@ -1963,13 +1964,6 @@ static gboolean img_to_nor_handler(RaucImage *image, RaucSlot *dest_slot, const 
 			g_propagate_error(error, ierror);
 			return FALSE;
 		}
-	}
-
-	/* erase */
-	g_message("erasing slot device %s", dest_slot->device);
-	if (!flash_format_slot(dest_slot->device, &ierror)) {
-		g_propagate_error(error, ierror);
-		return FALSE;
 	}
 
 	/* write */


### PR DESCRIPTION
The `--erase-all` option for `flashcp` does the same as the 'flash_erase <dev> 0 0' we currently run do before each nor_write_slot() call. Previously, we erased all blocks covered by the image twice, as `flash_cp` already erases the blocks it writes to by default.
