### PR TITLE
Duplicate efi slot bootname to avoid double free

### DIFF
--- a/src/bootloaders/efi.c
+++ b/src/bootloaders/efi.c
@@ -630,7 +630,7 @@ gchar *r_efi_get_current_bootname(RaucConfig *config, GError **error)
 	RaucSlot *slot = NULL;
 	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
 		if (g_strcmp0(slot->bootname, bootcurrent->name) == 0) {
-			return slot->bootname;
+			return g_strdup(slot->bootname);
 		}
 	}
 

--- a/test/bootchooser.c
+++ b/test/bootchooser.c
@@ -970,6 +970,7 @@ bootname=system1\n";
 
 	bootname = r_boot_get_current_bootname(r_context()->config, "", &error);
 	g_assert_nonnull(bootname);
+	g_clear_pointer(&bootname, g_free);
 }
 
 /* If the underlying 'efibootmgr --bootorder ...' call fails (e.g. the


### PR DESCRIPTION
When running `rauc status` on a x86_64 system without a rauc commandline set I see the following error using `valgrind`:

```
# valgrind rauc status
==200== Memcheck, a memory error detector
==200== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==200== Using Valgrind-3.26.0 and LibVEX; rerun with -h for copyright info
==200== Command: rauc status
==200== 
rauc-Message: 07:48:53.542: Using central status file /srv/rauc/central.raucs
rauc-Message: 07:48:53.630: Using system config file /etc/rauc/system.conf
rauc-Message: 07:48:53.645: Failed to load system status: No such file or directory
=== System Info ===
Compatible:     OPS QEMU Machine
Variant:        (null)
System Version: (null)
Booted from:    uki.0 (uki0)

=== Bootloader ===
Activated: uki.0 (uki0)

=== Slot States ===
x [uki.0] (/dev/vda3, raw, booted)
      bootname: uki0
      boot status: good
    [efi.0] (/dev/vda1, vfat, active)

o [uki.1] (/dev/vda4, raw, inactive)
      bootname: uki1
      boot status: good
    [efi.1] (/dev/vda2, vfat, inactive)
==200== Invalid free() / delete / delete[] / realloc()
==200==    at 0x48B578B: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==200==    by 0x403B5FA: r_slot_free (slot.c:22)
==200==    by 0x4914542: g_hash_table_remove_all_nodes.part.0 (in /usr/lib/libglib-2.0.so.0.8600.2)
==200==    by 0x491603F: g_hash_table_remove_all (in /usr/lib/libglib-2.0.so.0.8600.2)
==200==    by 0x491607D: g_hash_table_destroy (in /usr/lib/libglib-2.0.so.0.8600.2)
==200==    by 0x404C309: free_config (config_file.c:1585)
==200==    by 0x402908A: r_context_clean (context.c:939)
==200==    by 0x4014F23: main (main.c:3128)
==200==  Address 0x563daf0 is 0 bytes inside a block of size 5 free'd
==200==    at 0x48B578B: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==200==    by 0x4028F14: r_context_clean (context.c:926)
==200==    by 0x4014F23: main (main.c:3128)
==200==  Block was alloc'd at
==200==    at 0x48B27C4: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==200==    by 0x4930AFD: g_malloc (in /usr/lib/libglib-2.0.so.0.8600.2)
==200==    by 0x491E960: g_key_file_parse_value_as_string (in /usr/lib/libglib-2.0.so.0.8600.2)
==200==    by 0x4920C38: g_key_file_get_string (in /usr/lib/libglib-2.0.so.0.8600.2)
==200==    by 0x4045787: key_file_consume_string (utils.c:393)
==200==    by 0x4049DBA: parse_slots (config_file.c:1009)
==200==    by 0x404C570: parse_config (config_file.c:1401)
==200==    by 0x404C89F: load_config (config_file.c:1471)
==200==    by 0x40268D1: load_config_verbose (context.c:446)
==200==    by 0x4027EA5: r_context_configure (context.c:492)
==200==    by 0x400FF50: cmdline_handler (main.c:3065)
==200==    by 0x4014F1E: main (main.c:3126)
==200== 
==200== 
==200== HEAP SUMMARY:
==200==     in use at exit: 62,817 bytes in 568 blocks
==200==   total heap usage: 4,954 allocs, 4,387 frees, 875,000 bytes allocated
==200== 
==200== LEAK SUMMARY:
==200==    definitely lost: 0 bytes in 0 blocks
==200==    indirectly lost: 0 bytes in 0 blocks
==200==      possibly lost: 912 bytes in 3 blocks
==200==    still reachable: 58,177 bytes in 521 blocks
==200==         suppressed: 0 bytes in 0 blocks
==200== Rerun with --leak-check=full to see details of leaked memory
==200== 
==200== For lists of detected and suppressed errors, rerun with: -s
==200== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

This is caused by the fact that both `slot.c` and `context.c` try to free the `slot->bootname` string. `efi.c::r_efi_get_current_bootname()` did not duplicate the `slot->bootname`, causing it to get freed twice.

The simple fix is to simply duplicate the string, which happens when using the rauc commandline through the `get_cmdline_bootname_explicit()` -> `r_regex_match_simple()` -> `g_match_info_fetch()` chain