### PR TITLE
src/main: fix shortname option for write-slot --image-type to be -t

### DIFF
--- a/docs/man.rst
+++ b/docs/man.rst
@@ -314,7 +314,7 @@ COMMANDS
 
    **Options:**
 
-      **--image-type**
+      **-t**, **--image-type=**\ TYPE
          Select explicit image type to use.
 
 ENVIRONMENT

--- a/src/main.c
+++ b/src/main.c
@@ -2666,7 +2666,7 @@ static GOptionEntry entries_status[] = {
 };
 
 static GOptionEntry entries_write_slot[] = {
-	{"image-type", 't', 0, G_OPTION_ARG_STRING, &write_slot_image_type, "Select explicit image type to use.", NULL},
+	{"image-type", 't', 0, G_OPTION_ARG_STRING, &write_slot_image_type, "Select explicit image type to use.", "TYPE"},
 	/* The 'image-type' shortname was accidentally named 'l' before. This hidden option ensures compatibility with the old shortname */
 	{"image-type-compat", 'l', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &write_slot_image_type, "Select explicit image type to use (compat).", NULL},
 	{0}

--- a/src/main.c
+++ b/src/main.c
@@ -2666,7 +2666,9 @@ static GOptionEntry entries_status[] = {
 };
 
 static GOptionEntry entries_write_slot[] = {
-	{"image-type", 'l', 0, G_OPTION_ARG_STRING, &write_slot_image_type, "Select explicit image type to use.", NULL},
+	{"image-type", 't', 0, G_OPTION_ARG_STRING, &write_slot_image_type, "Select explicit image type to use.", NULL},
+	/* The 'image-type' shortname was accidentally named 'l' before. This hidden option ensures compatibility with the old shortname */
+	{"image-type-compat", 'l', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &write_slot_image_type, "Select explicit image type to use (compat).", NULL},
 	{0}
 };
 

--- a/test/test_write_slot.py
+++ b/test/test_write_slot.py
@@ -53,6 +53,14 @@ def test_write_slot_image_type(tmp_path, rauc_no_service):
     assert exitcode == 0
     assert "Slot written successfully" in out
 
+    out, err, exitcode = run(f"{rauc_no_service} write-slot -t raw rootfs.0 install-content/appfs.img")
+    assert exitcode == 0
+    assert "Slot written successfully" in out
+
+    out, err, exitcode = run(f"{rauc_no_service} write-slot -l raw rootfs.0 install-content/appfs.img")
+    assert exitcode == 0
+    assert "Slot written successfully" in out
+
 
 def test_write_slot_no_handler(tmp_path, rauc_no_service):
     open(tmp_path / "image.vfat", mode="w").close()


### PR DESCRIPTION
Accidentally, the shortname option was named '-l' instead of '-t'.

Rename it and provide a compatibility option and test both.

Fixes: 5c88aa94 ("src/main: add '--image-type' option to write-slot command")

Also complete the man page and help text.