### PR TITLE
test/conftest.py: explicitly read into dummy variable

### DIFF
--- a/test/.ruff.toml
+++ b/test/.ruff.toml
@@ -5,6 +5,3 @@ ignore = [
     "RUF059", # disable until fixed
     "BLE001", # accept catch all for Exception
 ]
-
-[lint.per-file-ignores]
-"conftest.py" = ["B018"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -669,7 +669,7 @@ class System:
             time.sleep(0.1)
             try:
                 self.proxy = bus.get_proxy("de.pengutronix.rauc", "/")
-                self.proxy.Operation  # try to access the service
+                _ = self.proxy.Operation  # try to access the service
                 break
             except DBusError:
                 if time.monotonic() > timeout:


### PR DESCRIPTION
This avoids having to disable ruff check here.