### PR TITLE
src/install: bound field access when parsing handler status lines

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -587,6 +587,7 @@ static gchar* parse_handler_output(gchar* line)
 {
 	gchar *message = NULL;
 	g_auto(GStrv) split = NULL;
+	guint fields;
 
 	g_assert_nonnull(line);
 
@@ -596,15 +597,16 @@ static gchar* parse_handler_output(gchar* line)
 	}
 
 	split = g_strsplit(line, " ", 5);
+	fields = g_strv_length(split);
 
-	if (!split[1])
+	if (fields < 2)
 		return NULL;
 
-	if (g_strcmp0(split[1], "handler") == 0) {
+	if (g_strcmp0(split[1], "handler") == 0 && fields >= 3) {
 		message = g_strdup_printf("Handler status: %s", split[2]);
-	} else if (g_strcmp0(split[1], "image") == 0) {
+	} else if (g_strcmp0(split[1], "image") == 0 && fields >= 4) {
 		message = g_strdup_printf("Image '%s' status: %s", split[2], split[3]);
-	} else if (g_strcmp0(split[1], "bootloader") == 0) {
+	} else if (g_strcmp0(split[1], "bootloader") == 0 && fields >= 3) {
 		message = g_strdup_printf("Bootloader status: %s", split[2]);
 	} else if (g_strcmp0(split[1], "error") == 0) {
 		g_autofree gchar *joined = g_strjoinv(" ", &split[2]);

--- a/test/install-content/custom_handler.sh
+++ b/test/install-content/custom_handler.sh
@@ -4,6 +4,10 @@ set -e
 
 echo "<< debug $*"
 
+# status lines with missing fields must not upset the parser
+echo "<< image"
+echo "<< handler"
+
 echo "<< handler [STARTED]"
 
 function exit_if_empty {


### PR DESCRIPTION
parse_handler_output() reads split[2] and split[3] after g_strsplit(line, " ", 5) without checking how many tokens came back, so a handler that prints a short status line like "<< image" makes it read one past the end of the pointer array and hand the garbage pointer to g_strdup_printf("%s"); "<< handler" and "<< bootloader" pass a NULL split[2] to %s the same way. The lines are the stdout of the custom handler and the pre/post-install handlers, so this is reachable whenever a handler emits a status line with a field missing. I check the token count before indexing and let short lines fall through to the existing "Unknown handler output" branch, and added two such lines to the test handler so the sanitizer job exercises them; worth confirming the extra output lines are welcome there.