### PR TITLE
src/hash_index: avoid division by zero for small images in hash_file

### DIFF
--- a/src/hash_index.c
+++ b/src/hash_index.c
@@ -74,6 +74,14 @@ static GBytes *hash_file(int data_fd, guint32 count, GError **error)
 		return NULL;
 	}
 
+	/* Split the overall hash index calculation into (R_HASH_INDEX_GEN_PROGRESS_SPAN - 1)
+	 * segments and increment the progress by one for each. For images with fewer
+	 * chunks than segments the integer division would yield 0, so clamp the
+	 * segment size to at least one chunk to avoid a division by zero below. */
+	guint32 progress_segment = count / (R_HASH_INDEX_GEN_PROGRESS_SPAN - 1);
+	if (progress_segment == 0)
+		progress_segment = 1;
+
 	for (guint32 i = 0; i < count; i++) {
 		if (!r_read_exact(data_fd, chunk->data, sizeof(chunk->data), &ierror)) {
 			if (ierror) {
@@ -89,10 +97,8 @@ static GBytes *hash_file(int data_fd, guint32 count, GError **error)
 		hash_chunk(chunk);
 		memcpy(&hashes->data[i*SHA256_LEN], chunk->hash, SHA256_LEN);
 
-		/* Split the overall hash index calculation into (R_HASH_INDEX_GEN_PROGRESS_SPAN - 1)
-		 * segments and increment the progress by one for each. */
 		if (r_context()->progress)
-			if (i % (count / (R_HASH_INDEX_GEN_PROGRESS_SPAN - 1)) == 0)
+			if (i % progress_segment == 0)
 				r_context_inc_step_percentage("copy_image");
 	}
 

--- a/test/hash_index.c
+++ b/test/hash_index.c
@@ -303,6 +303,44 @@ static void test_invalid_size(Fixture *fixture, gconstpointer user_data)
 	g_assert_null(index);
 }
 
+/* Builds a hash index for an image with fewer chunks than the progress span
+ * while a progress step is active. This exercises the progress segment size
+ * calculation in hash_file(), which divides the chunk count by
+ * (R_HASH_INDEX_GEN_PROGRESS_SPAN - 1) and previously divided by zero for such
+ * small images. Runs in a subprocess as the unfixed code aborts with SIGFPE. */
+static void test_small_image_progress(Fixture *fixture, gconstpointer user_data)
+{
+	if (g_test_subprocess()) {
+		g_autoptr(GError) error = NULL;
+		g_autoptr(RaucHashIndex) index = NULL;
+		g_autofree gchar *data_filename = NULL;
+		int datafd = -1;
+
+		/* a single 4096 byte chunk, well below the progress span */
+		data_filename = write_random_file(fixture->tmpdir, "small.img", 4096, 0xf56ce6bf);
+		g_assert_nonnull(data_filename);
+
+		datafd = g_open(data_filename, O_RDONLY|O_CLOEXEC, 0);
+		g_assert_cmpint(datafd, >, 0);
+
+		/* enable progress reporting so the segment size is evaluated */
+		r_context_begin_step("hash_index_test", "small image", 1);
+		r_context_begin_step("copy_image", "hashing", 0);
+
+		index = r_hash_index_open("test", datafd, NULL, &error);
+		g_assert_no_error(error);
+		g_assert_nonnull(index);
+		g_assert_cmpuint(index->count, ==, 1);
+
+		r_context_end_step("copy_image", TRUE);
+		r_context_end_step("hash_index_test", TRUE);
+		return;
+	}
+
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_passed();
+}
+
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, "C");
@@ -315,6 +353,7 @@ int main(int argc, char *argv[])
 	g_test_add("/hash_index/basic", Fixture, NULL, fixture_set_up, test_basic, fixture_tear_down);
 	g_test_add("/hash_index/ranges", Fixture, NULL, fixture_set_up, test_ranges, fixture_tear_down);
 	g_test_add("/hash_index/invalid-size", Fixture, NULL, fixture_set_up, test_invalid_size, fixture_tear_down);
+	g_test_add("/hash_index/small-image-progress", Fixture, NULL, fixture_set_up, test_small_image_progress, fixture_tear_down);
 
 	return g_test_run();
 }


### PR DESCRIPTION
hash_file() derives the progress-reporting interval as count / (R_HASH_INDEX_GEN_PROGRESS_SPAN - 1) and uses it as a modulo divisor once per chunk, so building the index for an image with fewer than nine 4k chunks while a progress step is active divides by zero (SIGFPE on x86, and the undefined behaviour is flagged by the UBSan job). This computes the interval once before the loop and clamps it to at least one chunk, the same zero guard r_copy_stream_with_progress() already has. The added hash_index test builds an index for a single-chunk image with progress enabled, which reviewers can run to confirm it no longer traps.