### PR TITLE
data/de.pengutronix.rauc.conf: Allow only root to talk to rauc over DBus

### DIFF
--- a/data/de.pengutronix.rauc.conf
+++ b/data/de.pengutronix.rauc.conf
@@ -2,14 +2,37 @@
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-  <!-- This config allows anyone to control rauc -->
+  <!-- This config allows only root to control rauc -->
   <!-- It is usually installed to /usr/share/dbus-1/system.d -->
 
   <policy context="default">
-    <allow send_destination="de.pengutronix.rauc"/>
+    <deny send_destination="de.pengutronix.rauc"/>
+    <allow receive_sender="de.pengutronix.rauc"/>
+
+    <!-- allow introspection -->
+    <allow send_destination="de.pengutronix.rauc"
+	   send_interface="org.freedesktop.DBus.Introspectable"/>
+
+    <allow send_destination="de.pengutronix.rauc"
+	   send_interface="org.freedesktop.DBus.Peer"/>
+
+    <allow send_destination="de.pengutronix.rauc"
+	   send_interface="org.freedesktop.DBus.Properties"
+	   send_member="Get"/>
+
+    <allow send_destination="de.pengutronix.rauc"
+	   send_interface="org.freedesktop.DBus.Properties"
+	   send_member="GetAll"/>
   </policy>
 
   <policy user="root">
     <allow own="de.pengutronix.rauc"/>
+    <allow send_destination="de.pengutronix.rauc"/>
   </policy>
+
+  <!-- example allowing a user to talk to rauc
+  <policy user="service">
+    <allow send_destination="de.pengutronix.rauc"/>
+  </policy>
+  -->
 </busconfig>


### PR DESCRIPTION
Random unprivileged user accounts shouldn't be allowed to trigger rauc. So limit access to the dbus service to `root` by default. Adding those rules may cause regressions in deployments that rely on rauc being wide open though.