### PR TITLE
src/signature: validate signing time attribute type before use

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -1484,8 +1484,22 @@ gboolean cms_verify_bytes(GBytes *content, GBytes *sig, X509_STORE *store, CMS_C
 			goto out;
 		}
 
+		/* The signingTime attribute value is an ASN.1 ANY that is decoded
+		 * before the signature is verified. Only UTCTime and GeneralizedTime
+		 * store an ASN1_STRING in the value union; for other tags (e.g. a
+		 * BOOLEAN) so->value.utctime is not a pointer at all, so dereferencing
+		 * it would be a type confusion. Reject anything that is not a time. */
+		if (so->type != V_ASN1_UTCTIME && so->type != V_ASN1_GENERALIZEDTIME) {
+			g_set_error(
+					error,
+					R_SIGNATURE_ERROR,
+					R_SIGNATURE_ERROR_INVALID,
+					"Bundle signing time attribute has unexpected type");
+			goto out;
+		}
+
 		/* convert to time_t to make it usable for setting verify parameter */
-		if (!so->value.utctime || !ASN1_TIME_to_tm(so->value.utctime, &tm)) {
+		if (!so->value.asn1_string || !ASN1_TIME_to_tm(so->value.asn1_string, &tm)) {
 			g_set_error(
 					error,
 					R_SIGNATURE_ERROR,


### PR DESCRIPTION
When use-bundle-signing-time is enabled, cms_verify_bytes reads the pkcs9 signingTime attribute out of the CMS before the signature is verified and dereferences so->value.utctime after only a NULL check. Because the attribute value is an ASN.1 ANY, a bundle whose signingTime is encoded as a non-time tag such as a BOOLEAN leaves that union member holding an int instead of a pointer, so the NULL check passes and ASN1_TIME_to_tm then dereferences a bogus pointer and crashes during verification. This checks the tag is UTCTime or GeneralizedTime before touching the value, and reads it through so->value.asn1_string.