### PR TITLE
SECURITY.md: align to the org-wide default policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,52 @@
-Reporting a Vulnerability
-=========================
+# Security Policy
 
-**Do not open GitHub issues for security vulnerabilities as they are public!**
+The RAUC project takes the security of its code seriously.
+If you think you have found a security vulnerability, please read this policy
+and follow the instructions to report your finding.
 
-Please report security vulnerabilities to security@pengutronix.de.
-We will work with the reporter to create a fix and to coordinate the disclosure.
+## Reporting a Vulnerability
+
+If you think you have found a vulnerability, please report it to us through
+coordinated disclosure.
+
+**Please DO NOT report vulnerabilities via public issues, discussions, pull
+requests, chat channels or mailing lists.**
+
+Instead, report security vulnerabilities to the [Pengutronix Security
+Team](mailto:security@pengutronix.de).
+Reports in English or German are welcome.
+
+Please provide a detailed description of the issue, the steps and configuration
+to reproduce it, the affected version(s), whether you are aware of exploitation
+in the wild and, if already available, a proposal for a fix.
+This information will help us triage your report more quickly.
+You should receive a response within five German business days.
+If for some reason you do not, please follow up via email to ensure we received
+your original message.
+
+If we confirm the issue as a vulnerability, we will publish a Security Advisory
+on GitHub and credit you in the advisory if desired.
+We follow the [coordinated vulnerability
+disclosure](https://certcc.github.io/CERT-Guide-to-CVD/) model and will define
+an appropriate disclosure timeline together with you.
+Note that legal reporting obligations may require us to notify authorities
+about certain vulnerabilities within fixed deadlines, independent of the agreed
+disclosure timeline.
+If you have not requested a CVE yourself, we will request one via GitHub where
+appropriate.
+
+Note that we do not offer financial compensation or maintain a hall of fame for
+vulnerability reports.
+
+## Safe Harbor
+
+We consider good-faith security research on the code in our repositories to be
+authorized and welcome, and we will not pursue legal action for accidental
+violations of this policy in the course of such research.
+
+Please test only in your own environment or against systems you are authorized
+to test;
+do not target Pengutronix infrastructure, use social engineering, or access
+data that is not your own.
+This safe harbor covers only claims under our control and does not absolve you
+of obligations under applicable law.


### PR DESCRIPTION
We've added a default security policy to the RAUC org, so adopt the relevant parts for RAUC itself.