### PR TITLE
Check if bootcurrent is valid before using it to avoid segfault

### DIFF
--- a/src/bootloaders/efi.c
+++ b/src/bootloaders/efi.c
@@ -625,12 +625,15 @@ gchar *r_efi_get_current_bootname(RaucConfig *config, GError **error)
 		return NULL;
 	}
 
-	GHashTableIter iter;
-	g_hash_table_iter_init(&iter, config->slots);
-	RaucSlot *slot = NULL;
-	while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
-		if (g_strcmp0(slot->bootname, bootcurrent->name) == 0) {
-			return slot->bootname;
+	if (bootcurrent != NULL)
+	{
+		GHashTableIter iter;
+		g_hash_table_iter_init(&iter, config->slots);
+		RaucSlot *slot = NULL;
+		while (g_hash_table_iter_next(&iter, NULL, (gpointer*) &slot)) {
+			if (g_strcmp0(slot->bootname, bootcurrent->name) == 0) {
+				return slot->bootname;
+			}
 		}
 	}
 


### PR DESCRIPTION
On a x86-64 system Rauc segfaults when the `BootCurrent` entry of `efibootmgr` no longer points to an existing efi boot entry.
This is because `bootcurrent` is used without checking its validity.

I get this segfault when I change the efi boot entries on a first setup of a system, causing the old boot entry to be deleted. Running `rauc status` thereafter produces the following output:

```
rauc-Message: 07:39:55.203: Using central status file /srv/rauc/central.raucs
rauc-Message: 07:39:55.204: Using system config file /etc/rauc/system.conf
rauc-Message: 07:39:55.205: Failed to load system status: No such file or directory
rauc[231]: segfault at 8 ip 000055b4bb125f3f sp 00007ffd6d606500 error 4 in rauc[1bf3f,55b4bb117000+41000] likely on CPU 1 (core 1, socket 0)
Code: 87 1c ff ff 48 c7 44 24 18 00 00 00 00 48 8d 54 24 18 48 8d 7c 24 20 be 00 00 00 00 e8 9a 1f ff ff 85 c0 74 41 48 8b 44 24 10 <48> 8b 70 08 48 8b 44 24 18 48 8b 78 30 e8 af 2d ff ff 85 c0 75 cd
Segmentation fault (core dumped)
```

GDB produces the following output:
```
# gdb --args rauc status
GNU gdb (GDB) 15.2
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-buildroot-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from rauc...
(gdb) r
Starting program: /usr/bin/rauc status
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
rauc-Message: 08:13:30.657: Using central status file /srv/rauc/central.raucs
rauc-Message: 08:13:30.659: Using system config file /etc/rauc/system.conf
rauc-Message: 08:13:30.660: Failed to load system status: No such file or directory
[Detaching after fork from child process 234]
[New Thread 0x7febb81576c0 (LWP 235)]
[New Thread 0x7febb79566c0 (LWP 236)]
[New Thread 0x7febb71556c0 (LWP 237)]

Thread 1 "rauc" received signal SIGSEGV, Segmentation fault.
0x000055a0aca6d993 in r_efi_get_current_bootname (config=config@entry=0x55a0acae9940, error=error@entry=0x7ffe50e15e20) at ../src/bootloaders/efi.c:515
warning: 515	../src/bootloaders/efi.c: No such file or directory
(gdb) p bootcurrent
$1 = (warning: could not convert 'efi_bootentry' from the host encoding (ANSI_X3.4-1968) to UTF-32.
This normally should not happen, please file a bug report.
efi_bootentry *) 0x0
```