### PR TITLE
add per-slot runtime-state storage in /run/rauc

### DIFF
--- a/include/runtime_state.h
+++ b/include/runtime_state.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <glib.h>
+
+#include "slot.h"
+
+/**
+ * Initialize the runtime-state subsystem.
+ *
+ * Allocates an internal GKeyFile and remembers the path. If @path already
+ * exists it is loaded; missing files yield an empty GKeyFile and success. A
+ * corrupt file is renamed to <path>.broken and a fresh empty GKeyFile is used.
+ *
+ * @param path Path to the runtime-state file
+ * @param error Return location for a GError, or NULL
+ *
+ * @return TRUE on success (including the "file does not exist" case),
+ *         FALSE on a non-recoverable error
+ */
+gboolean r_runtime_state_init(const gchar *path, GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
+ * Set a per-slot key/value pair.
+ *
+ * If @value is NULL, the key is removed from the slot's group.
+ * Changes are held in memory until r_runtime_state_commit() is called.
+ *
+ * @param slot Slot whose name selects the group
+ * @param key Key name within the slot group
+ * @param value Value, or NULL to remove the key
+ */
+void r_runtime_state_slot_set(RaucSlot *slot, const gchar *key, const gchar *value);
+
+/**
+ * Get a per-slot key value.
+ *
+ * @param slot Slot whose name selects the group
+ * @param key Key name within the slot group
+ * @param value Out-parameter, newly-allocated value on TRUE, NULL on FALSE
+ *
+ * @return TRUE if the key exists, FALSE otherwise (also FALSE if init
+ *         has not been called)
+ */
+gboolean r_runtime_state_slot_get(RaucSlot *slot, const gchar *key, gchar **value)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
+ * Persist the current runtime-state.
+ *
+ * Creates the parent directory if needed.
+ *
+ * @param error Return location for a GError, or NULL
+ *
+ * @return TRUE on success, FALSE on error
+ */
+gboolean r_runtime_state_commit(GError **error)
+G_GNUC_WARN_UNUSED_RESULT;
+
+/**
+ * Free the runtime-state subsystem's storage.
+ *
+ * Called from r_context_clean() at process teardown.
+ */
+void r_runtime_state_cleanup(void);

--- a/meson.build
+++ b/meson.build
@@ -133,6 +133,7 @@ sources_rauc = files([
   'src/mbr.c',
   'src/mount.c',
   'src/polling.c',
+  'src/runtime_state.c',
   'src/service.c',
   'src/shell.c',
   'src/signature.c',

--- a/src/context.c
+++ b/src/context.c
@@ -10,6 +10,7 @@
 #include "status_file.h"
 #include "network.h"
 #include "install.h"
+#include "runtime_state.h"
 #include "signature.h"
 #include "utils.h"
 
@@ -376,6 +377,13 @@ static gboolean r_context_configure_target(GError **error)
 		}
 
 		r_slot_status_load_globally(context->config->statusfile_path, context->config->slots);
+	}
+
+	g_autofree gchar *runtime_state_path = g_build_filename(
+			context->runtime_directory, "runtime-state", NULL);
+	if (!r_runtime_state_init(runtime_state_path, &ierror)) {
+		g_warning("Failed to initialize runtime state: %s", ierror->message);
+		g_clear_error(&ierror);
 	}
 
 	/* set up logging */
@@ -948,6 +956,7 @@ void r_context_clean(void)
 		g_clear_pointer(&context->configoverride, g_list_free);
 
 		g_clear_pointer(&context->system_status, r_system_status_free);
+		r_runtime_state_cleanup();
 
 		g_clear_pointer(&context, g_free);
 	}

--- a/src/runtime_state.c
+++ b/src/runtime_state.c
@@ -1,0 +1,134 @@
+#include <errno.h>
+#include <glib/gstdio.h>
+
+#include "runtime_state.h"
+#include "status_file.h"
+
+/* Module-private state. Kept here rather than on the RaucContext struct
+ * because the API must remain usable both during configure_target (when
+ * r_context() would recurse) and after configure (when r_context_conf()
+ * would re-set pending=TRUE and risk a spurious re-configure). */
+static GMutex runtime_state_lock;
+static GKeyFile *runtime_state_keyfile = NULL;
+static gchar *runtime_state_path = NULL;
+
+static gchar *make_group_name(RaucSlot *slot)
+{
+	return g_strdup_printf(RAUC_SLOT_PREFIX ".%s", slot->name);
+}
+
+gboolean r_runtime_state_init(const gchar *path, GError **error)
+{
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(path, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	G_GNUC_UNUSED g_autoptr(GMutexLocker) locker = g_mutex_locker_new(&runtime_state_lock);
+
+	g_autoptr(GKeyFile) key_file = g_key_file_new();
+	if (!g_key_file_load_from_file(key_file, path, G_KEY_FILE_NONE, &ierror)) {
+		if (g_error_matches(ierror, G_FILE_ERROR, G_FILE_ERROR_NOENT)) {
+			g_info("Runtime state file '%s' does not exist yet", path);
+			g_clear_error(&ierror);
+		} else {
+			g_autofree gchar *broken_file = g_strconcat(path, ".broken", NULL);
+			g_warning("Failed to load runtime state '%s': %s", path, ierror->message);
+			g_warning("Will move runtime state file to %s and re-create it.", broken_file);
+			g_clear_error(&ierror);
+			if (g_rename(path, broken_file) != 0) {
+				int err = errno;
+				g_warning("Renaming %s to %s failed: %s", path, broken_file, g_strerror(err));
+			}
+			g_clear_pointer(&key_file, g_key_file_unref);
+			key_file = g_key_file_new();
+		}
+	}
+
+	g_clear_pointer(&runtime_state_keyfile, g_key_file_unref);
+	g_clear_pointer(&runtime_state_path, g_free);
+	runtime_state_keyfile = g_steal_pointer(&key_file);
+	runtime_state_path = g_strdup(path);
+
+	return TRUE;
+}
+
+void r_runtime_state_slot_set(RaucSlot *slot, const gchar *key, const gchar *value)
+{
+	g_return_if_fail(slot);
+	g_return_if_fail(key);
+
+	G_GNUC_UNUSED g_autoptr(GMutexLocker) locker = g_mutex_locker_new(&runtime_state_lock);
+
+	g_return_if_fail(runtime_state_keyfile);
+
+	g_autofree gchar *group = make_group_name(slot);
+	if (value == NULL)
+		g_key_file_remove_key(runtime_state_keyfile, group, key, NULL);
+	else
+		g_key_file_set_string(runtime_state_keyfile, group, key, value);
+}
+
+gboolean r_runtime_state_slot_get(RaucSlot *slot, const gchar *key, gchar **value)
+{
+	g_autoptr(GError) ierror = NULL;
+
+	g_return_val_if_fail(slot, FALSE);
+	g_return_val_if_fail(key, FALSE);
+	g_return_val_if_fail(value && *value == NULL, FALSE);
+
+	G_GNUC_UNUSED g_autoptr(GMutexLocker) locker = g_mutex_locker_new(&runtime_state_lock);
+
+	if (!runtime_state_keyfile)
+		return FALSE;
+
+	g_autofree gchar *group = make_group_name(slot);
+	gchar *result = g_key_file_get_string(runtime_state_keyfile, group, key, &ierror);
+	if (!result) {
+		if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_GROUP_NOT_FOUND) ||
+		    g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND))
+			return FALSE;
+		g_warning("Failed to read runtime-state key '%s' in [%s]: %s",
+				key, group, ierror->message);
+		return FALSE;
+	}
+
+	*value = result;
+	return TRUE;
+}
+
+gboolean r_runtime_state_commit(GError **error)
+{
+	GError *ierror = NULL;
+
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	G_GNUC_UNUSED g_autoptr(GMutexLocker) locker = g_mutex_locker_new(&runtime_state_lock);
+
+	g_return_val_if_fail(runtime_state_keyfile, FALSE);
+	g_return_val_if_fail(runtime_state_path, FALSE);
+
+	g_autofree gchar *dir = g_path_get_dirname(runtime_state_path);
+	if (g_mkdir_with_parents(dir, 0755) != 0) {
+		int err = errno;
+		g_set_error(error, G_FILE_ERROR, g_file_error_from_errno(err),
+				"Failed to create runtime state directory '%s': %s",
+				dir, g_strerror(err));
+		return FALSE;
+	}
+
+	if (!g_key_file_save_to_file(runtime_state_keyfile, runtime_state_path, &ierror)) {
+		g_propagate_error(error, ierror);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+void r_runtime_state_cleanup(void)
+{
+	G_GNUC_UNUSED g_autoptr(GMutexLocker) locker = g_mutex_locker_new(&runtime_state_lock);
+
+	g_clear_pointer(&runtime_state_keyfile, g_key_file_unref);
+	g_clear_pointer(&runtime_state_path, g_free);
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,6 +16,7 @@ tests = [
   'install',
   'manifest',
   'progress',
+  'runtime_state',
   'service',
   'signature',
   'slot',

--- a/test/runtime_state.c
+++ b/test/runtime_state.c
@@ -1,0 +1,162 @@
+#include <stdio.h>
+#include <locale.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include <runtime_state.h>
+#include <slot.h>
+
+typedef struct {
+	gchar *tmpdir;
+	gchar *path;
+} RuntimeStateFixture;
+
+static void runtime_state_fixture_set_up(RuntimeStateFixture *fixture, gconstpointer user_data)
+{
+	fixture->tmpdir = g_dir_make_tmp("rauc-runtime-state-XXXXXX", NULL);
+	g_assert_nonnull(fixture->tmpdir);
+	fixture->path = g_build_filename(fixture->tmpdir, "runtime-state.conf", NULL);
+}
+
+static void runtime_state_fixture_tear_down(RuntimeStateFixture *fixture, gconstpointer user_data)
+{
+	r_runtime_state_cleanup();
+
+	if (fixture->path)
+		g_unlink(fixture->path);
+	g_autofree gchar *broken = g_strconcat(fixture->path, ".broken", NULL);
+	g_unlink(broken);
+
+	g_rmdir(fixture->tmpdir);
+	g_clear_pointer(&fixture->tmpdir, g_free);
+	g_clear_pointer(&fixture->path, g_free);
+}
+
+static RaucSlot *make_slot(const gchar *name)
+{
+	RaucSlot *slot = g_new0(RaucSlot, 1);
+	slot->name = g_intern_string(name);
+	return slot;
+}
+
+static void runtime_state_test_init_missing(RuntimeStateFixture *fixture, gconstpointer user_data)
+{
+	GError *ierror = NULL;
+	g_autoptr(RaucSlot) slot = make_slot("rootfs.0");
+	g_autofree gchar *value = NULL;
+
+	g_assert_true(r_runtime_state_init(fixture->path, &ierror));
+	g_assert_no_error(ierror);
+
+	g_assert_false(r_runtime_state_slot_get(slot, "any-key", &value));
+	g_assert_null(value);
+}
+
+static void runtime_state_test_set_get(RuntimeStateFixture *fixture, gconstpointer user_data)
+{
+	GError *ierror = NULL;
+	g_autoptr(RaucSlot) slot = make_slot("rootfs.0");
+	g_autofree gchar *value = NULL;
+
+	g_assert_true(r_runtime_state_init(fixture->path, &ierror));
+	g_assert_no_error(ierror);
+
+	r_runtime_state_slot_set(slot, "good-region", "primary");
+
+	g_assert_true(r_runtime_state_slot_get(slot, "good-region", &value));
+	g_assert_cmpstr(value, ==, "primary");
+}
+
+static void runtime_state_test_commit_persistence(RuntimeStateFixture *fixture, gconstpointer user_data)
+{
+	GError *ierror = NULL;
+	g_autoptr(RaucSlot) slot = make_slot("bootloader.0");
+	g_autofree gchar *value = NULL;
+
+	g_assert_true(r_runtime_state_init(fixture->path, &ierror));
+	g_assert_no_error(ierror);
+	r_runtime_state_slot_set(slot, "good-region", "secondary");
+	g_assert_true(r_runtime_state_commit(&ierror));
+	g_assert_no_error(ierror);
+	g_assert_true(g_file_test(fixture->path, G_FILE_TEST_EXISTS));
+
+	r_runtime_state_cleanup();
+
+	g_assert_true(r_runtime_state_init(fixture->path, &ierror));
+	g_assert_no_error(ierror);
+	g_assert_true(r_runtime_state_slot_get(slot, "good-region", &value));
+	g_assert_cmpstr(value, ==, "secondary");
+}
+
+static void runtime_state_test_set_null_removes(RuntimeStateFixture *fixture, gconstpointer user_data)
+{
+	GError *ierror = NULL;
+	g_autoptr(RaucSlot) slot = make_slot("rootfs.0");
+	g_autofree gchar *value = NULL;
+
+	g_assert_true(r_runtime_state_init(fixture->path, &ierror));
+	g_assert_no_error(ierror);
+	r_runtime_state_slot_set(slot, "good-region", "primary");
+	g_assert_true(r_runtime_state_slot_get(slot, "good-region", &value));
+	g_clear_pointer(&value, g_free);
+
+	r_runtime_state_slot_set(slot, "good-region", NULL);
+	g_assert_false(r_runtime_state_slot_get(slot, "good-region", &value));
+	g_assert_null(value);
+}
+
+static void runtime_state_test_corrupt_file(RuntimeStateFixture *fixture, gconstpointer user_data)
+{
+	GError *ierror = NULL;
+	g_autoptr(RaucSlot) slot = make_slot("rootfs.0");
+	g_autofree gchar *value = NULL;
+	g_autofree gchar *broken = g_strconcat(fixture->path, ".broken", NULL);
+
+	g_assert_true(g_file_set_contents(fixture->path, "this is not a keyfile\n", -1, NULL));
+
+	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+			"Failed to load runtime state*");
+	g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+			"Will move runtime state file*");
+
+	g_assert_true(r_runtime_state_init(fixture->path, &ierror));
+	g_assert_no_error(ierror);
+
+	g_test_assert_expected_messages();
+
+	g_assert_true(g_file_test(broken, G_FILE_TEST_EXISTS));
+	g_assert_false(g_file_test(fixture->path, G_FILE_TEST_EXISTS));
+
+	g_assert_false(r_runtime_state_slot_get(slot, "good-region", &value));
+	g_assert_null(value);
+}
+
+int main(int argc, char *argv[])
+{
+	setlocale(LC_ALL, "C");
+
+	g_test_init(&argc, &argv, NULL);
+
+	g_test_add("/runtime-state/init-missing", RuntimeStateFixture, NULL,
+			runtime_state_fixture_set_up,
+			runtime_state_test_init_missing,
+			runtime_state_fixture_tear_down);
+	g_test_add("/runtime-state/set-get", RuntimeStateFixture, NULL,
+			runtime_state_fixture_set_up,
+			runtime_state_test_set_get,
+			runtime_state_fixture_tear_down);
+	g_test_add("/runtime-state/commit-persistence", RuntimeStateFixture, NULL,
+			runtime_state_fixture_set_up,
+			runtime_state_test_commit_persistence,
+			runtime_state_fixture_tear_down);
+	g_test_add("/runtime-state/set-null-removes", RuntimeStateFixture, NULL,
+			runtime_state_fixture_set_up,
+			runtime_state_test_set_null_removes,
+			runtime_state_fixture_tear_down);
+	g_test_add("/runtime-state/corrupt-file", RuntimeStateFixture, NULL,
+			runtime_state_fixture_set_up,
+			runtime_state_test_corrupt_file,
+			runtime_state_fixture_tear_down);
+
+	return g_test_run();
+}


### PR DESCRIPTION
Add a small subsystem that lets handlers persist per-slot key/value pairs in `/run/rauc/runtime-state` using the same `GKeyFile` approach as the existing status file. The state is wiped on reboot (tmpfs) but survives a 'rauc' process restart within the same boot, which is what the upcoming boot-mtd-fallback recovery logic needs.

Public API (`include/runtime_state.h`):
```
  gboolean r_runtime_state_init(const gchar *path, GError **error);
  void     r_runtime_state_slot_set(RaucSlot *, const gchar *key, const gchar *value);
  gboolean r_runtime_state_slot_get(RaucSlot *, const gchar *key, gchar **value);
  gboolean r_runtime_state_commit(GError **error);
  void     r_runtime_state_cleanup(void);
```
Groups follow the existing `slot.<slot.name>` convention from the `system.conf` sections. A corrupt file is renamed to `<path>.broken` on init, matching the status-file recovery pattern.

I've used Claude to generate this code based on my specs. I've reviewed, tested and slightly reworked the result.

Assisted-by: Claude:claude-opus-4.7