### PR TITLE
src/checksum: remove unused verify_checksum()

### DIFF
--- a/include/checksum.h
+++ b/include/checksum.h
@@ -30,15 +30,3 @@ typedef struct {
  */
 gboolean compute_checksum(RaucChecksum *checksum, const gchar *filename, GError **error)
 G_GNUC_WARN_UNUSED_RESULT;
-
-/**
- * Verifies provided file checksum.
- *
- * The provided checksum if compared the the checksum calculated for the provided file
- *
- * @param checksum file checksum to verify
- * @param filename name of file to verify checksum against
- * @return TRUE on success, FALSE if an error occurred
- */
-gboolean verify_checksum(const RaucChecksum *checksum, const gchar *filename, GError **error)
-G_GNUC_WARN_UNUSED_RESULT;

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -69,34 +69,3 @@ gboolean compute_checksum(RaucChecksum *checksum, const gchar *filename, GError 
 
 	return TRUE;
 }
-
-gboolean verify_checksum(const RaucChecksum *checksum, const gchar *filename, GError **error)
-{
-	gboolean res = FALSE;
-	RaucChecksum computed = {};
-
-	if (checksum->digest == NULL) {
-		g_set_error(error, R_CHECKSUM_ERROR, R_CHECKSUM_ERROR_FAILED, "No digest provided");
-		goto out;
-	}
-	computed.type = checksum->type;
-
-	if (!compute_checksum(&computed, filename, error))
-		goto out;
-
-	res = checksum->size == computed.size;
-	if (!res) {
-		g_set_error(error, R_CHECKSUM_ERROR, R_CHECKSUM_ERROR_SIZE_MISMATCH, "Sizes do not match");
-		goto out;
-	}
-
-	res = g_str_equal(checksum->digest, computed.digest);
-	if (!res) {
-		g_set_error(error, R_CHECKSUM_ERROR, R_CHECKSUM_ERROR_DIGEST_MISMATCH, "Digests do not match");
-		goto out;
-	}
-
-out:
-	g_free(computed.digest);
-	return res;
-}

--- a/test/checksum.c
+++ b/test/checksum.c
@@ -11,45 +11,6 @@ static void checksum_test1(void)
 	RaucChecksum checksum = {};
 	GError *error = NULL;
 
-	checksum.type = 0;
-	checksum.digest = NULL;
-	g_assert_false(verify_checksum(&checksum, "test/install-content/appfs.img", &error));
-	g_assert_error(error, R_CHECKSUM_ERROR, R_CHECKSUM_ERROR_FAILED);
-	g_clear_error(&error);
-
-	checksum.type = G_CHECKSUM_SHA256;
-	g_free(checksum.digest);
-	checksum.digest = g_strdup(TEST_DIGEST_FAIL);
-	g_assert_false(verify_checksum(&checksum, "test/install-content/appfs.img", &error));
-	g_assert_error(error, R_CHECKSUM_ERROR, R_CHECKSUM_ERROR_SIZE_MISMATCH);
-	g_clear_error(&error);
-
-	checksum.size = 32768;
-	g_assert_false(verify_checksum(&checksum, "test/install-content/appfs.img", &error));
-	g_assert_error(error, R_CHECKSUM_ERROR, R_CHECKSUM_ERROR_DIGEST_MISMATCH);
-	g_clear_error(&error);
-
-	checksum.size = 0;
-	g_free(checksum.digest);
-	checksum.digest = g_strdup(TEST_DIGEST_GOOD);
-	g_assert_false(verify_checksum(&checksum, "test/install-content/appfs.img", &error));
-	g_assert_error(error, R_CHECKSUM_ERROR, R_CHECKSUM_ERROR_SIZE_MISMATCH);
-	g_clear_error(&error);
-
-	checksum.size = 32768;
-	g_assert_true(verify_checksum(&checksum, "test/install-content/appfs.img", &error));
-	g_assert_no_error(error);
-
-	g_assert_false(verify_checksum(&checksum, "tesinstall-content/rootfs.img", &error));
-	g_assert_error(error, G_FILE_ERROR, G_FILE_ERROR_NOENT);
-	g_clear_error(&error);
-
-	g_assert_false(verify_checksum(&checksum, "test/_MISSING_", &error));
-	g_assert_error(error, G_FILE_ERROR, G_FILE_ERROR_NOENT);
-	g_clear_error(&error);
-
-	g_clear_pointer(&checksum.digest, g_free);
-	checksum.size = 0;
 	g_assert_true(compute_checksum(&checksum, "test/install-content/appfs.img", &error));
 	g_assert_no_error(error);
 	g_assert_cmpstr(checksum.digest, ==, TEST_DIGEST_GOOD);


### PR DESCRIPTION
This is unused code since a87a227a ("src/install: remove checksum verification for files in bundle").

Verifying the checksums during installation was only required for the old RAUC 'network' mode that was removed with cc86459f ("src/install: remove network mode") in 2019 already.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

<!--
In case your PR fixes an issue, please reference it in the next line, i.e.
Fixes: #[insert number without brackets here]
-->
