### PR TITLE
src/main: don't print image type for artifacts

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1114,7 +1114,8 @@ static gchar *info_formatter_readable(RaucManifest *manifest)
 		} else {
 			g_string_append_printf(text, "    (no image file)\n");
 		}
-		g_string_append_printf(text, "    Type:      %s%s\n", img->type, img->type_from_fileext ? " (detected)" : "");
+		if (!img->artifact) // as long as 'type' is not supported for artifacts, don't display it for artifacts
+			g_string_append_printf(text, "    Type:      %s%s\n", img->type, img->type_from_fileext ? " (detected)" : "");
 		if (img->filename) {
 			g_autofree gchar* formatted_size = g_format_size_full(img->checksum.size, G_FORMAT_SIZE_LONG_FORMAT);
 			g_string_append_printf(text, "    Checksum:  %s\n", img->checksum.digest);


### PR DESCRIPTION
Currently, the purpose of image types is not defined for artifacts. So don't display lines like

  | Type:      tar (detected)

for these, to not confuse users.

The if clause may be removed as soon as 'type' has a meaning for artifacts.

Inspired by #1991.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
