### PR TITLE
.github/dependabot: group codeql GitHub Actions update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: ".github/workflows"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
They are all based on the same version and updating them individually will likely cause errors like:

| Error: analyze post-action step failed: Loaded a configuration file for version '4.36.2', but running version '4.37.0'

https://github.com/rauc/rauc/actions/runs/28982640681/job/86004666690?pr=1979

Fixes: 8e900ca1 (".github: add dependabot config for GitHub Actions")

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
