### PR TITLE
src/main: always create symlinks for slot independent artifacts

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2415,9 +2415,6 @@ static void create_run_links(void)
 		}
 	}
 
-	if (!booted_slot)
-		return;
-
 	g_autofree gchar *run_artifacts = g_build_filename(
 			r_context()->runtime_directory, "artifacts", NULL);
 
@@ -2435,6 +2432,9 @@ static void create_run_links(void)
 		if (!repo->parent_class) {
 			target = g_build_filename(repo->path, NULL);
 		} else {
+			if (!booted_slot)
+				continue;
+
 			target = g_build_filename(repo->path, booted_slot->name, NULL);
 		}
 


### PR DESCRIPTION
Create the symlinks for slot independent artifacts even when RAUC cannot determine the currently booted slot (e.g. when booting via NFS).

As a side effect the artifacts directory is also always created and isn't missing when no booted slot could be determined.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
