### PR TITLE
bootloaders/efi: propagate inner error from efi_bootorder_set()

### DIFF
--- a/src/bootloaders/efi.c
+++ b/src/bootloaders/efi.c
@@ -484,7 +484,7 @@ static gboolean efi_modify_persistent_bootorder(RaucSlot *slot, gboolean prepend
 
 	g_autofree gchar *order = g_strjoinv(",", (gchar**)bootorder->pdata);
 
-	if (!efi_bootorder_set(order, NULL)) {
+	if (!efi_bootorder_set(order, &ierror)) {
 		g_propagate_prefixed_error(error, ierror, "Modifying bootorder failed: ");
 		return FALSE;
 	}

--- a/test/bin/efibootmgr
+++ b/test/bin/efibootmgr
@@ -80,6 +80,9 @@ def json_mode(args, vars_file):
 
 def static_mode(args):
     if args.bootorder is not None:
+        if os.environ.get("EFIBOOTMGR_FAIL_BOOTORDER"):
+            print("efibootmgr: error setting boot order", file=sys.stderr)
+            sys.exit(1)
         # Test code must move system1 to primary position. Assert this!
         print(f"--bootorder: {args.bootorder}")
         # if args.bootorder != "0002,0001,0003,0000":

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -972,6 +972,57 @@ bootname=system1\n";
 	g_assert_nonnull(bootname);
 }
 
+/* If the underlying 'efibootmgr --bootorder ...' call fails (e.g. the
+ * firmware refuses the NVRAM write), r_boot_set_state()/r_boot_set_primary()
+ * must fail cleanly with a proper GError set instead of aborting. */
+static void bootchooser_efi_bootorder_failure(BootchooserFixture *fixture,
+		gconstpointer user_data)
+{
+	RaucSlot *slot;
+	GError *error = NULL;
+
+	const gchar *cfg_file = "\
+[system]\n\
+compatible=FooCorp Super BarBazzer\n\
+bootloader=efi\n\
+mountprefix=/mnt/myrauc/\n\
+\n\
+[keyring]\n\
+path=/etc/rauc/keyring/\n\
+\n\
+[slot.rootfs.0]\n\
+device=/dev/rootfs-0\n\
+type=ext4\n\
+bootname=system0\n\
+\n\
+[slot.rootfs.1]\n\
+device=/dev/rootfs-1\n\
+type=ext4\n\
+bootname=system1\n";
+
+	gchar* pathname = write_tmp_file(fixture->tmpdir, "efi-fail.conf", cfg_file, NULL);
+	g_assert_nonnull(pathname);
+
+	g_clear_pointer(&r_context_conf()->configpath, g_free);
+	r_context_conf()->configpath = pathname;
+	r_context();
+
+	slot = find_config_slot_by_name(r_context()->config, "rootfs.0");
+	g_assert_nonnull(slot);
+
+	g_assert_true(g_setenv("EFIBOOTMGR_FAIL_BOOTORDER", "1", TRUE));
+
+	g_assert_false(r_boot_set_state(slot, FALSE, &error));
+	g_assert_nonnull(error);
+	g_clear_error(&error);
+
+	g_assert_false(r_boot_set_primary(slot, &error));
+	g_assert_nonnull(error);
+	g_clear_error(&error);
+
+	g_unsetenv("EFIBOOTMGR_FAIL_BOOTORDER");
+}
+
 /* Write content to state storage for custom-backend RAUC mock
  * tools. Content should be similar to:
  * "\
@@ -1234,6 +1285,10 @@ int main(int argc, char *argv[])
 
 	g_test_add("/bootchooser/efi", BootchooserFixture, NULL,
 			bootchooser_fixture_set_up, bootchooser_efi,
+			bootchooser_fixture_tear_down);
+
+	g_test_add("/bootchooser/efi-bootorder-failure", BootchooserFixture, NULL,
+			bootchooser_fixture_set_up, bootchooser_efi_bootorder_failure,
 			bootchooser_fixture_tear_down);
 
 	g_test_add("/bootchooser/custom", BootchooserFixture, NULL,


### PR DESCRIPTION
While reading through the EFI bootchooser backend I noticed `efi_modify_persistent_bootorder()` calls `efi_bootorder_set(order, NULL)` and just throws away the inner error. Right after that it does `g_propagate_prefixed_error(error, ierror, "Modifying bootorder failed: ")`, which unconditionally dereferences `ierror` - but `ierror` is always NULL here since nothing ever gets a chance to set it. GLib's GError functions assert that the source error is non-NULL, so this doesn't turn into a nice error message, it aborts the process.

This path is reached from `r_mark_good()`/`r_mark_bad()`/`r_mark_active()` on every boot when `bootloader=efi`, so any time the underlying `efibootmgr --bootorder ...` call fails for a real-world reason (NVRAM full, firmware refusing the write, insufficient permissions, etc.) the rauc mark-good service or CLI crashes instead of just reporting the failure.

Fix is a one-liner: pass `&ierror` instead of `NULL` so the inner error actually gets captured before being propagated.

I reproduced it locally by building with meson/ninja and making the `efibootmgr` test mock fail the `--bootorder` call - before the fix `bootchooser-test` aborts with `GLib-FATAL-CRITICAL: g_propagate_error: assertion 'src != NULL' failed`, after the fix it just returns FALSE with a proper error message. Added a regression test (`/bootchooser/efi-bootorder-failure`) covering this along with a small env-var-gated failure trigger in the `efibootmgr` mock script, both included in this PR.
