### PR TITLE
test: check casync conversion of archive (tar) images

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,10 +2,12 @@ import json
 import os
 import shutil
 import subprocess
+import tarfile
 import time
 from configparser import ConfigParser
 from contextlib import contextmanager
 from functools import cache
+from io import BytesIO
 from pathlib import Path
 from random import Random
 
@@ -481,6 +483,15 @@ class Bundle:
     def make_random_image(self, image_name, size, seed):
         path = self.content / self.manifest[f"image.{image_name}"]["filename"]
         self._make_random_file(path, size, seed)
+
+    def make_tar_image(self, image_name, contents):
+        path = self.content / self.manifest[f"image.{image_name}"]["filename"]
+
+        with tarfile.open(name=path, mode="w") as t:
+            for filename, data in contents.items():
+                f = tarfile.TarInfo(name=filename)
+                f.size = len(data)
+                t.addfile(f, BytesIO(data))
 
     def add_hook_script(self, hook_script):
         path = self.content / "hook.sh"

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -1,6 +1,7 @@
+import json
 import shutil
 
-from conftest import have_casync, have_desync
+from conftest import have_casync, have_desync, have_json
 from helper import run
 
 
@@ -125,6 +126,42 @@ def test_convert_verity(tmp_path):
 
     assert (tmp_path / "casync-verity.raucb").exists()
     assert (tmp_path / "casync-verity.castr").is_dir()
+
+
+@have_casync
+@have_json
+def test_convert_archive(tmp_path, bundle):
+    bundle.manifest["image.rootfs"] = {
+        "filename": "rootfs.tar",
+    }
+    bundle.make_tar_image("rootfs", {"file": b"archive content"})
+    bundle.build()
+
+    out, err, exitcode = run(
+        "rauc"
+        " --cert openssl-ca/dev/autobuilder-1.cert.pem"
+        " --key openssl-ca/dev/private/autobuilder-1.pem"
+        " --keyring openssl-ca/dev-ca.pem"
+        f" convert {bundle.output} {tmp_path}/casync-archive.raucb"
+    )
+
+    assert exitcode == 0
+
+    assert (tmp_path / "casync-archive.raucb").exists()
+    assert (tmp_path / "casync-archive.castr").is_dir()
+
+    out, err, exitcode = run(
+        f"rauc --keyring openssl-ca/dev-ca.pem info --output-format=json-2 {tmp_path}/casync-archive.raucb"
+    )
+
+    assert exitcode == 0
+
+    info = json.loads(out)
+
+    images = {image["slot-class"]: image for image in info["images"]}
+    # archive images are converted to a casync directory tree index (.caidx),
+    # not a blob index (.caibx)
+    assert images["rootfs"]["filename"] == "rootfs.tar.caidx"
 
 
 @have_desync


### PR DESCRIPTION
Add `Bundle.make_tar_image()` to `conftest.py` for building a tar-based image and use it to verify that `rauc convert` converts an archive image (matched by `*.tar*/*.catar`) into a casync directory tree index (`.caidx`) instead of a blob index (`.caibx`).