### PR TITLE
src/manifest: reject '/' in image filenames from bundled manifests

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -629,6 +629,11 @@ static gboolean check_manifest_bundled(const RaucManifest *mf, GError **error)
 		if (!image->filename)
 			continue;
 
+		if (strchr(image->filename, '/')) {
+			g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_CHECK_ERROR, "Image filename %s must not contain '/'", image->filename);
+			return FALSE;
+		}
+
 		if (image->checksum.type != G_CHECKSUM_SHA256) {
 			g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_CHECK_ERROR, "Unsupported checksum algorithm for image %s", image->filename);
 			return FALSE;
@@ -663,6 +668,15 @@ static gboolean check_manifest_bundled(const RaucManifest *mf, GError **error)
 			if (expected_len != image->converted->len) {
 				g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_CHECK_ERROR, "Inconsistent number of converted inputs/outputs for image %s", image->filename);
 				return FALSE;
+			}
+
+			for (guint i = 0; i < image->converted->len; i++) {
+				const gchar *converted = g_ptr_array_index(image->converted, i);
+
+				if (strchr(converted, '/')) {
+					g_set_error(error, R_MANIFEST_ERROR, R_MANIFEST_CHECK_ERROR, "Converted image filename %s must not contain '/'", converted);
+					return FALSE;
+				}
 			}
 		}
 	}

--- a/test/manifest.c
+++ b/test/manifest.c
@@ -876,6 +876,43 @@ hooks=install\n\
 	g_assert_true(res);
 }
 
+/* Check that an image filename containing '/' is rejected for a manifest read
+ * from a bundle, as such a filename is used to build a path below the bundle
+ * directory.
+ */
+static void test_manifest_image_filename_with_slash(void)
+{
+	g_autofree gchar *tmpdir = NULL;
+	g_autofree gchar *manifestpath = NULL;
+	g_autoptr(RaucManifest) rm = NULL;
+	gboolean res = FALSE;
+	g_autoptr(GError) error = NULL;
+	const gchar *mffile = "\
+[update]\n\
+compatible=FooCorp Super BarBazzer\n\
+version=2015.04-1\n\
+\n\
+[image.rootfs]\n\
+filename=../../../../tmp/rootfs-default.ext4\n\
+sha256=0815\n\
+size=1\n\
+";
+
+	tmpdir = g_dir_make_tmp("rauc-XXXXXX", NULL);
+	g_assert_nonnull(tmpdir);
+
+	manifestpath = write_tmp_file(tmpdir, "manifest.raucm", mffile, NULL);
+	g_assert_nonnull(manifestpath);
+
+	res = load_manifest_file(manifestpath, &rm, &error);
+	g_assert_no_error(error);
+	g_assert_true(res);
+
+	res = check_manifest_internal(rm, &error);
+	g_assert_error(error, R_MANIFEST_ERROR, R_MANIFEST_CHECK_ERROR);
+	g_assert_false(res);
+}
+
 /* Test manifest/invalid_data:
  *
  * Tests parsing invalid data: *
@@ -1026,6 +1063,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/manifest/invalid_hook_combination", test_manifest_invalid_hook_combination);
 	g_test_add_func("/manifest/missing_hook_name", test_manifest_missing_hook_name);
 	g_test_add_func("/manifest/missing_image_size", test_manifest_missing_image_size);
+	g_test_add_func("/manifest/image_filename_with_slash", test_manifest_image_filename_with_slash);
 	g_test_add_func("/manifest/invalid_data", test_invalid_data);
 
 	return g_test_run();


### PR DESCRIPTION
check_manifest_bundled backs check_manifest_internal and check_manifest_external, but unlike check_manifest_input it never rejects an image filename containing '/'. Those filenames become path components: install.c uses image->filename verbatim when it is absolute and otherwise joins it onto the bundle directory, and the casync conversion path joins it onto the extracted content dir, so a bundle-supplied manifest with `filename=/etc/shadow` or `filename=../../../../tmp/x` resolves outside the bundle. This applies the same rejection check_manifest_input already does, to the image filename and to the converted output names that install.c builds paths from in the same way. Worth checking that last part: 'rauc bundle' derives the converted names from the image filename, so they should never legitimately contain a slash, and no bundle rauc can create is affected since check_manifest_input already forbids it.