### PR TITLE
src/update_handler: emmc: allow bootloader updates, if user partition was active

### DIFF
--- a/src/update_handler.c
+++ b/src/update_handler.c
@@ -2348,11 +2348,22 @@ static gboolean img_to_boot_emmc_handler(RaucImage *image, RaucSlot *dest_slot, 
 	/* read active boot partition from ext_csd */
 	res = r_emmc_read_bootpart(realdev, &part_active, &ierror);
 	if (!res) {
-		g_propagate_error(error, ierror);
-		return FALSE;
-	}
-
-	if (part_active == -1) {
+		/* An active user partition (UDA) is not a valid boot partition,
+		 * but was historically supported. Preserve that behaviour by
+		 * only warning and continuing instead of aborting. Reserved or
+		 * otherwise invalid values are still rejected below. */
+		if (g_error_matches(ierror, R_EMMC_ERROR, R_EMMC_ERROR_BOOTPART_UDA)) {
+			g_warning("%s Check your setup! Continuing using boot1 for the update.", ierror->message);
+			g_clear_error(&ierror);
+			/* For simplicity: Consider boot0 to be active, so that the
+			 * (inactive) boot1 partition is used as update target, matching
+			 * the behaviour prior to the UDA sanity check being added. */
+			part_active = 0;
+		} else {
+			g_propagate_error(error, ierror);
+			return FALSE;
+		}
+	} else if (part_active == -1) {
 		g_warning("eMMC device was not enabled for booting, yet. Ignoring.");
 		/* For simplicity: Consider boot1 to be active */
 		part_active = 1;


### PR DESCRIPTION
Commit 7a463272c (src/emmc: error-out for invalid bootpart in r_emmc_read_bootpart()) changed the behaviour to disallow bootloader updates in case the user partition was currently active.

The change restores the behaviour to allow that and log a warning only. Also match the implementation detail, that the boot partition 1 is used in that case.

<!--
Thank you for your pull request!

If this is your first pull request for RAUC, please read:
https://rauc.readthedocs.io/en/latest/contributing.html

Please describe what it changes, e.g. fixes a bug (and how), adds a feature, fixes documentation…

If you add a feature, please answer these questions:
- What do you use the feature for?
- How does RAUC benefit from the feature?
- How did you verify the feature works?
- If hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Please also allow edits by maintainers, so we can apply minor fixes directly.
-->

Fixes: #2017 
